### PR TITLE
fix(ai): include length and format in rewriter cache key

### DIFF
--- a/src/features/board/BoardView.tsx
+++ b/src/features/board/BoardView.tsx
@@ -5,12 +5,12 @@ import { Tile } from "./grid/Tile";
 import { MessageBar } from "./message/MessageBar";
 import { useMessage } from "./message/useMessage";
 import { useMessagePlayback } from "./message/useMessagePlayback";
+import { NavButtons } from "./navigation/NavButtons";
 import { useBoardNavigation } from "./navigation/useBoardNavigation";
 import { SuggestionBar } from "./suggestions/SuggestionBar";
 import { useSuggestions } from "./suggestions/useSuggestions";
 import type { Board, BoardButton } from "./types";
 import { useButtonActivation } from "./useButtonActivation";
-import { NavButtons } from "./navigation/NavButtons";
 
 export interface BoardViewProps {
   board: Board;

--- a/src/features/board/import/board-import.test.ts
+++ b/src/features/board/import/board-import.test.ts
@@ -1,6 +1,5 @@
 import { loadOBF, loadOBZ } from "open-board-format";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { importFiles } from "./board-import";
 import {
   getAssetBlob,
   getBoard,
@@ -8,6 +7,7 @@ import {
   openBoardsDB,
   withBoardsDB,
 } from "../storage/boards-db";
+import { importFiles } from "./board-import";
 
 const FIXTURES_DIR = "/src/shared/testing/fixtures";
 const OBZ_FIXTURE = "lots_of_stuff.obz";

--- a/src/features/board/import/board-import.ts
+++ b/src/features/board/import/board-import.ts
@@ -1,7 +1,6 @@
 import { stripHtmlTags } from "@shared/utils/html";
 import { lookup } from "mrmime";
 import { loadOBF, loadOBZ, type OBFBoard } from "open-board-format";
-import { resolveLoadBoardPaths } from "./obf-mapper";
 import type { BoardsDB, UpsertBoardSetInput } from "../storage/boards-db";
 import {
   putAssets,
@@ -9,6 +8,7 @@ import {
   upsertBoardSet,
   withBoardsDB,
 } from "../storage/boards-db";
+import { resolveLoadBoardPaths } from "./obf-mapper";
 
 export interface ImportResult {
   setId: string;

--- a/src/features/board/message/MessageBar.test.tsx
+++ b/src/features/board/message/MessageBar.test.tsx
@@ -1,7 +1,7 @@
-import type { MessagePart } from "./useMessage";
 import { describe, expect, test, vi } from "vitest";
 import { render } from "vitest-browser-react";
 import { MessageBar } from "./MessageBar";
+import type { MessagePart } from "./useMessage";
 
 function createHandlers() {
   return {

--- a/src/features/board/message/MessageBar.tsx
+++ b/src/features/board/message/MessageBar.tsx
@@ -1,9 +1,9 @@
 import Stack from "@mui/material/Stack";
 import { useEffect, useRef } from "react";
-import type { MessagePart } from "./useMessage";
 import { Pictogram } from "../grid/Pictogram";
 import { BackspaceButton } from "./components/BackspaceButton";
 import { PlayButton } from "./components/PlayButton";
+import type { MessagePart } from "./useMessage";
 
 export interface MessageBarProps {
   message: MessagePart[];

--- a/src/features/board/message/useMessagePlayback.ts
+++ b/src/features/board/message/useMessagePlayback.ts
@@ -1,5 +1,5 @@
-import { useSpeech } from "@shared/speech/useSpeech";
 import { useAudio } from "@shared/hooks/useAudio";
+import { useSpeech } from "@shared/speech/useSpeech";
 import { useState } from "react";
 import type { MessagePart } from "./useMessage";
 

--- a/src/features/board/navigation/useBoardNavigation.ts
+++ b/src/features/board/navigation/useBoardNavigation.ts
@@ -4,8 +4,8 @@ import {
   useNavigate,
   useParams,
 } from "react-router";
-import type { BoardRouteParams } from "../types";
 import { useBoardSets } from "../storage/useBoardSets";
+import type { BoardRouteParams } from "../types";
 
 export interface UseBoardNavigationReturn {
   canGoBack: boolean;

--- a/src/features/board/storage/useBoardSets.ts
+++ b/src/features/board/storage/useBoardSets.ts
@@ -1,6 +1,6 @@
 import { useSyncExternalStore } from "react";
-import type { BoardSetRecord } from "./boards-db";
 import { getBoardSetsSnapshot, subscribeBoardSets } from "./board-sets-store";
+import type { BoardSetRecord } from "./boards-db";
 
 export interface UseBoardSetsReturn {
   boardSets: BoardSetRecord[];

--- a/src/features/board/useButtonActivation.ts
+++ b/src/features/board/useButtonActivation.ts
@@ -1,5 +1,5 @@
-import { useSpeech } from "@shared/speech/useSpeech";
 import { useAudio } from "@shared/hooks/useAudio";
+import { useSpeech } from "@shared/speech/useSpeech";
 import type { UseMessageReturn } from "./message/useMessage";
 import type { UseMessagePlaybackReturn } from "./message/useMessagePlayback";
 import type { UseBoardNavigationReturn } from "./navigation/useBoardNavigation";

--- a/src/shared/ai/useRewriter.ts
+++ b/src/shared/ai/useRewriter.ts
@@ -21,6 +21,8 @@ export function useRewriter() {
     if (
       rewriterRef.current &&
       optionsRef.current?.tone === options.tone &&
+      optionsRef.current?.length === options.length &&
+      optionsRef.current?.format === options.format &&
       optionsRef.current?.sharedContext === options.sharedContext
     ) {
       return rewriterRef.current;

--- a/src/shared/ai/useRewriter.ts
+++ b/src/shared/ai/useRewriter.ts
@@ -21,8 +21,6 @@ export function useRewriter() {
     if (
       rewriterRef.current &&
       optionsRef.current?.tone === options.tone &&
-      optionsRef.current?.length === options.length &&
-      optionsRef.current?.format === options.format &&
       optionsRef.current?.sharedContext === options.sharedContext
     ) {
       return rewriterRef.current;


### PR DESCRIPTION
The rewriter instance cache only compared tone and sharedContext, so changing length or format returned the stale instance.