### PR TITLE
fix(speech): avoid synchronous setState in voices effect

### DIFF
--- a/src/shared/speech/useSpeechSynthesis.ts
+++ b/src/shared/speech/useSpeechSynthesis.ts
@@ -33,7 +33,9 @@ const isSpeechSupported = "speechSynthesis" in globalThis;
 const synth = globalThis.speechSynthesis;
 
 export function useSpeechSynthesis(): UseSpeechSynthesisReturn {
-  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
+  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>(() =>
+    isSpeechSupported ? synth.getVoices() : [],
+  );
   const [voiceURI, setVoiceURI] = useState("");
   const [rate, setRate] = useState(1);
   const [pitch, setPitch] = useState(1);
@@ -58,16 +60,14 @@ export function useSpeechSynthesis(): UseSpeechSynthesisReturn {
       return;
     }
 
-    const getVoices = () => {
-      const availableVoices = synth.getVoices();
-      setVoices(availableVoices);
+    const handleVoicesChanged = () => {
+      setVoices(synth.getVoices());
     };
 
-    getVoices();
-    synth.addEventListener("voiceschanged", getVoices);
+    synth.addEventListener("voiceschanged", handleVoicesChanged);
 
     return () => {
-      synth.removeEventListener("voiceschanged", getVoices);
+      synth.removeEventListener("voiceschanged", handleVoicesChanged);
     };
   }, []);
 


### PR DESCRIPTION
## Summary

Resolves the `react-x/set-state-in-effect` lint warning in `useSpeechSynthesis`:

```
src/shared/speech/useSpeechSynthesis.ts
  63:7  warning  Do not call the 'set' function 'setVoices' of 'useState' synchronously in an effect.
```

## Change

- Initialize `voices` lazily via `useState(() => isSpeechSupported ? synth.getVoices() : [])` so the first render already has the available voices (when the platform has them ready).
- The effect now only attaches/detaches the `voiceschanged` listener — `setVoices` only runs in response to a real DOM event, never synchronously inside the effect.

Behavior is unchanged: the same set of voices ends up in state via the same code path; we just stop the redundant initial `setVoices` call.

## Verification

- `npm run lint` — clean
- `npm run build` — clean (typecheck + Vite build)
- `npm test` — 154/154 passing