### PR TITLE
refactor(language): separate locale (full BCP-47) from language (primary subtag)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -110,6 +110,19 @@ Once enabled, the browser downloads the AI model for local inference.
 
 ---
 
+## Locale vs. Language
+
+Both [OBF](./external/open-board-format.md) (`board.locale`) and the Web Speech API (`voice.lang`) use [BCP-47](https://www.rfc-editor.org/info/bcp47) tags. Inside the app we split them into two roles:
+
+| Term           | Meaning                              | Examples          |
+| -------------- | ------------------------------------ | ----------------- |
+| **`locale`**   | Full BCP-47 tag (language + region). | `"en"`, `"en-US"` |
+| **`language`** | Primary subtag only.                 | `"en"`, `"pt"`    |
+
+Helpers in [`src/shared/language/locale.ts`](../src/shared/language/locale.ts): `normalizeLocaleCode` (canonical casing) and `getPrimaryLanguage` (locale → language).
+
+---
+
 ## PWA & Offline Support
 
 The app is a **Progressive Web App** powered by `vite-plugin-pwa`:

--- a/src/app/drawers/SettingsDrawer/panels/LanguageSettings.tsx
+++ b/src/app/drawers/SettingsDrawer/panels/LanguageSettings.tsx
@@ -12,7 +12,7 @@ import { useAI } from "@shared/ai/useAI";
 import { useLanguage } from "@shared/language/useLanguage";
 
 export function LanguageSettings() {
-  const { languages, locale, setLocale } = useLanguage();
+  const { languages, language, setLanguage } = useLanguage();
   const { downloads } = useAI();
 
   const isDownloading = downloads.translator > 0 && downloads.translator < 1;
@@ -26,13 +26,13 @@ export function LanguageSettings() {
           label="Language"
           labelId="language-select-label"
           id="language-select"
-          value={locale}
+          value={language}
           disabled={!isTranslatorSupported}
-          onChange={(event) => setLocale(event.target.value)}
+          onChange={(event) => setLanguage(event.target.value)}
         >
-          {languages.map((language) => (
-            <MenuItem key={language.code} value={language.code}>
-              {language.name}
+          {languages.map((lang) => (
+            <MenuItem key={lang.code} value={lang.code}>
+              {lang.name}
             </MenuItem>
           ))}
         </Select>

--- a/src/app/drawers/SettingsDrawer/panels/SpeechSettings.tsx
+++ b/src/app/drawers/SettingsDrawer/panels/SpeechSettings.tsx
@@ -42,7 +42,9 @@ export function SpeechSettings() {
     .filter((voiceLocale) => getPrimaryLanguage(voiceLocale) === language)
     .sort((a, b) => a.localeCompare(b));
 
-  const localeDisplayNames = new Intl.DisplayNames([language], {
+  const hasMultipleLocales = locales.length > 1;
+
+  const languageNames = new Intl.DisplayNames([language], {
     type: "language",
   });
 
@@ -76,10 +78,11 @@ export function SpeechSettings() {
       targetLanguage: language,
     });
 
-    const text = "Hi, this is my voice!";
-    const previewText = (await translator?.translate(text)) ?? text;
+    const defaultGreeting = "Hi, this is my voice!";
+    const greeting =
+      (await translator?.translate(defaultGreeting)) ?? defaultGreeting;
 
-    void speak(previewText);
+    void speak(greeting);
   }
 
   return (
@@ -96,9 +99,9 @@ export function SpeechSettings() {
           onChange={(event) => setVoiceURI(event.target.value)}
         >
           {locales.map((voiceLocale) => [
-            locales.length > 1 && (
+            hasMultipleLocales && (
               <ListSubheader key={`header-${voiceLocale}`}>
-                {localeDisplayNames.of(voiceLocale) ?? voiceLocale}
+                {languageNames.of(voiceLocale) ?? voiceLocale}
               </ListSubheader>
             ),
             ...(voicesByLocale[voiceLocale] ?? []).map((voice) => (

--- a/src/app/drawers/SettingsDrawer/panels/SpeechSettings.tsx
+++ b/src/app/drawers/SettingsDrawer/panels/SpeechSettings.tsx
@@ -8,6 +8,7 @@ import Slider from "@mui/material/Slider";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { useTranslator } from "@shared/ai/useTranslator";
+import { getPrimaryLanguage } from "@shared/language/locale";
 import { useLanguage } from "@shared/language/useLanguage";
 import { useSpeech } from "@shared/speech/useSpeech";
 import {
@@ -34,14 +35,14 @@ export function SpeechSettings() {
     speak,
   } = useSpeech();
 
-  const { locale } = useLanguage();
+  const { language } = useLanguage();
   const { createTranslator } = useTranslator();
 
   const locales = Object.keys(voicesByLocale)
-    .filter((voiceLocale) => voiceLocale.startsWith(locale))
+    .filter((voiceLocale) => getPrimaryLanguage(voiceLocale) === language)
     .sort((a, b) => a.localeCompare(b));
 
-  const localeDisplayNames = new Intl.DisplayNames([locale], {
+  const localeDisplayNames = new Intl.DisplayNames([language], {
     type: "language",
   });
 
@@ -72,7 +73,7 @@ export function SpeechSettings() {
   async function previewVoice() {
     const translator = await createTranslator({
       sourceLanguage: "en",
-      targetLanguage: locale,
+      targetLanguage: language,
     });
 
     const text = "Hi, this is my voice!";

--- a/src/features/board/import/board-import.ts
+++ b/src/features/board/import/board-import.ts
@@ -1,3 +1,4 @@
+import { normalizeLocaleCode } from "@shared/language/locale";
 import { stripHtmlTags } from "@shared/utils/html";
 import { lookup } from "mrmime";
 import { loadOBF, loadOBZ, type OBFBoard } from "open-board-format";
@@ -109,7 +110,7 @@ function buildBoardSetInput(
       ? stripHtmlTags(obfBoard.description_html)
       : undefined,
     license: obfBoard?.license?.type,
-    locale: obfBoard?.locale,
+    locale: obfBoard?.locale ? normalizeLocaleCode(obfBoard.locale) : undefined,
     gridRows: obfBoard?.grid.rows,
     gridColumns: obfBoard?.grid.columns,
   };

--- a/src/features/board/import/obf-mapper.test.ts
+++ b/src/features/board/import/obf-mapper.test.ts
@@ -47,6 +47,20 @@ describe("obfToBoard", () => {
       expect(board.descriptionHTML).toBe("<p>Board description</p>");
     });
 
+    test("normalizes the locale to BCP-47 casing on import", () => {
+      const obfBoard: OBFBoard = {
+        format: "open-board-0.1",
+        id: "board-locale-casing",
+        locale: "en_us",
+        buttons: [],
+        grid: { rows: 1, columns: 1, order: [[null]] },
+      };
+
+      const board = obfToBoard(obfBoard);
+
+      expect(board.locale).toBe("en-US");
+    });
+
     test("handles board without optional name field", () => {
       const obfBoard: OBFBoard = {
         format: "open-board-0.1",

--- a/src/features/board/import/obf-mapper.ts
+++ b/src/features/board/import/obf-mapper.ts
@@ -1,3 +1,4 @@
+import { normalizeLocaleCode } from "@shared/language/locale";
 import type {
   OBFBoard,
   OBFButton,
@@ -22,7 +23,7 @@ export function obfToBoard(obfBoard: OBFBoard): Board {
   const board: Board = {
     id: obfBoard.id,
     name: obfBoard.name,
-    locale: obfBoard.locale,
+    locale: obfBoard.locale ? normalizeLocaleCode(obfBoard.locale) : undefined,
     descriptionHTML: obfBoard.description_html,
     buttons: obfBoard.buttons.map((obfButton) =>
       transformButton(obfButton, imageSourceById, soundSourceById),

--- a/src/features/board/useBoardTranslation.ts
+++ b/src/features/board/useBoardTranslation.ts
@@ -1,4 +1,5 @@
 import { useTranslator } from "@shared/ai/useTranslator";
+import { getPrimaryLanguage } from "@shared/language/locale";
 import { useLanguage } from "@shared/language/useLanguage";
 import { useEffect, useState } from "react";
 import { updateBoardStrings, withBoardsDB } from "./storage/boards-db";
@@ -17,7 +18,7 @@ export function useBoardTranslation({
   setId,
   board,
 }: UseBoardTranslationOptions): UseBoardTranslationReturn {
-  const { locale } = useLanguage();
+  const { language } = useLanguage();
   const { createTranslator } = useTranslator();
 
   const [translatedBoard, setTranslatedBoard] = useState<Board | null>(null);
@@ -30,16 +31,14 @@ export function useBoardTranslation({
         return;
       }
 
-      const boardLocale = board.locale ?? "en";
-      const isSameLanguage =
-        locale.startsWith(boardLocale) || boardLocale.startsWith(locale);
+      const boardLanguage = getPrimaryLanguage(board.locale ?? "en");
 
-      if (isSameLanguage) {
+      if (boardLanguage === language) {
         setTranslatedBoard(board);
         return;
       }
 
-      const existingStrings = board.strings?.[locale];
+      const existingStrings = findStringsForLanguage(board.strings, language);
 
       if (existingStrings) {
         setTranslatedBoard(applyStrings(board, existingStrings));
@@ -47,8 +46,8 @@ export function useBoardTranslation({
       }
 
       const translator = await createTranslator({
-        sourceLanguage: boardLocale,
-        targetLanguage: locale,
+        sourceLanguage: boardLanguage,
+        targetLanguage: language,
       });
 
       if (cancelled) {
@@ -67,7 +66,7 @@ export function useBoardTranslation({
         return;
       }
 
-      void persistStrings(setId, board.id, locale, translatedStrings);
+      void persistStrings(setId, board.id, language, translatedStrings);
 
       setTranslatedBoard(applyStrings(board, translatedStrings));
     };
@@ -77,11 +76,32 @@ export function useBoardTranslation({
     return () => {
       cancelled = true;
     };
-  }, [createTranslator, locale, board, setId]);
+  }, [createTranslator, language, board, setId]);
 
   return {
     translatedBoard,
   };
+}
+
+function findStringsForLanguage(
+  strings: Board["strings"],
+  language: string,
+): Record<string, string> | undefined {
+  if (!strings) {
+    return undefined;
+  }
+
+  if (strings[language]) {
+    return strings[language];
+  }
+
+  for (const [key, value] of Object.entries(strings)) {
+    if (getPrimaryLanguage(key) === language) {
+      return value;
+    }
+  }
+
+  return undefined;
 }
 
 function collectTranslatableStrings(board: Board): Set<string> {
@@ -138,12 +158,12 @@ function applyStrings(board: Board, strings: Record<string, string>): Board {
 async function persistStrings(
   setId: string,
   boardId: string,
-  locale: string,
+  language: string,
   strings: Record<string, string>,
 ): Promise<void> {
   try {
     await withBoardsDB(async (db) => {
-      await updateBoardStrings(db, setId, boardId, locale, strings);
+      await updateBoardStrings(db, setId, boardId, language, strings);
     });
   } catch (err) {
     console.warn("Failed to persist translated strings:", err);

--- a/src/pages/LibraryPage/components/BoardSetInfoDialog.tsx
+++ b/src/pages/LibraryPage/components/BoardSetInfoDialog.tsx
@@ -7,7 +7,7 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogTitle from "@mui/material/DialogTitle";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
-import { getLanguageDisplayName } from "@shared/language/locale";
+import { getLocaleDisplayName } from "@shared/language/locale";
 
 export interface BoardSetInfoDialogProps {
   boardSet: BoardSetRecord | null;
@@ -77,7 +77,7 @@ function buildChipLabels(boardSet: BoardSetRecord): string[] {
   }
 
   if (boardSet.locale) {
-    labels.push(getLanguageDisplayName(boardSet.locale));
+    labels.push(getLocaleDisplayName(boardSet.locale));
   }
 
   if (boardSet.license) {

--- a/src/shared/language/LanguageContext.ts
+++ b/src/shared/language/LanguageContext.ts
@@ -2,8 +2,8 @@ import { createContext } from "react";
 
 export interface LanguageContextValue {
   languages: { code: string; name: string }[];
-  locale: string;
-  setLocale: (locale: string) => void;
+  language: string;
+  setLanguage: (language: string) => void;
 }
 
 export const LanguageContext = createContext<LanguageContextValue | null>(null);

--- a/src/shared/language/LanguageProvider.tsx
+++ b/src/shared/language/LanguageProvider.tsx
@@ -1,6 +1,7 @@
 import { usePersistentState } from "@shared/hooks/usePersistentState";
 import { useSpeech } from "@shared/speech/useSpeech";
 import { useEffect, type ReactNode } from "react";
+import { getPrimaryLanguage } from "./locale";
 import { LanguageContext, type LanguageContextValue } from "./LanguageContext";
 
 export interface LanguageProviderProps {
@@ -8,13 +9,13 @@ export interface LanguageProviderProps {
 }
 
 export function LanguageProvider({ children }: LanguageProviderProps) {
-  const { langs, voicesByLang, setVoiceURI } = useSpeech();
-  const [locale, setLocale] = usePersistentState<string>("locale", "en");
+  const { locales, voicesByLanguage, setVoiceURI } = useSpeech();
+  const [language, setLanguage] = usePersistentState<string>("language", "en");
 
-  const unsupportedLangs = ["ca", "ms", "nb", "yue"];
+  const unsupportedLanguages = ["ca", "ms", "nb", "yue"];
   const supportedLanguages = Array.from(
-    new Set(langs.map((langCode) => langCode.split("-")[0])),
-  ).filter((langCode) => !unsupportedLangs.includes(langCode));
+    new Set(locales.map(getPrimaryLanguage)),
+  ).filter((langCode) => !unsupportedLanguages.includes(langCode));
 
   const languages = supportedLanguages.map((lang) => {
     const displayName = new Intl.DisplayNames([lang], { type: "language" });
@@ -27,19 +28,19 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
 
   const contextValue: LanguageContextValue = {
     languages,
-    locale,
-    setLocale,
+    language,
+    setLanguage,
   };
 
   useEffect(() => {
     const defaultVoice =
-      voicesByLang[locale]?.find((voice) => voice.default) ??
-      voicesByLang[locale]?.[0];
+      voicesByLanguage[language]?.find((voice) => voice.default) ??
+      voicesByLanguage[language]?.[0];
 
     if (defaultVoice) {
       setVoiceURI(defaultVoice?.voiceURI);
     }
-  }, [locale, voicesByLang, setVoiceURI]);
+  }, [language, voicesByLanguage, setVoiceURI]);
 
   return <LanguageContext value={contextValue}>{children}</LanguageContext>;
 }

--- a/src/shared/language/locale.test.ts
+++ b/src/shared/language/locale.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { normalizeLocaleCode } from "./locale";
+import { getPrimaryLanguage, normalizeLocaleCode } from "./locale";
 
 describe("normalizeLocaleCode", () => {
   test("lowercases a language-only code", () => {
@@ -24,5 +24,23 @@ describe("normalizeLocaleCode", () => {
 
   test("handles already-normalized code", () => {
     expect(normalizeLocaleCode("zh-TW")).toBe("zh-TW");
+  });
+});
+
+describe("getPrimaryLanguage", () => {
+  test("returns a language-only code as-is", () => {
+    expect(getPrimaryLanguage("en")).toBe("en");
+  });
+
+  test("strips the region from a hyphen-separated locale", () => {
+    expect(getPrimaryLanguage("en-US")).toBe("en");
+  });
+
+  test("strips the region from an underscore-separated locale", () => {
+    expect(getPrimaryLanguage("pt_BR")).toBe("pt");
+  });
+
+  test("lowercases the primary subtag", () => {
+    expect(getPrimaryLanguage("EN-GB")).toBe("en");
   });
 });

--- a/src/shared/language/locale.ts
+++ b/src/shared/language/locale.ts
@@ -1,5 +1,6 @@
 /**
- * Normalizes a locale code to BCP 47 format.
+ * Normalizes a BCP-47 locale code to canonical casing
+ * (lowercase language subtag, uppercase region subtag, hyphen separator).
  */
 export function normalizeLocaleCode(code: string): string {
   const [language, region] = code.split(/[_-]/);
@@ -12,10 +13,18 @@ export function normalizeLocaleCode(code: string): string {
 }
 
 /**
+ * Extracts the primary language subtag from a BCP-47 locale code
+ * (e.g. "en-US" → "en"). Always lowercase.
+ */
+export function getPrimaryLanguage(code: string): string {
+  return code.split(/[_-]/)[0].toLowerCase();
+}
+
+/**
  * Returns the display name of a locale code in English.
  * Falls back to the original code if the locale is not recognized.
  */
-export function getLanguageDisplayName(code: string): string {
+export function getLocaleDisplayName(code: string): string {
   try {
     const displayNames = new Intl.DisplayNames(["en"], { type: "language" });
     return displayNames.of(normalizeLocaleCode(code)) ?? code;

--- a/src/shared/speech/useSpeechSynthesis.ts
+++ b/src/shared/speech/useSpeechSynthesis.ts
@@ -1,3 +1,4 @@
+import { getPrimaryLanguage } from "@shared/language/locale";
 import { useEffect, useState } from "react";
 
 export const RATE_MIN = 0.1;
@@ -8,8 +9,8 @@ export const VOLUME_MIN = 0;
 export const VOLUME_MAX = 1;
 
 export interface UseSpeechSynthesisReturn {
-  langs: string[];
-  voicesByLang: Partial<Record<string, SpeechSynthesisVoice[]>>;
+  locales: string[];
+  voicesByLanguage: Partial<Record<string, SpeechSynthesisVoice[]>>;
   voicesByLocale: Partial<Record<string, SpeechSynthesisVoice[]>>;
   voices: SpeechSynthesisVoice[];
   voiceURI: string;
@@ -30,11 +31,11 @@ export interface UseSpeechSynthesisReturn {
 }
 
 const isSpeechSupported = "speechSynthesis" in globalThis;
-const synth = globalThis.speechSynthesis;
+const synthesis = globalThis.speechSynthesis;
 
 export function useSpeechSynthesis(): UseSpeechSynthesisReturn {
   const [voices, setVoices] = useState<SpeechSynthesisVoice[]>(() =>
-    isSpeechSupported ? synth.getVoices() : [],
+    isSpeechSupported ? synthesis.getVoices() : [],
   );
   const [voiceURI, setVoiceURI] = useState("");
   const [rate, setRate] = useState(1);
@@ -44,13 +45,12 @@ export function useSpeechSynthesis(): UseSpeechSynthesisReturn {
   const [isSpeaking, setIsSpeaking] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
 
-  const langs = Array.from(new Set(voices.map((voice) => voice.lang))).sort(
+  const locales = Array.from(new Set(voices.map((voice) => voice.lang))).sort(
     (a, b) => a.localeCompare(b),
   );
 
-  const voicesByLang = Object.groupBy(
-    voices,
-    (voice) => voice.lang.split("-")[0],
+  const voicesByLanguage = Object.groupBy(voices, (voice) =>
+    getPrimaryLanguage(voice.lang),
   );
 
   const voicesByLocale = Object.groupBy(voices, (voice) => voice.lang);
@@ -61,18 +61,18 @@ export function useSpeechSynthesis(): UseSpeechSynthesisReturn {
     }
 
     const handleVoicesChanged = () => {
-      setVoices(synth.getVoices());
+      setVoices(synthesis.getVoices());
     };
 
-    synth.addEventListener("voiceschanged", handleVoicesChanged);
+    synthesis.addEventListener("voiceschanged", handleVoicesChanged);
 
     return () => {
-      synth.removeEventListener("voiceschanged", handleVoicesChanged);
+      synthesis.removeEventListener("voiceschanged", handleVoicesChanged);
     };
   }, []);
 
-  const speak = async (text: string) => {
-    return new Promise<void>((resolve, reject) => {
+  const speak = (text: string) =>
+    new Promise<void>((resolve, reject) => {
       if (!isSpeechSupported) {
         reject(new Error("Speech Synthesis is not supported in this browser."));
         return;
@@ -86,57 +86,56 @@ export function useSpeechSynthesis(): UseSpeechSynthesisReturn {
       utterance.rate = rate;
       utterance.volume = volume;
 
-      utterance.onstart = () => {
+      const markSpeaking = () => {
         setIsSpeaking(true);
         setIsPaused(false);
       };
 
-      utterance.onend = () => {
-        setIsSpeaking(false);
-        setIsPaused(false);
-
-        resolve();
-      };
-
-      utterance.onresume = () => {
-        setIsSpeaking(true);
-        setIsPaused(false);
-      };
-
-      utterance.onpause = () => {
+      const markPaused = () => {
         setIsSpeaking(false);
         setIsPaused(true);
       };
 
-      utterance.onerror = (event) => {
+      const markIdle = () => {
         setIsSpeaking(false);
         setIsPaused(false);
+      };
 
+      utterance.onstart = markSpeaking;
+      utterance.onresume = markSpeaking;
+      utterance.onpause = markPaused;
+
+      utterance.onend = () => {
+        markIdle();
+        resolve();
+      };
+
+      utterance.onerror = (event) => {
+        markIdle();
         reject(new Error(event.error));
       };
 
-      synth.cancel();
-      synth.speak(utterance);
+      synthesis.cancel();
+      synthesis.speak(utterance);
     });
-  };
 
   const cancel = () => {
-    synth.cancel();
+    synthesis.cancel();
   };
 
   const pause = () => {
-    synth.pause();
+    synthesis.pause();
   };
 
   const resume = () => {
-    synth.resume();
+    synthesis.resume();
   };
 
   return {
     isSpeechSupported,
     voices,
-    langs,
-    voicesByLang,
+    locales,
+    voicesByLanguage,
     voicesByLocale,
     voiceURI,
     setVoiceURI,


### PR DESCRIPTION
Splits a single overloaded concept (`locale` / `lang` / `language`) into two named roles backed by a documented convention.

## Convention

| Term         | Meaning                              | Examples          |
| ------------ | ------------------------------------ | ----------------- |
| **`locale`**   | Full BCP-47 tag (language + region). | `"en"`, `"en-US"` |
| **`language`** | Primary subtag only.                 | `"en"`, `"pt"`    |

Helpers live in `src/shared/language/locale.ts`: `normalizeLocaleCode` (canonical casing) and the new `getPrimaryLanguage` (locale → language).

## Changes

- **Helpers** — Add `getPrimaryLanguage`; rename `getLanguageDisplayName` → `getLocaleDisplayName`.
- **`LanguageContext`** — Rename `locale`/`setLocale` → `language`/`setLanguage`; persistent-state key changes from `"locale"` to `"language"` (one-time UI-language reset for existing users; pet project, no migration shim).
- **`useSpeechSynthesis`** — Rename `langs`/`voicesByLang` → `locales`/`voicesByLanguage`; group `voicesByLanguage` via `getPrimaryLanguage` for consistent casing; minor cleanup of `speak` (extract `markSpeaking`/`markPaused`/`markIdle`, drop redundant `async`, rename `synth` → `synthesis`).
- **OBF import** — Normalize `obfBoard.locale` (and `boardSet.locale`) through `normalizeLocaleCode` at the boundary, so `"en_us"` becomes `"en-US"`.
- **`useBoardTranslation`** — Replace symmetric `startsWith` heuristic with primary-language equality; add a `findStringsForLanguage` fallback that scans existing `board.strings` keys by primary subtag (fixes the case where `strings["en-US"]` was unreachable when the user selected `"en"`).
- **Docs** — New "Locale vs. Language" section in `docs/architecture.md`.

## Tests

- Added: `getPrimaryLanguage` (4 cases), OBF locale normalization on import.
- All existing tests continue to pass; `npm run lint` and `npm run build` clean.

## Notes

- `voice.lang` and HTML `lang=` are untouched — those are foreign-API fields we read but don't propagate as `lang` into our own surface.
- `Board.strings` keys remain locales per OBF spec; `useBoardTranslation` writes new entries under the primary-subtag key, which is spec-allowed.