### PR TITLE
refactor(message-bar): hoist play button out of input stack

### DIFF
--- a/src/features/board/message/MessageBar.tsx
+++ b/src/features/board/message/MessageBar.tsx
@@ -53,6 +53,7 @@ export function MessageBar({
         sx={(theme) => ({
           flexGrow: 2,
           gap: 2,
+          paddingInlineEnd: 2,
           borderRadius: 18,
           overflow: "hidden",
           backgroundColor:
@@ -78,19 +79,17 @@ export function MessageBar({
           ))}
         </Stack>
 
-        <Stack direction="row" sx={{ gap: 1 }}>
-          <BackspaceButton
-            onPress={onBackspacePress}
-            onLongPress={onBackspaceLongPress}
-          />
-
-          <PlayButton
-            isPlaying={isPlaying}
-            onPlayClick={onPlayClick}
-            onStopClick={onStopClick}
-          />
-        </Stack>
+        <BackspaceButton
+          onPress={onBackspacePress}
+          onLongPress={onBackspaceLongPress}
+        />
       </Stack>
+
+      <PlayButton
+        isPlaying={isPlaying}
+        onPlayClick={onPlayClick}
+        onStopClick={onStopClick}
+      />
     </Stack>
   );
 }

--- a/src/features/board/message/components/PlayButton.tsx
+++ b/src/features/board/message/components/PlayButton.tsx
@@ -21,7 +21,7 @@ export function PlayButton({
 
   return (
     <Tooltip title={playButtonLabel}>
-      <Box sx={{ m: 1 }}>
+      <Box>
         <IconButton
           aria-label={playButtonLabel}
           size="large"


### PR DESCRIPTION
## Summary

Adjust the `MessageBar` layout so the play button sits beside the input row instead of nested inside it.

## Changes

- Move `PlayButton` to be a sibling of the input row rather than grouped with `BackspaceButton` inside the inner stack.
- Drop the wrapping `Box` margin around `PlayButton` (`m: 1`) since spacing now comes from the parent stack.
- Add `paddingInlineEnd: 2` to the input container to keep the backspace button visually balanced.

## Verification

- `npm run lint`
- `npm test` (MessageBar tests pass)
- `npm run build`