### PR TITLE
refactor(translation): clarify vocabulary in useBoardTranslation

### DIFF
--- a/src/features/board/useBoardTranslation.ts
+++ b/src/features/board/useBoardTranslation.ts
@@ -3,7 +3,7 @@ import { getPrimaryLanguage } from "@shared/language/locale";
 import { useLanguage } from "@shared/language/useLanguage";
 import { useEffect, useState } from "react";
 import { updateBoardStrings, withBoardsDB } from "./storage/boards-db";
-import type { Board, BoardButton } from "./types";
+import type { Board } from "./types";
 
 export interface UseBoardTranslationOptions {
   setId: string;
@@ -38,10 +38,13 @@ export function useBoardTranslation({
         return;
       }
 
-      const existingStrings = findStringsForLanguage(board.strings, language);
+      const existingTranslations = findTranslationsForLanguage(
+        board.strings,
+        language,
+      );
 
-      if (existingStrings) {
-        setTranslatedBoard(applyStrings(board, existingStrings));
+      if (existingTranslations) {
+        setTranslatedBoard(applyTranslations(board, existingTranslations));
         return;
       }
 
@@ -59,16 +62,16 @@ export function useBoardTranslation({
         return;
       }
 
-      const keys = collectTranslatableStrings(board);
-      const translatedStrings = await translateStrings(keys, translator);
+      const phrases = collectSourcePhrases(board);
+      const translations = await translatePhrases(phrases, translator);
 
       if (cancelled) {
         return;
       }
 
-      void persistStrings(setId, board.id, language, translatedStrings);
+      void persistTranslations(setId, board.id, language, translations);
 
-      setTranslatedBoard(applyStrings(board, translatedStrings));
+      setTranslatedBoard(applyTranslations(board, translations));
     };
 
     void translateBoard();
@@ -83,7 +86,7 @@ export function useBoardTranslation({
   };
 }
 
-function findStringsForLanguage(
+function findTranslationsForLanguage(
   strings: Board["strings"],
   language: string,
 ): Record<string, string> | undefined {
@@ -95,77 +98,77 @@ function findStringsForLanguage(
     return strings[language];
   }
 
-  for (const [key, value] of Object.entries(strings)) {
-    if (getPrimaryLanguage(key) === language) {
-      return value;
+  for (const [locale, translations] of Object.entries(strings)) {
+    if (getPrimaryLanguage(locale) === language) {
+      return translations;
     }
   }
 
   return undefined;
 }
 
-function collectTranslatableStrings(board: Board): Set<string> {
-  const keys = new Set<string>();
+function collectSourcePhrases(board: Board): Set<string> {
+  const phrases = new Set<string>();
 
   if (board.name) {
-    keys.add(board.name);
+    phrases.add(board.name);
   }
 
   for (const button of board.buttons) {
     if (button.label) {
-      keys.add(button.label);
+      phrases.add(button.label);
     }
     if (button.vocalization) {
-      keys.add(button.vocalization);
+      phrases.add(button.vocalization);
     }
   }
 
-  return keys;
+  return phrases;
 }
 
-async function translateStrings(
-  keys: Set<string>,
+async function translatePhrases(
+  phrases: Set<string>,
   translator: Translator,
 ): Promise<Record<string, string>> {
   const entries = await Promise.all(
-    Array.from(keys).map(async (key) => {
-      const translated = await translator.translate(key);
-      return [key, translated] as const;
+    Array.from(phrases).map(async (phrase) => {
+      const translated = await translator.translate(phrase);
+      return [phrase, translated] as const;
     }),
   );
 
   return Object.fromEntries(entries);
 }
 
-function applyStrings(board: Board, strings: Record<string, string>): Board {
-  const resolvedButtons: BoardButton[] = board.buttons.map((button) => ({
-    ...button,
-    label: button.label
-      ? (strings[button.label] ?? button.label)
-      : button.label,
-    vocalization: button.vocalization
-      ? (strings[button.vocalization] ?? button.vocalization)
-      : button.vocalization,
-  }));
+function applyTranslations(
+  board: Board,
+  translations: Record<string, string>,
+): Board {
+  const translate = (phrase: string | undefined) =>
+    phrase ? (translations[phrase] ?? phrase) : phrase;
 
   return {
     ...board,
-    name: board.name ? (strings[board.name] ?? board.name) : board.name,
-    buttons: resolvedButtons,
+    name: translate(board.name),
+    buttons: board.buttons.map((button) => ({
+      ...button,
+      label: translate(button.label),
+      vocalization: translate(button.vocalization),
+    })),
   };
 }
 
-async function persistStrings(
+async function persistTranslations(
   setId: string,
   boardId: string,
   language: string,
-  strings: Record<string, string>,
+  translations: Record<string, string>,
 ): Promise<void> {
   try {
     await withBoardsDB(async (db) => {
-      await updateBoardStrings(db, setId, boardId, language, strings);
+      await updateBoardStrings(db, setId, boardId, language, translations);
     });
   } catch (err) {
-    console.warn("Failed to persist translated strings:", err);
+    console.warn("Failed to persist translations:", err);
   }
 }


### PR DESCRIPTION
## Summary

The translation pipeline in `useBoardTranslation.ts` had an overworked noun: "strings" was used to mean five different things (the OBF strings map, a single locale's translation dictionary, the source phrases, the resulting translations, and the act of persisting them). This PR replaces the overloaded vocabulary with precise nouns *inside* the module while preserving the OBF-spec vocabulary at the file boundary.

## Renames

| Before | After | Why |
|---|---|---|
| `findStringsForLanguage` | `findTranslationsForLanguage` | Returns one language's dictionary, not the OBF strings map |
| `existingStrings` | `existingTranslations` | A dictionary of source → translated |
| `collectTranslatableStrings` | `collectSourcePhrases` | These are inputs to the translator, not translations |
| `keys` (parameter) | `phrases` | They are not "keys" until they index a dictionary |
| `translateStrings` | `translatePhrases` | Verb takes its true object |
| `translatedStrings` | `translations` | Leading adjective is redundant |
| `applyStrings(board, strings)` | `applyTranslations(board, translations)` | Pairs the verb with its true object |
| `persistStrings` | `persistTranslations` | Same |

Also collapses three near-duplicate ternaries in `applyTranslations` into a small local `translate()` helper.

## Boundary preservation

The OBF-facing names are deliberately untouched:
- `board.strings` / `Board["strings"]`
- `updateBoardStrings` (storage layer)

The OBF spec calls this field `strings`; that vocabulary is correct at the file boundary.

## Verification

- `npm run lint` — clean
- `npm run build` — clean (typecheck + bundle)
- `npm test` — 159/159 passing

No behavior change.