### PR TITLE
chore: bump version to 1.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aac-board-ai",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aac-board-ai",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aac-board-ai",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "engines": {
     "node": ">=24"


### PR DESCRIPTION
## Summary

- Bump package metadata from 1.3.0 to 1.3.1.
- Prepare the maintenance release after the runtime fixes, refactors, and dependency updates already merged to main.

## Verification

- `npm run lint` passed.
- `npm run build` passed, with the existing Vite chunk-size warning.
- `npm test` was run; the known flaky BackspaceButton long-press test failed, and the remaining 158 tests passed.

## Release note

This is intended as a patch maintenance release. After this PR is merged, recreate/push `v1.3.1` on the resulting main commit.