### PR TITLE
docs(prose): add "read the siblings" naming heuristic

### DIFF
--- a/.github/agents/prose.agent.md
+++ b/.github/agents/prose.agent.md
@@ -38,6 +38,7 @@ Names are the foundation of comprehension. They must be exact, unambiguous, and 
 - **Call-Site Readability:** A return property's name is never read alone — it is always prefixed by the consumer's variable name. Before renaming a return field, verify the compound phrase at every call site. It must not stutter (e.g., `suggestions.suggestions`) and both words must have distinct silhouettes (e.g., `suggestions.phrases`).
 - **Zero Ambiguity:** Suggest replacements for cryptic abbreviations or single-letter variables (unless they are standard loop counters or geometric coordinates).
 - **Respect Idiomatic Names:** Do not rename variables that carry established convention in their ecosystem. A name like `next` in a state-update function, `acc` in a reducer, or `prev` in a comparison is not vague — it is _expected_. Only rename when the idiomatic term is genuinely ambiguous in context.
+- **Read the Siblings:** Before condemning a generic-sounding name (`components`, `utils`, `data`, `helpers`), audit its peers. When the siblings form a consistent axis — by kind, by layer, by capability — the "vague" name is the axis label, doing precise work; renaming it breaks the parent's grammar. Judge a name by the next plausible member of its set, not by the snapshot of today's contents.
 
 ### 3. The Fluency Edit (Simplicity & Flow)
 


### PR DESCRIPTION
Adds a new bullet to the **Naming** section of the prose agent: before condemning a generic-sounding folder/variable name, audit its peers. When siblings form a consistent axis (kind, layer, capability), the 'vague' name is the axis label doing precise work — renaming it breaks the parent's grammar.

The heuristic asks the reviewer to judge a name by the next plausible member of the set, not by a snapshot of today's contents.

### Change

- One-line addition to `.github/agents/prose.agent.md` under "1. The Precision Edit (Naming)."