### PR TITLE
test: add unit tests for useMessagePlayback and useButtonActivation hooks

### DIFF
--- a/src/features/board/message/useMessagePlayback.test.tsx
+++ b/src/features/board/message/useMessagePlayback.test.tsx
@@ -1,0 +1,189 @@
+import { SpeechProvider } from "@shared/speech/SpeechProvider";
+import { stubAudio, stubSpeech } from "@shared/testing/device-output";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { renderHook } from "vitest-browser-react";
+import type { MessagePart } from "./useMessage";
+import { useMessagePlayback } from "./useMessagePlayback";
+
+function SpeechWrapper({ children }: { children: ReactNode }) {
+  return <SpeechProvider>{children}</SpeechProvider>;
+}
+
+describe("useMessagePlayback", () => {
+  let speech: ReturnType<typeof stubSpeech>;
+  let audio: ReturnType<typeof stubAudio>;
+
+  beforeEach(() => {
+    speech = stubSpeech();
+    audio = stubAudio();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("speaks consecutive text parts as one merged utterance", async () => {
+    const parts: MessagePart[] = [
+      { id: "1", label: "I" },
+      { id: "2", label: "want" },
+    ];
+
+    const { result } = await renderHook(() => useMessagePlayback(parts), {
+      wrapper: SpeechWrapper,
+    });
+
+    await result.current.play();
+
+    expect(speech.speak).toHaveBeenCalledTimes(1);
+    expect(speech.speak.mock.calls[0][0].text).toBe("I want");
+  });
+
+  test("plays a sound part as audio rather than speaking it", async () => {
+    const parts: MessagePart[] = [
+      { id: "1", label: "bell", soundSrc: "bell.mp3" },
+    ];
+
+    const { result } = await renderHook(() => useMessagePlayback(parts), {
+      wrapper: SpeechWrapper,
+    });
+
+    await result.current.play();
+
+    expect(audio.play).toHaveBeenCalledTimes(1);
+    expect(speech.speak).not.toHaveBeenCalled();
+  });
+
+  test("interleaves speech and audio in order when a sound breaks a text run", async () => {
+    const parts: MessagePart[] = [
+      { id: "1", label: "before" },
+      { id: "2", label: "ding", soundSrc: "ding.mp3" },
+      { id: "3", label: "after" },
+    ];
+
+    const callOrder: string[] = [];
+    speech.speak.mockImplementation((utterance) => {
+      callOrder.push(`speak:${utterance.text}`);
+      queueMicrotask(() => {
+        utterance.onend?.({ utterance } as unknown as SpeechSynthesisEvent);
+      });
+    });
+    audio.play.mockImplementation(function (this: HTMLAudioElement) {
+      callOrder.push(`play:${this.src.split("/").pop()}`);
+      queueMicrotask(() => {
+        this.dispatchEvent(new Event("play"));
+        this.dispatchEvent(new Event("ended"));
+      });
+      return Promise.resolve();
+    });
+
+    const { result } = await renderHook(() => useMessagePlayback(parts), {
+      wrapper: SpeechWrapper,
+    });
+
+    await result.current.play();
+
+    expect(callOrder).toEqual(["speak:before", "play:ding.mp3", "speak:after"]);
+  });
+
+  test("drops parts with no audible content", async () => {
+    const parts: MessagePart[] = [{ id: "1" }];
+
+    const { result } = await renderHook(() => useMessagePlayback(parts), {
+      wrapper: SpeechWrapper,
+    });
+
+    await result.current.play();
+
+    expect(speech.speak).not.toHaveBeenCalled();
+    expect(audio.play).not.toHaveBeenCalled();
+  });
+
+  test("prefers vocalization over label when both are present", async () => {
+    const parts: MessagePart[] = [{ id: "1", label: "I", vocalization: "eye" }];
+
+    const { result } = await renderHook(() => useMessagePlayback(parts), {
+      wrapper: SpeechWrapper,
+    });
+
+    await result.current.play();
+
+    expect(speech.speak.mock.calls[0][0].text).toBe("eye");
+  });
+
+  test("reports isPlaying true during playback and false after it resolves", async () => {
+    let resolveSpeak: (() => void) | undefined;
+    speech.speak.mockImplementationOnce((utterance) => {
+      resolveSpeak = () => {
+        utterance.onend?.({ utterance } as unknown as SpeechSynthesisEvent);
+      };
+    });
+
+    const parts: MessagePart[] = [{ id: "1", label: "hi" }];
+
+    const { result, rerender } = await renderHook(
+      () => useMessagePlayback(parts),
+      { wrapper: SpeechWrapper },
+    );
+
+    const playPromise = result.current.play();
+    await rerender();
+    expect(result.current.isPlaying).toBe(true);
+
+    resolveSpeak?.();
+    await playPromise;
+    await rerender();
+    expect(result.current.isPlaying).toBe(false);
+  });
+
+  test("stop() cancels speech and clears isPlaying", async () => {
+    let resolveSpeak: (() => void) | undefined;
+    speech.speak.mockImplementationOnce((utterance) => {
+      resolveSpeak = () => {
+        utterance.onend?.({ utterance } as unknown as SpeechSynthesisEvent);
+      };
+    });
+
+    const parts: MessagePart[] = [{ id: "1", label: "hi" }];
+
+    const { result, rerender } = await renderHook(
+      () => useMessagePlayback(parts),
+      { wrapper: SpeechWrapper },
+    );
+
+    const playPromise = result.current.play();
+    await rerender();
+
+    result.current.stop();
+    await rerender();
+
+    expect(speech.cancel).toHaveBeenCalled();
+    expect(result.current.isPlaying).toBe(false);
+
+    resolveSpeak?.();
+    await playPromise;
+  });
+
+  test("swallows playback errors and still resets isPlaying to false", async () => {
+    speech.speak.mockImplementationOnce((utterance) => {
+      queueMicrotask(() => {
+        utterance.onerror?.({
+          error: "synthesis-failed",
+        } as unknown as SpeechSynthesisErrorEvent);
+      });
+    });
+    vi.spyOn(console, "error").mockReturnValue(undefined);
+
+    const parts: MessagePart[] = [{ id: "1", label: "hi" }];
+
+    const { result, rerender } = await renderHook(
+      () => useMessagePlayback(parts),
+      { wrapper: SpeechWrapper },
+    );
+
+    await expect(result.current.play()).resolves.toBeUndefined();
+    await rerender();
+
+    expect(result.current.isPlaying).toBe(false);
+  });
+});

--- a/src/features/board/useButtonActivation.test.tsx
+++ b/src/features/board/useButtonActivation.test.tsx
@@ -1,0 +1,245 @@
+import { SpeechProvider } from "@shared/speech/SpeechProvider";
+import { stubAudio, stubSpeech } from "@shared/testing/device-output";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { renderHook } from "vitest-browser-react";
+import type { MessagePart, UseMessageReturn } from "./message/useMessage";
+import type { UseMessagePlaybackReturn } from "./message/useMessagePlayback";
+import type { UseBoardNavigationReturn } from "./navigation/useBoardNavigation";
+import type { BoardAction, BoardButton } from "./types";
+import { useButtonActivation } from "./useButtonActivation";
+
+function SpeechWrapper({ children }: { children: ReactNode }) {
+  return <SpeechProvider>{children}</SpeechProvider>;
+}
+
+function createMessageStub(parts: MessagePart[] = []): UseMessageReturn {
+  return {
+    parts,
+    text: parts.map((p) => p.label ?? "").join(" "),
+    addPart: vi.fn(),
+    addSpace: vi.fn(),
+    setParts: vi.fn(),
+    setFromText: vi.fn(),
+    removeLastPart: vi.fn(),
+    updateLastPart: vi.fn(),
+    clear: vi.fn(),
+  };
+}
+
+function createPlaybackStub(): UseMessagePlaybackReturn {
+  return {
+    isPlaying: false,
+    play: vi.fn(() => Promise.resolve()),
+    stop: vi.fn(),
+  };
+}
+
+function createNavigationStub(): UseBoardNavigationReturn {
+  return {
+    canGoBack: false,
+    canGoHome: true,
+    goToBoard: vi.fn(),
+    goBack: vi.fn(),
+    goHome: vi.fn(),
+  };
+}
+
+interface SetupOptions {
+  message?: UseMessageReturn;
+  playback?: UseMessagePlaybackReturn;
+  navigation?: UseBoardNavigationReturn;
+}
+
+async function setup(opts: SetupOptions = {}) {
+  const message = opts.message ?? createMessageStub();
+  const playback = opts.playback ?? createPlaybackStub();
+  const navigation = opts.navigation ?? createNavigationStub();
+
+  const { result } = await renderHook(
+    () => useButtonActivation({ message, playback, navigation }),
+    { wrapper: SpeechWrapper },
+  );
+
+  return { result, message, playback, navigation };
+}
+
+describe("useButtonActivation", () => {
+  let speech: ReturnType<typeof stubSpeech>;
+  let audio: ReturnType<typeof stubAudio>;
+
+  beforeEach(() => {
+    speech = stubSpeech();
+    audio = stubAudio();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("navigates to the linked board and skips message and audio when loadBoard.id is set", async () => {
+    const { result, message, playback, navigation } = await setup();
+
+    const button: BoardButton = {
+      id: "btn",
+      label: "Folder",
+      loadBoard: { id: "child-board" },
+    };
+
+    await result.current.activateButton(button);
+
+    expect(navigation.goToBoard).toHaveBeenCalledWith("child-board");
+    expect(message.addPart).not.toHaveBeenCalled();
+    expect(playback.play).not.toHaveBeenCalled();
+    expect(speech.speak).not.toHaveBeenCalled();
+    expect(audio.play).not.toHaveBeenCalled();
+  });
+
+  test("runs each action in order for an actions array", async () => {
+    const callOrder: string[] = [];
+    const message = createMessageStub();
+    message.addSpace = vi.fn(() => {
+      callOrder.push("addSpace");
+    });
+    message.clear = vi.fn(() => {
+      callOrder.push("clear");
+    });
+    const playback = createPlaybackStub();
+    playback.play = vi.fn(() => {
+      callOrder.push("play");
+      return Promise.resolve();
+    });
+
+    const { result } = await setup({ message, playback });
+
+    await result.current.activateButton({
+      id: "btn",
+      actions: [":space", ":speak", ":clear"],
+    });
+
+    expect(callOrder).toEqual(["addSpace", "play", "clear"]);
+  });
+
+  test.each([
+    [":space", "addSpace"],
+    [":backspace", "removeLastPart"],
+    [":clear", "clear"],
+  ] as const)("maps %s to message.%s", async (action, methodName) => {
+    const { result, message } = await setup();
+
+    await result.current.activateButton({ id: "btn", actions: [action] });
+
+    expect(message[methodName]).toHaveBeenCalledTimes(1);
+  });
+
+  test("maps :speak to playback.play", async () => {
+    const { result, playback } = await setup();
+
+    await result.current.activateButton({ id: "btn", actions: [":speak"] });
+
+    expect(playback.play).toHaveBeenCalledTimes(1);
+  });
+
+  test("maps :home to navigation.goHome", async () => {
+    const { result, navigation } = await setup();
+
+    await result.current.activateButton({ id: "btn", actions: [":home"] });
+
+    expect(navigation.goHome).toHaveBeenCalledTimes(1);
+  });
+
+  test("appends a spelling action's text to the last message part's label", async () => {
+    const message = createMessageStub([{ id: "ca", label: "ca" }]);
+    const { result } = await setup({ message });
+
+    await result.current.activateButton({ id: "btn", actions: ["+t"] });
+
+    expect(message.updateLastPart).toHaveBeenCalledWith({
+      id: "t",
+      label: "cat",
+    });
+  });
+
+  test("ignores unrecognized default actions", async () => {
+    const { result, message, playback, navigation } = await setup();
+
+    await result.current.activateButton({
+      id: "btn",
+      actions: [":unknown" as BoardAction],
+    });
+
+    expect(message.addPart).not.toHaveBeenCalled();
+    expect(message.addSpace).not.toHaveBeenCalled();
+    expect(message.removeLastPart).not.toHaveBeenCalled();
+    expect(message.updateLastPart).not.toHaveBeenCalled();
+    expect(message.clear).not.toHaveBeenCalled();
+    expect(playback.play).not.toHaveBeenCalled();
+    expect(navigation.goHome).not.toHaveBeenCalled();
+    expect(speech.speak).not.toHaveBeenCalled();
+    expect(audio.play).not.toHaveBeenCalled();
+  });
+
+  test("adds the button as a message part when there are no actions and no loadBoard", async () => {
+    const { result, message } = await setup();
+
+    await result.current.activateButton({
+      id: "btn",
+      label: "hi",
+      vocalization: "hello",
+      imageSrc: "img.png",
+    });
+
+    expect(message.addPart).toHaveBeenCalledWith({
+      id: "btn",
+      label: "hi",
+      vocalization: "hello",
+      imageSrc: "img.png",
+      soundSrc: undefined,
+    });
+  });
+
+  test("plays the button's soundSrc rather than speaking when both are present", async () => {
+    const { result } = await setup();
+
+    await result.current.activateButton({
+      id: "btn",
+      label: "bell",
+      soundSrc: "bell.mp3",
+    });
+
+    expect(audio.play).toHaveBeenCalledTimes(1);
+    expect(speech.speak).not.toHaveBeenCalled();
+  });
+
+  test("speaks the lowercased vocalization when no soundSrc", async () => {
+    const { result } = await setup();
+
+    await result.current.activateButton({
+      id: "btn",
+      label: "I",
+      vocalization: "Hello",
+    });
+
+    expect(speech.speak).toHaveBeenCalledTimes(1);
+    expect(speech.speak.mock.calls[0][0].text).toBe("hello");
+  });
+
+  test("falls back to the lowercased label when vocalization is absent", async () => {
+    const { result } = await setup();
+
+    await result.current.activateButton({ id: "btn", label: "Goodbye" });
+
+    expect(speech.speak).toHaveBeenCalledTimes(1);
+    expect(speech.speak.mock.calls[0][0].text).toBe("goodbye");
+  });
+
+  test("stays silent when the button has neither sound nor any speakable text", async () => {
+    const { result, message } = await setup();
+
+    await result.current.activateButton({ id: "btn" });
+
+    expect(message.addPart).toHaveBeenCalledTimes(1);
+    expect(speech.speak).not.toHaveBeenCalled();
+    expect(audio.play).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/testing/device-output.ts
+++ b/src/shared/testing/device-output.ts
@@ -1,0 +1,36 @@
+import { vi } from "vitest";
+
+// Real speak()/play() resolve via utterance.onend / audio.onended; the spies
+// trigger those events via microtask so awaited callers can settle in tests.
+// cancel/pause are stubbed alongside because the real hooks call them as part
+// of their start/stop lifecycle, and exercising them on real device output
+// causes spurious AbortErrors in browser-mode tests.
+
+export function stubSpeech() {
+  const cancel = vi.spyOn(speechSynthesis, "cancel").mockReturnValue(undefined);
+  const speak = vi
+    .spyOn(speechSynthesis, "speak")
+    .mockImplementation((utterance) => {
+      queueMicrotask(() => {
+        utterance.onend?.({ utterance } as unknown as SpeechSynthesisEvent);
+      });
+    });
+  return { speak, cancel };
+}
+
+export function stubAudio() {
+  const pause = vi
+    .spyOn(HTMLAudioElement.prototype, "pause")
+    .mockReturnValue(undefined);
+
+  const play = vi
+    .spyOn(HTMLAudioElement.prototype, "play")
+    .mockImplementation(function (this: HTMLAudioElement) {
+      queueMicrotask(() => {
+        this.dispatchEvent(new Event("play"));
+        this.dispatchEvent(new Event("ended"));
+      });
+      return Promise.resolve();
+    });
+  return { play, pause };
+}


### PR DESCRIPTION
## Summary
- Adds unit tests for `useMessagePlayback` (8 tests) and `useButtonActivation` (14 tests), the two hooks at the heart of the daily-use flow (Play button + tile activation). Both were untested.
- Introduces a small testing helper at `src/shared/testing/device-output.ts` with `stubSpeech()` / `stubAudio()` — each returns the paired spies for that device (`speak`/`cancel`, `play`/`pause`) so test files don't have to remember to stub each method individually.
- Follows the updated AGENTS.md testing policy: full-tree render, `vi.spyOn` only on device output (`speechSynthesis`, `HTMLAudioElement`), no `vi.mock` of internals.

## Test plan
- [x] `npm test` — all 22 test files / 180 tests pass in browser mode
- [x] `npm run lint` — clean
- [x] `npm run build` — clean