### PR TITLE
refactor(board): drop redundant error log in useLoadBoard

### DIFF
--- a/src/features/board/suggestions/SuggestionBar.tsx
+++ b/src/features/board/suggestions/SuggestionBar.tsx
@@ -30,9 +30,9 @@ export function SuggestionBar({
           overflowX: "auto",
         }}
       >
-        {suggestions.map((suggestion, index) => (
+        {suggestions.map((suggestion) => (
           <Chip
-            key={index}
+            key={suggestion}
             label={suggestion}
             onClick={() => onSuggestionClick(suggestion)}
           />

--- a/src/features/board/useBoard.ts
+++ b/src/features/board/useBoard.ts
@@ -9,13 +9,17 @@ export interface UseBoardOptions {
 
 export interface UseBoardReturn {
   board: Board | null;
+  isLoading: boolean;
+  error: Error | null;
 }
 
 export function useBoard({ setId, boardId }: UseBoardOptions): UseBoardReturn {
-  const { board } = useLoadBoard({ setId, boardId });
+  const { board, isLoading, error } = useLoadBoard({ setId, boardId });
   const { translatedBoard } = useBoardTranslation({ setId, board });
 
   return {
     board: translatedBoard,
+    isLoading,
+    error,
   };
 }

--- a/src/features/board/useLoadBoard.ts
+++ b/src/features/board/useLoadBoard.ts
@@ -14,6 +14,8 @@ export interface UseLoadBoardOptions {
 
 export interface UseLoadBoardReturn {
   board: Board | null;
+  isLoading: boolean;
+  error: Error | null;
 }
 
 export function useLoadBoard({
@@ -21,6 +23,8 @@ export function useLoadBoard({
   boardId,
 }: UseLoadBoardOptions): UseLoadBoardReturn {
   const [board, setBoard] = useState<Board | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
   const registryRef = useRef<ObjectUrlRegistry | null>(null);
 
   useEffect(() => {
@@ -30,8 +34,13 @@ export function useLoadBoard({
     async function fetchAndApply() {
       if (!setId || !boardId) {
         setBoard(null);
+        setIsLoading(false);
+        setError(null);
         return;
       }
+
+      setIsLoading(true);
+      setError(null);
 
       try {
         const loaded = await loadBoard({ setId, boardId, registry });
@@ -39,6 +48,7 @@ export function useLoadBoard({
           registryRef.current?.revokeAll();
           registryRef.current = registry;
           setBoard(loaded);
+          setIsLoading(false);
         } else {
           registry.revokeAll();
         }
@@ -47,6 +57,8 @@ export function useLoadBoard({
         registry.revokeAll();
         if (!cancelled) {
           setBoard(null);
+          setError(err instanceof Error ? err : new Error(String(err)));
+          setIsLoading(false);
         }
       }
     }
@@ -65,7 +77,7 @@ export function useLoadBoard({
     };
   }, []);
 
-  return { board };
+  return { board, isLoading, error };
 }
 
 async function loadBoard({

--- a/src/features/board/useLoadBoard.ts
+++ b/src/features/board/useLoadBoard.ts
@@ -53,7 +53,6 @@ export function useLoadBoard({
           registry.revokeAll();
         }
       } catch (err) {
-        console.error("Error loading board:", err);
         registry.revokeAll();
         if (!cancelled) {
           setBoard(null);

--- a/src/pages/BoardPage.test.tsx
+++ b/src/pages/BoardPage.test.tsx
@@ -1,0 +1,78 @@
+import { AppProviders } from "@app/AppProviders";
+import { invalidateBoardSets } from "@features/board/storage/board-sets-store";
+import { putBoards, upsertBoardSet } from "@features/board/storage/boards-db";
+import {
+  openCleanBoardsDB,
+  resetBoardsDB,
+} from "@features/board/storage/test-helpers";
+import type { OBFBoard } from "open-board-format";
+import type { ReactNode } from "react";
+import { MemoryRouter, Route, Routes } from "react-router";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { render } from "vitest-browser-react";
+import BoardPage from "./BoardPage";
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <AppProviders>{children}</AppProviders>;
+}
+
+function renderBoardPage(setId: string, boardId: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/sets/${setId}/boards/${boardId}`]}>
+      <Routes>
+        <Route path="/sets/:setId/boards/:boardId" element={<BoardPage />} />
+      </Routes>
+    </MemoryRouter>,
+    { wrapper: Wrapper },
+  );
+}
+
+async function seedBoard(setId: string, boardId: string) {
+  const db = await openCleanBoardsDB();
+  try {
+    await upsertBoardSet(db, { setId, name: setId, rootBoardId: boardId });
+    const json: OBFBoard = {
+      format: "open-board-0.1",
+      id: boardId,
+      locale: "en",
+      buttons: [{ id: "btn-1", label: "Hello" }],
+      grid: { rows: 1, columns: 1, order: [["btn-1"]] },
+    };
+    await putBoards(db, setId, [{ boardId, name: boardId, json }]);
+  } finally {
+    db.close();
+  }
+  await invalidateBoardSets();
+}
+
+describe("BoardPage", () => {
+  beforeEach(async () => {
+    await resetBoardsDB();
+    await invalidateBoardSets();
+  });
+
+  afterEach(async () => {
+    localStorage.clear();
+    await resetBoardsDB();
+    await invalidateBoardSets();
+  });
+
+  test("renders the error fallback when the board is not in IndexedDB", async () => {
+    const screen = await renderBoardPage("missing-set", "missing-board");
+
+    await expect
+      .element(screen.getByText("Failed to load board"))
+      .toBeVisible();
+    await expect.element(screen.getByText(/Board not found/)).toBeVisible();
+  });
+
+  test("renders the board when present", async () => {
+    await seedBoard("test-set", "board-1");
+
+    const screen = await renderBoardPage("test-set", "board-1");
+
+    await expect
+      .element(screen.getByRole("button", { name: "Hello" }))
+      .toBeVisible();
+  });
+});

--- a/src/pages/BoardPage.tsx
+++ b/src/pages/BoardPage.tsx
@@ -1,19 +1,26 @@
 import { usePageTitle } from "@app/usePageTitle";
 import { BoardView, useBoard, type BoardRouteParams } from "@features/board";
+import { ErrorFallback } from "@shared/components/ErrorFallback";
 import { LoadingIndicator } from "@shared/components/LoadingIndicator";
 import { useEffect } from "react";
 import { useParams } from "react-router";
 
 function BoardPage() {
   const { setId = "", boardId = "" } = useParams<BoardRouteParams>();
-  const { board } = useBoard({ setId, boardId });
+  const { board, isLoading, error } = useBoard({ setId, boardId });
   const { setPageTitle } = usePageTitle();
 
   useEffect(() => {
     setPageTitle(board?.name);
   }, [setPageTitle, board?.name]);
 
-  if (!board) {
+  if (error) {
+    return (
+      <ErrorFallback title="Failed to load board" message={error.message} />
+    );
+  }
+
+  if (isLoading || !board) {
     return <LoadingIndicator />;
   }
 


### PR DESCRIPTION
## Summary

Removes `console.error("Error loading board:", err)` from `useLoadBoard`'s catch block. The error is now captured into the hook's `error` state and rendered by `BoardPage` via `<ErrorFallback>`, so the in-hook log is redundant.

The codebase pattern is to log errors that are *swallowed* (no propagation). With #236 merged, the load error propagates — so it should follow the same rule and stop being logged. Asset hydration errors at line 136 stay logged because they are intentionally swallowed (the board still renders without missing assets).

Side benefit: the `BoardPage` error-path test no longer prints a stack trace into the test runner output.

## Depends on

[#236](https://github.com/shayc/aac-board-ai/pull/236) — without it the error would be silently swallowed entirely. Will rebase after #236 lands; until then this PR's diff against `main` includes #236's commits.

## Test plan

- [x] `npm run lint`
- [x] `npm test` — 184/184 passing
- [x] Confirmed test runner output no longer contains `Error loading board:` stack trace from the `BoardPage` error-path test

🤖 Generated with [Claude Code](https://claude.com/claude-code)