### PR TITLE
feat(board): surface load errors via ErrorFallback in BoardPage

### DIFF
--- a/src/features/board/useBoard.ts
+++ b/src/features/board/useBoard.ts
@@ -9,13 +9,17 @@ export interface UseBoardOptions {
 
 export interface UseBoardReturn {
   board: Board | null;
+  isLoading: boolean;
+  error: Error | null;
 }
 
 export function useBoard({ setId, boardId }: UseBoardOptions): UseBoardReturn {
-  const { board } = useLoadBoard({ setId, boardId });
+  const { board, isLoading, error } = useLoadBoard({ setId, boardId });
   const { translatedBoard } = useBoardTranslation({ setId, board });
 
   return {
     board: translatedBoard,
+    isLoading,
+    error,
   };
 }

--- a/src/features/board/useLoadBoard.ts
+++ b/src/features/board/useLoadBoard.ts
@@ -14,6 +14,8 @@ export interface UseLoadBoardOptions {
 
 export interface UseLoadBoardReturn {
   board: Board | null;
+  isLoading: boolean;
+  error: Error | null;
 }
 
 export function useLoadBoard({
@@ -21,6 +23,8 @@ export function useLoadBoard({
   boardId,
 }: UseLoadBoardOptions): UseLoadBoardReturn {
   const [board, setBoard] = useState<Board | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
   const registryRef = useRef<ObjectUrlRegistry | null>(null);
 
   useEffect(() => {
@@ -29,9 +33,16 @@ export function useLoadBoard({
 
     async function fetchAndApply() {
       if (!setId || !boardId) {
+        registryRef.current?.revokeAll();
+        registryRef.current = null;
         setBoard(null);
+        setIsLoading(false);
+        setError(null);
         return;
       }
+
+      setIsLoading(true);
+      setError(null);
 
       try {
         const loaded = await loadBoard({ setId, boardId, registry });
@@ -39,14 +50,17 @@ export function useLoadBoard({
           registryRef.current?.revokeAll();
           registryRef.current = registry;
           setBoard(loaded);
+          setIsLoading(false);
+          setError(null);
         } else {
           registry.revokeAll();
         }
       } catch (err) {
-        console.error("Error loading board:", err);
         registry.revokeAll();
         if (!cancelled) {
           setBoard(null);
+          setIsLoading(false);
+          setError(err instanceof Error ? err : new Error(String(err)));
         }
       }
     }
@@ -65,7 +79,7 @@ export function useLoadBoard({
     };
   }, []);
 
-  return { board };
+  return { board, isLoading, error };
 }
 
 async function loadBoard({
@@ -103,11 +117,12 @@ async function hydrateBoard(
   board: OBFBoard,
   registry: ObjectUrlRegistry,
 ): Promise<OBFBoard> {
-  return {
-    ...board,
-    images: await hydrateAssets(db, setId, board.images, "image", registry),
-    sounds: await hydrateAssets(db, setId, board.sounds, "sound", registry),
-  };
+  const [images, sounds] = await Promise.all([
+    hydrateAssets(db, setId, board.images, "image", registry),
+    hydrateAssets(db, setId, board.sounds, "sound", registry),
+  ]);
+
+  return { ...board, images, sounds };
 }
 
 async function hydrateAssets(
@@ -121,25 +136,23 @@ async function hydrateAssets(
     return assets;
   }
 
-  const resolvedMedia: OBFMedia[] = [];
-  for (const asset of assets) {
-    if (!asset.path) {
-      resolvedMedia.push(asset);
-      continue;
-    }
+  return Promise.all(
+    assets.map(async (asset) => {
+      if (!asset.path) {
+        return asset;
+      }
 
-    try {
-      const blob = await getAssetBlob(db, setId, asset.path);
-      const url = blob ? registry.create(blob) : null;
-      resolvedMedia.push(url ? { ...asset, data: url } : asset);
-    } catch (err) {
-      console.warn(
-        `Failed to load ${kind} ${asset.id} from path ${asset.path}:`,
-        err,
-      );
-      resolvedMedia.push(asset);
-    }
-  }
-
-  return resolvedMedia;
+      try {
+        const blob = await getAssetBlob(db, setId, asset.path);
+        const url = blob ? registry.create(blob) : null;
+        return url ? { ...asset, data: url } : asset;
+      } catch (err) {
+        console.warn(
+          `Failed to load ${kind} ${asset.id} from path ${asset.path}:`,
+          err,
+        );
+        return asset;
+      }
+    }),
+  );
 }

--- a/src/pages/BoardPage.tsx
+++ b/src/pages/BoardPage.tsx
@@ -1,19 +1,26 @@
 import { usePageTitle } from "@app/usePageTitle";
 import { BoardView, useBoard, type BoardRouteParams } from "@features/board";
+import { ErrorFallback } from "@shared/components/ErrorFallback";
 import { LoadingIndicator } from "@shared/components/LoadingIndicator";
 import { useEffect } from "react";
 import { useParams } from "react-router";
 
 function BoardPage() {
   const { setId = "", boardId = "" } = useParams<BoardRouteParams>();
-  const { board } = useBoard({ setId, boardId });
+  const { board, isLoading, error } = useBoard({ setId, boardId });
   const { setPageTitle } = usePageTitle();
 
   useEffect(() => {
     setPageTitle(board?.name);
   }, [setPageTitle, board?.name]);
 
-  if (!board) {
+  if (error) {
+    return (
+      <ErrorFallback title="Failed to load board" message={error.message} />
+    );
+  }
+
+  if (isLoading || !board) {
     return <LoadingIndicator />;
   }
 


### PR DESCRIPTION
## Summary
- `useLoadBoard` and `useBoard` now expose `isLoading` and `error: Error | null` alongside `board`, matching the `useBoardSets` pattern. Errors are no longer swallowed to `console.error` — they propagate to the caller.
- `BoardPage` renders `<ErrorFallback title="Failed to load board" message={error.message} />` on failure instead of spinning indefinitely when a load throws (e.g., `Board not found: <id>`).
- Hydrates board assets concurrently: images and sounds load in parallel, and each kind's assets are fetched in parallel via `Promise.all` (order preserved).
- Tightens the early-return branch in `useLoadBoard` to revoke the prior registry and clear the ref, for consistency with the other cleanup paths. Currently unreachable through `BoardPage`'s route (react-router unmounts on missing params, and the unmount cleanup already revokes), but avoids a latent leak if the hook is ever called with cleared params.

## Test plan
- [x] `tsc -b` clean
- [x] `npm run lint` clean
- [x] `npm test` — 22 files / 182 tests pass
- [ ] Manual: load an existing board — renders normally
- [ ] Manual: visit a board URL with a non-existent `boardId` — `ErrorFallback` shows "Failed to load board" / "Board not found: …" instead of an infinite spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)