### PR TITLE
test: drop duplicate Tile color tests and parameterize lookup tables

### DIFF
--- a/src/features/board/Tile.test.tsx
+++ b/src/features/board/Tile.test.tsx
@@ -43,37 +43,16 @@ describe("Tile", () => {
     expect(afterStyles.display).toBe("block");
   });
 
-  test("applies backgroundColor to the button", async () => {
+  test("applies backgroundColor and a readable text color", async () => {
     const screen = await render(
-      <Tile label="Colored" backgroundColor="#ff0000" onClick={vi.fn()} />,
+      <Tile label="Colored" backgroundColor="#000000" onClick={vi.fn()} />,
     );
 
     const button = screen.getByRole("button", { name: "Colored" });
     const styles = getComputedStyle(button.element());
 
-    expect(styles.backgroundColor).toBe("rgb(255, 0, 0)");
-  });
-
-  test("uses light text color on dark backgrounds", async () => {
-    const screen = await render(
-      <Tile label="Dark bg" backgroundColor="#000000" onClick={vi.fn()} />,
-    );
-
-    const button = screen.getByRole("button", { name: "Dark bg" });
-    const styles = getComputedStyle(button.element());
-
+    expect(styles.backgroundColor).toBe("rgb(0, 0, 0)");
     expect(styles.color).toBe("rgb(255, 255, 255)");
-  });
-
-  test("uses dark text color on light backgrounds", async () => {
-    const screen = await render(
-      <Tile label="Light bg" backgroundColor="#ffffff" onClick={vi.fn()} />,
-    );
-
-    const button = screen.getByRole("button", { name: "Light bg" });
-    const styles = getComputedStyle(button.element());
-
-    expect(styles.color).toBe("rgb(0, 0, 0)");
   });
 
   test("applies borderColor when provided", async () => {

--- a/src/features/board/suggestions/ToneSelector.test.tsx
+++ b/src/features/board/suggestions/ToneSelector.test.tsx
@@ -3,44 +3,17 @@ import { render } from "vitest-browser-react";
 import { ToneSelector } from "./ToneSelector";
 
 describe("ToneSelector", () => {
-  test("highlights direct tone when selected", async () => {
-    const onChange = vi.fn();
-
+  test.each([
+    ["as-is", "direct tone"],
+    ["more-formal", "professional tone"],
+    ["more-casual", "friendly tone"],
+  ] as const)("highlights %s as the %s button", async (tone, label) => {
     const screen = await render(
-      <ToneSelector tone="as-is" onChange={onChange} />,
+      <ToneSelector tone={tone} onChange={vi.fn()} />,
     );
 
-    const directButton = screen.getByRole("button", { name: "direct tone" });
-    await expect.element(directButton).toHaveAttribute("aria-pressed", "true");
-  });
-
-  test("highlights professional tone when selected", async () => {
-    const onChange = vi.fn();
-
-    const screen = await render(
-      <ToneSelector tone="more-formal" onChange={onChange} />,
-    );
-
-    const professionalButton = screen.getByRole("button", {
-      name: "professional tone",
-    });
     await expect
-      .element(professionalButton)
-      .toHaveAttribute("aria-pressed", "true");
-  });
-
-  test("highlights friendly tone when selected", async () => {
-    const onChange = vi.fn();
-
-    const screen = await render(
-      <ToneSelector tone="more-casual" onChange={onChange} />,
-    );
-
-    const friendlyButton = screen.getByRole("button", {
-      name: "friendly tone",
-    });
-    await expect
-      .element(friendlyButton)
+      .element(screen.getByRole("button", { name: label }))
       .toHaveAttribute("aria-pressed", "true");
   });
 

--- a/src/shared/language/locale.test.ts
+++ b/src/shared/language/locale.test.ts
@@ -2,45 +2,25 @@ import { describe, expect, test } from "vitest";
 import { getPrimaryLanguage, normalizeLocaleCode } from "./locale";
 
 describe("normalizeLocaleCode", () => {
-  test("lowercases a language-only code", () => {
-    expect(normalizeLocaleCode("EN")).toBe("en");
-  });
-
-  test("returns a language-only code as-is when already lowercase", () => {
-    expect(normalizeLocaleCode("fr")).toBe("fr");
-  });
-
-  test("normalizes language-region with hyphen separator", () => {
-    expect(normalizeLocaleCode("en-us")).toBe("en-US");
-  });
-
-  test("normalizes language-region with underscore separator", () => {
-    expect(normalizeLocaleCode("pt_br")).toBe("pt-BR");
-  });
-
-  test("normalizes mixed-case language-region", () => {
-    expect(normalizeLocaleCode("EN-gb")).toBe("en-GB");
-  });
-
-  test("handles already-normalized code", () => {
-    expect(normalizeLocaleCode("zh-TW")).toBe("zh-TW");
+  test.each([
+    ["EN", "en"],
+    ["fr", "fr"],
+    ["en-us", "en-US"],
+    ["pt_br", "pt-BR"],
+    ["EN-gb", "en-GB"],
+    ["zh-TW", "zh-TW"],
+  ])("normalizes %s → %s", (input, expected) => {
+    expect(normalizeLocaleCode(input)).toBe(expected);
   });
 });
 
 describe("getPrimaryLanguage", () => {
-  test("returns a language-only code as-is", () => {
-    expect(getPrimaryLanguage("en")).toBe("en");
-  });
-
-  test("strips the region from a hyphen-separated locale", () => {
-    expect(getPrimaryLanguage("en-US")).toBe("en");
-  });
-
-  test("strips the region from an underscore-separated locale", () => {
-    expect(getPrimaryLanguage("pt_BR")).toBe("pt");
-  });
-
-  test("lowercases the primary subtag", () => {
-    expect(getPrimaryLanguage("EN-GB")).toBe("en");
+  test.each([
+    ["en", "en"],
+    ["en-US", "en"],
+    ["pt_BR", "pt"],
+    ["EN-GB", "en"],
+  ])("extracts primary language from %s → %s", (input, expected) => {
+    expect(getPrimaryLanguage(input)).toBe(expected);
   });
 });


### PR DESCRIPTION
## Summary
- Tile had three `getComputedStyle` assertions covering the same `getReadableTextColor` wiring — collapsed to one test that verifies both bg and readable foreground in a single render.
- ToneSelector and locale tests were near-identical input/output cases; switched to `test.each` since the body is a one-line assertion.
- NavButtons and boards-db validation were intentionally left as explicit tests after trying `test.each` — the conditional and function-in-tuple patterns hurt readability there.

## Test plan
- [x] `npm run lint`
- [x] `npm test` for the touched files (62 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)