### PR TITLE
chore: simplify MUI dependencies optimization

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    include: ["@mui/material", "@mui/icons-material"],
+    include: ["@mui/material/*", "@mui/icons-material/*"],
   },
   test: {
     browser: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,57 +6,6 @@ import path from "path";
 import { defineConfig } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
 
-const MUI_DEPS = [
-  // Core
-  "react-dom/client",
-  "react-error-boundary",
-
-  // Icons
-  "@mui/icons-material/AutoAwesomeOutlined",
-  "@mui/icons-material/Cancel",
-  "@mui/icons-material/CheckCircle",
-  "@mui/icons-material/Close",
-  "@mui/icons-material/CollectionsBookmarkOutlined",
-  "@mui/icons-material/Downloading",
-  "@mui/icons-material/InfoOutlined",
-  "@mui/icons-material/LockOutlined",
-  "@mui/icons-material/Menu",
-  "@mui/icons-material/SettingsOutlined",
-  "@mui/icons-material/Translate",
-
-  // Components
-  "@mui/material/Alert",
-  "@mui/material/AlertTitle",
-  "@mui/material/AppBar",
-  "@mui/material/CssBaseline",
-  "@mui/material/Dialog",
-  "@mui/material/DialogActions",
-  "@mui/material/DialogContent",
-  "@mui/material/DialogContentText",
-  "@mui/material/DialogTitle",
-  "@mui/material/Divider",
-  "@mui/material/Drawer",
-  "@mui/material/Fade",
-  "@mui/material/FormControl",
-  "@mui/material/FormControlLabel",
-  "@mui/material/FormLabel",
-  "@mui/material/InputLabel",
-  "@mui/material/List",
-  "@mui/material/ListItem",
-  "@mui/material/ListItemButton",
-  "@mui/material/ListItemIcon",
-  "@mui/material/ListItemText",
-  "@mui/material/ListSubheader",
-  "@mui/material/MenuItem",
-  "@mui/material/Radio",
-  "@mui/material/RadioGroup",
-  "@mui/material/Select",
-  "@mui/material/Slider",
-  "@mui/material/Snackbar",
-  "@mui/material/TextField",
-  "@mui/material/Toolbar",
-];
-
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
@@ -82,7 +31,7 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    include: MUI_DEPS,
+    include: ["@mui/material", "@mui/icons-material"],
   },
   test: {
     browser: {


### PR DESCRIPTION
## Description
This PR simplifies the MUI dependencies optimization by using package-level paths instead of an explicit list of submodules.

## Changes
- Replaced `MUI_DEPS` array with direct package paths: `@mui/material` and `@mui/icons-material`
- Vite handles package-level inclusion more effectively for pre-bundling
- Reduces maintenance burden of tracking individual module imports

## Type of Change
- [x] Chore (non-code change)