### PR TITLE
ci: install only chromium for Playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm ci
 
       - name: Install Playwright
-        run: npx playwright install --with-deps
+        run: npx playwright install --with-deps chromium
 
       - name: Run lint
         run: npm run lint


### PR DESCRIPTION
## Summary
- Vitest browser tests only target chromium (see [vite.config.ts:41](vite.config.ts:41)), so installing firefox and webkit in CI was wasted time.
- Scopes the install to `chromium` only.

## Test plan
- [ ] CI workflow runs green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)