### PR TITLE
refactor: drop redundant getState from ExternalStore

### DIFF
--- a/src/app/usePageTitle.ts
+++ b/src/app/usePageTitle.ts
@@ -18,7 +18,7 @@ export function usePageTitle() {
 
   function setPageTitle(title: string | undefined) {
     const next = title ?? "";
-    if (store.getState() !== next) {
+    if (store.getSnapshot() !== next) {
       store.setState(next);
       ownsTitle.current = next !== "";
     }

--- a/src/features/board/storage/board-sets-store.ts
+++ b/src/features/board/storage/board-sets-store.ts
@@ -69,7 +69,7 @@ export async function fetchBoardSets(): Promise<BoardSetRecord[]> {
     await refresh();
   }
 
-  return store.getState().boardSets;
+  return store.getSnapshot().boardSets;
 }
 
 export async function invalidateBoardSets(): Promise<void> {

--- a/src/shared/utils/external-store.test.ts
+++ b/src/shared/utils/external-store.test.ts
@@ -5,14 +5,12 @@ describe("createExternalStore", () => {
   test("should return the initial state", () => {
     const store = createExternalStore(42);
     expect(store.getSnapshot()).toBe(42);
-    expect(store.getState()).toBe(42);
   });
 
   test("should update state with setState", () => {
     const store = createExternalStore("hello");
     store.setState("world");
     expect(store.getSnapshot()).toBe("world");
-    expect(store.getState()).toBe("world");
   });
 
   test("should notify listeners on setState", () => {

--- a/src/shared/utils/external-store.ts
+++ b/src/shared/utils/external-store.ts
@@ -1,7 +1,6 @@
 export interface ExternalStore<T> {
   subscribe: (listener: () => void) => () => void;
   getSnapshot: () => T;
-  getState: () => T;
   setState: (next: T) => void;
 }
 
@@ -26,14 +25,10 @@ export function createExternalStore<T>(initialState: T): ExternalStore<T> {
     return state;
   }
 
-  function getState() {
-    return state;
-  }
-
   function setState(next: T) {
     state = next;
     emit();
   }
 
-  return { subscribe, getSnapshot, getState, setState };
+  return { subscribe, getSnapshot, setState };
 }


### PR DESCRIPTION
## Summary
- `getSnapshot` and `getState` on the `ExternalStore` interface returned identical values — one of them was dead surface area.
- Kept `getSnapshot` (the React `useSyncExternalStore` convention) and removed `getState` from the interface, the factory, the two production call sites, and the redundant test assertions.

## Test plan
- [x] `npm run lint` clean
- [x] `npm run build` green (typecheck + Vite build)
- [x] `npm test src/shared/utils/external-store.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)