### PR TITLE
fix: adjust BoardSetInfoDialog maxWidth from xs to sm

### DIFF
--- a/src/pages/library/components/BoardSetInfoDialog.tsx
+++ b/src/pages/library/components/BoardSetInfoDialog.tsx
@@ -26,7 +26,7 @@ export function BoardSetInfoDialog({
       onClose={onClose}
       aria-labelledby="info-dialog-title"
       fullWidth
-      maxWidth="xs"
+      maxWidth="sm"
     >
       <DialogTitle id="info-dialog-title">
         {boardSet?.name}


### PR DESCRIPTION
Change BoardSetInfoDialog dialog width from xs to sm to better fit expanded content.