### PR TITLE
refactor: extract shared EmptyState component

### DIFF
--- a/src/pages/library/LibraryPage.tsx
+++ b/src/pages/library/LibraryPage.tsx
@@ -9,13 +9,13 @@ import AddIcon from "@mui/icons-material/Add";
 import Button from "@mui/material/Button";
 import Container from "@mui/material/Container";
 import Stack from "@mui/material/Stack";
+import { EmptyState } from "@shared/components/EmptyState";
 import { useSnackbar } from "@shared/snackbar/useSnackbar";
 import { useEffect, useState } from "react";
 import { generatePath, useNavigate } from "react-router";
 import { BoardSetDeleteDialog } from "./components/BoardSetDeleteDialog";
 import { BoardSetInfoDialog } from "./components/BoardSetInfoDialog";
 import { BoardSetList } from "./components/BoardSetList";
-import { LibraryEmptyState } from "./components/LibraryEmptyState";
 
 function LibraryPage() {
   const { boardSets, isLoading } = useBoardSets();
@@ -78,7 +78,9 @@ function LibraryPage() {
         </Button>
       </Stack>
 
-      {!isLoading && boardSets.length === 0 && <LibraryEmptyState />}
+      {!isLoading && boardSets.length === 0 && (
+        <EmptyState message="No board sets imported yet." />
+      )}
 
       {!isLoading && boardSets.length > 0 && (
         <>

--- a/src/shared/components/EmptyState.tsx
+++ b/src/shared/components/EmptyState.tsx
@@ -1,13 +1,17 @@
 import Typography from "@mui/material/Typography";
 
-export function LibraryEmptyState() {
+export interface EmptyStateProps {
+  message: string;
+}
+
+export function EmptyState({ message }: EmptyStateProps) {
   return (
     <Typography
       variant="body1"
       color="text.secondary"
       sx={{ textAlign: "center", py: 8 }}
     >
-      No board sets imported yet.
+      {message}
     </Typography>
   );
 }


### PR DESCRIPTION
## Summary
- Lift `LibraryEmptyState` into a generic `EmptyState` under `src/shared/components/`, alongside `ErrorFallback` and `LoadingIndicator`.
- Component takes a required `message: string` prop — matches the naming used by sibling shared components.
- Update `LibraryPage` to render `<EmptyState message="No board sets imported yet." />` and delete the old single-purpose file.

## Test plan
- [ ] `npm run lint` is clean.
- [ ] `npx tsc -b` is clean.
- [ ] Visit `/library` with no imported board sets — placeholder text renders centered with the same vertical padding as before.
- [ ] Visit `/library` with at least one board set — list renders normally, no empty state shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)