### PR TITLE
chore: bump version to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aac-board-ai",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.4.0",
   "type": "module",
   "engines": {
     "node": ">=24"


### PR DESCRIPTION
## Summary

- Sync `package.json` version to `1.4.0` to match the existing `v1.4.0` git tag already pushed to GitHub.