### PR TITLE
refactor: replace real-time delay with deterministic fake timers in BackspaceButton test

### DIFF
--- a/src/features/board/message/BackspaceButton.test.tsx
+++ b/src/features/board/message/BackspaceButton.test.tsx
@@ -1,6 +1,6 @@
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { render } from "vitest-browser-react";
-import { BackspaceButton, LONG_PRESS_THRESHOLD_MS } from "./BackspaceButton";
+import { BackspaceButton } from "./BackspaceButton";
 
 function createHandlers() {
   return {
@@ -9,7 +9,31 @@ function createHandlers() {
   };
 }
 
+// pressure must be non-zero: react-aria treats pressure===0 + pointerType==="mouse"
+// as a virtual (assistive-technology) event and skips the long-press timer entirely.
+function longPress(element: Element) {
+  element.dispatchEvent(
+    new PointerEvent("pointerdown", {
+      bubbles: true,
+      button: 0,
+      pointerType: "mouse",
+      pressure: 0.5,
+    }),
+  );
+  vi.advanceTimersByTime(700);
+  element.dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+}
+
 describe("BackspaceButton", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
   test("calls onPress when clicked", async () => {
     const handlers = createHandlers();
 
@@ -28,7 +52,7 @@ describe("BackspaceButton", () => {
     const screen = await render(<BackspaceButton {...handlers} />);
 
     const button = screen.getByRole("button", { name: "Backspace" });
-    await button.click({ delay: LONG_PRESS_THRESHOLD_MS + 100 });
+    longPress(button.element());
 
     expect(handlers.onLongPress).toHaveBeenCalledTimes(1);
     expect(handlers.onPress).not.toHaveBeenCalled();

--- a/src/features/board/message/BackspaceButton.tsx
+++ b/src/features/board/message/BackspaceButton.tsx
@@ -9,7 +9,7 @@ import { mergeProps, useLongPress, usePress } from "react-aria";
 
 const RING_DELAY_MS = 300;
 const RING_FILL_MS = 300;
-export const LONG_PRESS_THRESHOLD_MS = RING_DELAY_MS + RING_FILL_MS;
+const LONG_PRESS_THRESHOLD_MS = RING_DELAY_MS + RING_FILL_MS;
 
 const StyledCircularProgress = styled(CircularProgress, {
   shouldForwardProp: (prop) => prop !== "active",


### PR DESCRIPTION
## Summary

- Removes the `export` from `LONG_PRESS_THRESHOLD_MS` in `BackspaceButton.tsx` — it was only exported so the test could read it, leaking an internal implementation constant into the public API.
- Replaces `button.click({ delay: LONG_PRESS_THRESHOLD_MS + 100 })` with a `longPress()` helper that dispatches a `pointerdown`, advances fake timers by 700 ms via `vi.advanceTimersByTime`, then dispatches `pointerup` — reducing the test from ~600 ms wall-clock time to <10 ms.
- Sets `pressure: 0.5` on the synthetic `pointerdown` to bypass react-aria's `isVirtualPointerEvent` guard (`pressure === 0` + `pointerType === "mouse"` is treated as an assistive-technology event and causes the long-press timer to be skipped entirely).

## Fields justified

| Field | Reason |
|---|---|
| `bubbles: true` | Required for React's event delegation to pick up the event |
| `button: 0` | react-aria bails out immediately on any other value |
| `pointerType: "mouse"` | `useLongPress` only arms the timer for `"mouse"` or `"touch"` |
| `pressure: 0.5` | Bypasses the virtual-pointer guard |

`pointerup` carries only `{ bubbles: true }` — by the time it fires, react-aria's timer has already dispatched `pointercancel` and reset press state.