### PR TITLE
refactor: extract resolveButtonIntent as a pure exported function

### DIFF
--- a/src/features/board/useButtonActivation.test.tsx
+++ b/src/features/board/useButtonActivation.test.tsx
@@ -7,7 +7,10 @@ import type { MessagePart, UseMessageReturn } from "./message/useMessage";
 import type { UseMessagePlaybackReturn } from "./message/useMessagePlayback";
 import type { UseBoardNavigationReturn } from "./navigation/useBoardNavigation";
 import type { BoardAction, BoardButton } from "./types";
-import { useButtonActivation } from "./useButtonActivation";
+import {
+  resolveButtonIntent,
+  useButtonActivation,
+} from "./useButtonActivation";
 
 function SpeechWrapper({ children }: { children: ReactNode }) {
   return <SpeechProvider>{children}</SpeechProvider>;
@@ -241,5 +244,50 @@ describe("useButtonActivation", () => {
     expect(message.addPart).toHaveBeenCalledTimes(1);
     expect(speech.speak).not.toHaveBeenCalled();
     expect(audio.play).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveButtonIntent", () => {
+  test("navigate takes precedence over actions and utter when loadBoard.id is set", () => {
+    expect(
+      resolveButtonIntent({
+        id: "btn",
+        label: "Folder",
+        loadBoard: { id: "child-board" },
+        actions: [":space"],
+      }),
+    ).toEqual({ kind: "navigate", boardId: "child-board" });
+  });
+
+  test("treats loadBoard without an id as not navigable", () => {
+    const button: BoardButton = {
+      id: "btn",
+      label: "hi",
+      loadBoard: { name: "Other" },
+    };
+
+    expect(resolveButtonIntent(button)).toEqual({ kind: "utter", button });
+  });
+
+  test("returns actions when there is no loadBoard.id and actions is non-empty", () => {
+    expect(
+      resolveButtonIntent({ id: "btn", actions: [":space", ":speak"] }),
+    ).toEqual({ kind: "actions", actions: [":space", ":speak"] });
+  });
+
+  test("falls through to utter when actions is an empty array", () => {
+    const button: BoardButton = { id: "btn", label: "hi", actions: [] };
+
+    expect(resolveButtonIntent(button)).toEqual({ kind: "utter", button });
+  });
+
+  test("returns utter with the original button when there is no loadBoard.id and no actions", () => {
+    const button: BoardButton = {
+      id: "btn",
+      label: "hi",
+      vocalization: "hello",
+    };
+
+    expect(resolveButtonIntent(button)).toEqual({ kind: "utter", button });
   });
 });

--- a/src/features/board/useButtonActivation.ts
+++ b/src/features/board/useButtonActivation.ts
@@ -15,6 +15,23 @@ export interface UseButtonActivationReturn {
   activateButton: (button: BoardButton) => Promise<void>;
 }
 
+export type ButtonIntent =
+  | { kind: "navigate"; boardId: string }
+  | { kind: "actions"; actions: BoardAction[] }
+  | { kind: "utter"; button: BoardButton };
+
+export function resolveButtonIntent(button: BoardButton): ButtonIntent {
+  if (button.loadBoard?.id) {
+    return { kind: "navigate", boardId: button.loadBoard.id };
+  }
+
+  if (button.actions?.length) {
+    return { kind: "actions", actions: button.actions };
+  }
+
+  return { kind: "utter", button };
+}
+
 export function useButtonActivation({
   message,
   playback,
@@ -24,21 +41,28 @@ export function useButtonActivation({
   const audio = useAudio();
 
   async function activateButton(button: BoardButton) {
-    if (button.loadBoard?.id) {
-      navigation.goToBoard(button.loadBoard.id);
-      return;
-    }
+    const intent = resolveButtonIntent(button);
 
-    if (button.actions?.length) {
-      for (const action of button.actions) {
-        await executeAction(action);
+    switch (intent.kind) {
+      case "navigate":
+        navigation.goToBoard(intent.boardId);
+        return;
+      case "actions":
+        for (const action of intent.actions) {
+          await executeAction(action);
+        }
+        return;
+      case "utter":
+        message.addPart(toMessagePart(intent.button));
+        playButtonAudio(intent.button);
+        return;
+      default: {
+        const _exhaustive: never = intent;
+        throw new Error(
+          `Unhandled button intent: ${JSON.stringify(_exhaustive)}`,
+        );
       }
-
-      return;
     }
-
-    message.addPart(toMessagePart(button));
-    playButtonAudio(button);
   }
 
   async function executeAction(action: BoardAction) {


### PR DESCRIPTION
## Summary

- Extracts the button intent resolution logic from `activateButton` into a standalone, exported `resolveButtonIntent` pure function with a `ButtonIntent` discriminated union return type.
- Refactors `activateButton` to use a `switch` on the discriminated union, with an exhaustive `never` check for unhandled cases.
- Adds a dedicated `describe("resolveButtonIntent", ...)` test suite with 5 unit tests covering navigate, utter, actions, empty actions, and missing `loadBoard.id` cases.