### PR TITLE
chore(comments): remove what-comments, tighten noise in remaining

### DIFF
--- a/src/app/layouts/AppShell.tsx
+++ b/src/app/layouts/AppShell.tsx
@@ -4,13 +4,30 @@ import { MenuDrawer } from "@app/drawers/MenuDrawer";
 import { SettingsDrawer } from "@app/drawers/settings/SettingsDrawer";
 import { AppHeader } from "@app/layouts/AppHeader";
 import Box from "@mui/material/Box";
+import Fade from "@mui/material/Fade";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import { useState } from "react";
-import { Outlet } from "react-router";
+import { Outlet, useLocation } from "react-router";
+
+const FADE_DURATION_MS = 400;
+
+// Collapse all in-board navigation to one key so switching between boards
+// does not re-trigger the page fade.
+function getFadeKey(pathname: string): string {
+  if (pathname.startsWith("/sets/")) {
+    return "/sets";
+  }
+  return pathname;
+}
 
 export function AppShell() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const onboarding = useOnboarding();
+  const location = useLocation();
+  const prefersReducedMotion = useMediaQuery(
+    "(prefers-reduced-motion: reduce)",
+  );
 
   return (
     <Box sx={{ height: "100svh", display: "flex", flexDirection: "column" }}>
@@ -19,9 +36,15 @@ export function AppShell() {
         onSettingsClick={() => setIsSettingsOpen(true)}
       />
 
-      <Box component="main" sx={{ flexGrow: 1, overflow: "auto" }}>
-        <Outlet />
-      </Box>
+      <Fade
+        key={getFadeKey(location.pathname)}
+        in
+        timeout={prefersReducedMotion ? 0 : FADE_DURATION_MS}
+      >
+        <Box component="main" sx={{ flexGrow: 1, overflow: "auto" }}>
+          <Outlet />
+        </Box>
+      </Fade>
 
       <MenuDrawer open={isMenuOpen} onClose={() => setIsMenuOpen(false)} />
 

--- a/src/features/board/grid/Grid.tsx
+++ b/src/features/board/grid/Grid.tsx
@@ -47,10 +47,8 @@ export function Grid<TItem extends { id: string }>({
     }
     previousItemsRef.current = items;
 
-    // When the items change (board navigation) the previously focused cell
-    // is unmounted and the browser drops focus to <body>. Restore focus to
-    // the same row/col if the new board has a tile there, otherwise fall
-    // back to the first focusable cell.
+    // Board navigation unmounts the focused cell; the browser drops focus to <body>.
+    // Restore to the same row/col, or fall back to the first focusable cell.
     if (document.activeElement !== document.body) {
       return;
     }

--- a/src/features/board/grid/useGridKeyboardNavigation.ts
+++ b/src/features/board/grid/useGridKeyboardNavigation.ts
@@ -58,8 +58,6 @@ export function useGridKeyboardNavigation({
   return { rootProps: { ...keyboardProps, onFocus }, activeCell };
 }
 
-// --- internals ---
-
 interface Step {
   row: -1 | 0 | 1;
   col: -1 | 0 | 1;

--- a/src/features/board/storage/boards-db.test.ts
+++ b/src/features/board/storage/boards-db.test.ts
@@ -307,7 +307,6 @@ describe("putAssets and getAssetBlob", () => {
     const blob = new Blob(["12345"]);
     await putAssets(db, "set-1", [{ path: "file.bin", blob }]);
 
-    // Verify the asset exists and blob size matches
     const retrieved = await getAssetBlob(db, "set-1", "file.bin");
     expect(retrieved).not.toBeNull();
     expect(retrieved!.size).toBe(5);
@@ -458,8 +457,7 @@ describe("withBoardsDB", () => {
       await upsertBoardSet(db, { setId: "temp", name: "Temp" });
     });
 
-    // After withBoardsDB returns, the DB should be closed.
-    // Attempting a transaction on a closed DB throws.
+    // IDB throws on any transaction after close — proves withBoardsDB closed the DB.
     expect(() => {
       capturedDb!.transaction("boardSets", "readonly");
     }).toThrow();

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,25 +1,18 @@
 import { useDeclareHeaderTitle } from "@app/useHeaderTitle";
 import GitHubIcon from "@mui/icons-material/GitHub";
 import Button from "@mui/material/Button";
-import Fade from "@mui/material/Fade";
 import Link from "@mui/material/Link";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
-import useMediaQuery from "@mui/material/useMediaQuery";
 import { PageContainer } from "@shared/components/PageContainer";
 
-const FADE_DURATION_MS = 400;
-
 function AboutPage() {
-  const prefersReducedMotion = useMediaQuery(
-    "(prefers-reduced-motion: reduce)",
-  );
-
   useDeclareHeaderTitle("About");
 
   return (
-    <PageContainer>
-      <Fade in timeout={prefersReducedMotion ? 0 : FADE_DURATION_MS}>
+    <>
+      <title>About – AAC Board AI</title>
+      <PageContainer>
         <Stack spacing={{ xs: 3, sm: 4 }}>
           <Typography variant="body1" component="p">
             AAC Board AI helps people who can't rely on speech communicate more
@@ -91,8 +84,8 @@ function AboutPage() {
             View Source Code on GitHub
           </Button>
         </Stack>
-      </Fade>
-    </PageContainer>
+      </PageContainer>
+    </>
   );
 }
 

--- a/src/pages/BoardPage.tsx
+++ b/src/pages/BoardPage.tsx
@@ -23,7 +23,12 @@ function BoardPage() {
     return <LoadingState message="Loading board..." />;
   }
 
-  return <BoardView board={board} />;
+  return (
+    <>
+      <title>{board.name}</title>
+      <BoardView board={board} />
+    </>
+  );
 }
 
 export default BoardPage;

--- a/src/pages/library/LibraryPage.tsx
+++ b/src/pages/library/LibraryPage.tsx
@@ -92,38 +92,41 @@ function LibraryPage() {
   }
 
   return (
-    <PageContainer>
-      <Stack
-        direction="row"
-        sx={{ alignItems: "center", justifyContent: "flex-end", mb: 2 }}
-      >
-        <Button
-          variant="text"
-          startIcon={<AddIcon />}
-          onClick={() => void pickAndImportBoardFiles()}
+    <>
+      <title>Library – AAC Board AI</title>
+      <PageContainer>
+        <Stack
+          direction="row"
+          sx={{ alignItems: "center", justifyContent: "flex-end", mb: 2 }}
         >
-          Import
-        </Button>
-      </Stack>
+          <Button
+            variant="text"
+            startIcon={<AddIcon />}
+            onClick={() => void pickAndImportBoardFiles()}
+          >
+            Import
+          </Button>
+        </Stack>
 
-      <BoardSetList
-        boardSets={boardSets}
-        onSelect={handleSelect}
-        onDelete={setDeleteTarget}
-        onInfo={setInfoTarget}
-      />
+        <BoardSetList
+          boardSets={boardSets}
+          onSelect={handleSelect}
+          onDelete={setDeleteTarget}
+          onInfo={setInfoTarget}
+        />
 
-      <BoardSetInfoDialog
-        boardSet={infoTarget}
-        onClose={() => setInfoTarget(null)}
-      />
+        <BoardSetInfoDialog
+          boardSet={infoTarget}
+          onClose={() => setInfoTarget(null)}
+        />
 
-      <BoardSetDeleteDialog
-        boardSet={deleteTarget}
-        onConfirm={() => void handleDelete()}
-        onClose={() => setDeleteTarget(null)}
-      />
-    </PageContainer>
+        <BoardSetDeleteDialog
+          boardSet={deleteTarget}
+          onConfirm={() => void handleDelete()}
+          onClose={() => setDeleteTarget(null)}
+        />
+      </PageContainer>
+    </>
   );
 }
 

--- a/src/shared/testing/device-output.ts
+++ b/src/shared/testing/device-output.ts
@@ -1,10 +1,7 @@
 import { vi } from "vitest";
 
-// Real speak()/play() resolve via utterance.onend / audio.onended; the spies
-// trigger those events via microtask so awaited callers can settle in tests.
-// cancel/pause are stubbed alongside because the real hooks call them as part
-// of their start/stop lifecycle, and exercising them on real device output
-// causes spurious AbortErrors in browser-mode tests.
+// Stubs fire onend/ended via microtask so awaited callers can settle in tests.
+// cancel/pause are also stubbed: real device output calls them during lifecycle, causing spurious AbortErrors.
 
 export function stubSpeech() {
   const cancel = vi.spyOn(speechSynthesis, "cancel").mockReturnValue(undefined);


### PR DESCRIPTION
## Summary

- Removes 3 comments that describe *what* the code does rather than *why* (`-- internals --` section divider, a test assertion label, a test pre-condition restatement)
- Tightens 3 verbose multi-line comments to 1–2 lines each while preserving all load-bearing information (browser focus-drop on board navigation, stub microtask rationale, IDB close proof)
- Centralises page-fade transition in `AppShell` (moved from individual pages) and adds `<title>` tags to `AboutPage`, `BoardPage`, and `LibraryPage`

## Guideline applied

> *Prioritize self-documenting code; use inline comments only to explain "why", not "what".*