### PR TITLE
chore: bump open-board-format to 1.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mui/stylis-plugin-rtl": "^9.0.1",
         "idb": "^8.0.3",
         "mrmime": "^2.0.1",
-        "open-board-format": "^1.0.4",
+        "open-board-format": "^1.0.5",
         "react": "^19.2.6",
         "react-aria": "^3.48.0",
         "react-dom": "^19.2.6",
@@ -7286,13 +7286,13 @@
       }
     },
     "node_modules/open-board-format": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/open-board-format/-/open-board-format-1.0.4.tgz",
-      "integrity": "sha512-RPFZrTdhVAtzpp9Snj7eVLhtTcUIwWdm9UzO4IRBI1tDtSfk8vFhV0zoo7Zzw0+MR03FsRhfAoVu2BvcsJkCpg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/open-board-format/-/open-board-format-1.0.5.tgz",
+      "integrity": "sha512-r0/EOCV2RHL4I5YUSASMED37lK6EJKwynGWW3I1zPuqhhLOtNlr4+cXo5PZno9Ig2HHhWYCJrNYOT/egyDikew==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.2",
-        "zod": "^4.3.6"
+        "zod": "^4.4.3"
       }
     },
     "node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@mui/stylis-plugin-rtl": "^9.0.1",
     "idb": "^8.0.3",
     "mrmime": "^2.0.1",
-    "open-board-format": "^1.0.4",
+    "open-board-format": "^1.0.5",
     "react": "^19.2.6",
     "react-aria": "^3.48.0",
     "react-dom": "^19.2.6",


### PR DESCRIPTION
## Summary
- Bumps `open-board-format` from `1.0.4` → `1.0.5`
- Transitively updates `zod` from `^4.3.6` → `^4.4.3`

## Test plan
- [ ] Verify board save/load still works correctly
- [ ] Check no regressions in OBF file handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)