### PR TITLE
refactor: rename BoardView to BoardViewer

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,7 +19,7 @@ The codebase is **feature-sliced**. The single feature today is `board`. Layers 
 
 Aliases are declared in [tsconfig.app.json](../tsconfig.app.json) and mirrored in [vite.config.ts](../vite.config.ts).
 
-**Public-barrel rule.** UI layers consume the board feature through [`@features/board`](../src/features/board/index.ts). Reaching into `storage/`, `obf/`, or other internals from outside the feature is disallowed by convention. The barrel exposes `BoardView`, `useBoard`, `useBoardSets`, `useImportBoardFiles`, and the imperative store functions (`getBoardSets`, `importBoardFromUrl`, `removeBoardSet`).
+**Public-barrel rule.** UI layers consume the board feature through [`@features/board`](../src/features/board/index.ts). Reaching into `storage/`, `obf/`, or other internals from outside the feature is disallowed by convention. The barrel exposes `BoardViewer`, `useBoard`, `useBoardSets`, `useImportBoardFiles`, and the imperative store functions (`getBoardSets`, `importBoardFromUrl`, `removeBoardSet`).
 
 **See:** [tsconfig.app.json](../tsconfig.app.json), [src/features/board/index.ts](../src/features/board/index.ts).
 
@@ -93,14 +93,14 @@ flowchart TD
     G --> K[useBoardTranslation]
     K -. optional .-> L[Translator API]
     K -. cache .-> C
-    J --> M[BoardView]
+    J --> M[BoardViewer]
     K --> M
   end
 
   E --> F
 ```
 
-IndexedDB is the convergence point: it's written by import, read by board loading, and re-read after translation caches its results. The board-sets external store is invalidated whenever import or delete completes, and a `BroadcastChannel` propagates the invalidation to every open tab. From `BoardView`, tile activations flow through `useButtonActivation` into `useMessage` (localStorage) and `useBoardNavigation`; per-button preview plays directly through `useSpeech` / `useAudio`, while the message-bar play button uses `useMessagePlayback` — see Speech & audio for playback and Storage for persistence.
+IndexedDB is the convergence point: it's written by import, read by board loading, and re-read after translation caches its results. The board-sets external store is invalidated whenever import or delete completes, and a `BroadcastChannel` propagates the invalidation to every open tab. From `BoardViewer`, tile activations flow through `useButtonActivation` into `useMessage` (localStorage) and `useBoardNavigation`; per-button preview plays directly through `useSpeech` / `useAudio`, while the message-bar play button uses `useMessagePlayback` — see Speech & audio for playback and Storage for persistence.
 
 **See:** [src/features/board/storage/board-import.ts](../src/features/board/storage/board-import.ts), [src/features/board/storage/board-sets-store.ts](../src/features/board/storage/board-sets-store.ts), [src/features/board/useLoadBoard.ts](../src/features/board/useLoadBoard.ts), [src/features/board/useBoardTranslation.ts](../src/features/board/useBoardTranslation.ts), [src/features/board/useButtonActivation.ts](../src/features/board/useButtonActivation.ts).
 

--- a/src/features/board/BoardViewer.tsx
+++ b/src/features/board/BoardViewer.tsx
@@ -13,11 +13,11 @@ import { Tile } from "./tile/Tile";
 import type { Board, BoardButton } from "./types";
 import { useButtonActivation } from "./useButtonActivation";
 
-export interface BoardViewProps {
+export interface BoardViewerProps {
   board: Board;
 }
 
-export function BoardView({ board }: BoardViewProps) {
+export function BoardViewer({ board }: BoardViewerProps) {
   const { direction } = useLanguage();
   const message = useMessage();
   const playback = useMessagePlayback(message.parts);

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -1,4 +1,4 @@
-export { BoardView } from "./BoardView";
+export { BoardViewer } from "./BoardViewer";
 export type { BoardRouteParams } from "./navigation/types";
 export {
   getBoardSets,

--- a/src/pages/BoardPage.tsx
+++ b/src/pages/BoardPage.tsx
@@ -1,5 +1,5 @@
 import { useDeclareHeaderTitle } from "@app/useHeaderTitle";
-import { BoardView, useBoard, type BoardRouteParams } from "@features/board";
+import { BoardViewer, useBoard, type BoardRouteParams } from "@features/board";
 import { ErrorState } from "@shared/components/ErrorState";
 import { LoadingState } from "@shared/components/LoadingState";
 import { useParams } from "react-router";
@@ -26,7 +26,7 @@ function BoardPage() {
   return (
     <>
       <title>{board.name}</title>
-      <BoardView board={board} />
+      <BoardViewer board={board} />
     </>
   );
 }


### PR DESCRIPTION
## Summary
Renames `BoardView` component to `BoardViewer` for improved clarity and consistency.

## Changes
- Renamed component function from `BoardView` to `BoardViewer`
- Renamed interface from `BoardViewProps` to `BoardViewerProps`
- Renamed file `BoardView.tsx` to `BoardViewer.tsx`
- Updated export in `index.ts` to export `BoardViewer`
- Updated import and usage in `BoardPage.tsx`
- Updated documentation references in `architecture.md`

## Files Changed
- `src/features/board/BoardViewer.tsx` (renamed from `BoardView.tsx`)
- `src/features/board/index.ts`
- `src/pages/BoardPage.tsx`
- `docs/architecture.md`