### PR TITLE
refactor: simplify built-in AI lifecycle and types

### DIFF
--- a/src/shared/built-in-ai/internal/lifecycle/create-instance.ts
+++ b/src/shared/built-in-ai/internal/lifecycle/create-instance.ts
@@ -3,20 +3,18 @@ import {
   UnavailableError,
   UnsupportedError,
 } from "../../errors.ts";
+import type { BuiltInAIName } from "../../is-supported.ts";
 import {
   buildProgressKey,
   clearDownloadProgress,
   setDownloadProgress,
 } from "../progress-store.ts";
-import type { AINamespace, DestroyableInstance } from "./types.ts";
-
-function hasUserActivation(): boolean {
-  return navigator.userActivation?.isActive ?? false;
-}
+import { hasUserActivation } from "../user-activation.ts";
+import { getNamespace } from "./types.ts";
 
 export interface CreateInstanceOptions<O extends object> {
   /** Built-in AI global namespace name (`"Translator"`, `"Rewriter"`, …). */
-  name: string;
+  name: BuiltInAIName;
   /** Browser `create()` options, forwarded verbatim. */
   options: O | undefined;
   /** Cancels both the (optional) download and `namespace.create()`. */
@@ -39,13 +37,11 @@ export interface CreateInstanceOptions<O extends object> {
  */
 export async function createInstance<
   O extends object,
-  I extends DestroyableInstance,
+  I extends DestroyableModel,
 >(params: CreateInstanceOptions<O>): Promise<I & AsyncDisposable> {
   const { name, options, signal, onProgress } = params;
 
-  const namespace = (globalThis as Record<string, unknown>)[name] as
-    | AINamespace<O, I>
-    | undefined;
+  const namespace = getNamespace<O, I>(name);
   if (!namespace) {
     throw new UnsupportedError();
   }
@@ -80,7 +76,7 @@ export async function createInstance<
     });
     const disposable = instance as I & Partial<AsyncDisposable>;
     disposable[Symbol.asyncDispose] ??= () =>
-      Promise.resolve(disposable.destroy?.());
+      Promise.resolve(disposable.destroy());
     return disposable as I & AsyncDisposable;
   } finally {
     if (key) {

--- a/src/shared/built-in-ai/internal/lifecycle/store.ts
+++ b/src/shared/built-in-ai/internal/lifecycle/store.ts
@@ -5,14 +5,12 @@ import {
   UnavailableError,
   UnsupportedError,
 } from "../../errors.ts";
+import type { BuiltInAIName } from "../../is-supported.ts";
 import type { Status } from "../../types.ts";
 import { abortError, mergeSignals, raceAbort } from "../signal.ts";
+import { hasUserActivation } from "../user-activation.ts";
 import { createInstance } from "./create-instance.ts";
-import type { AINamespace, DestroyableInstance } from "./types.ts";
-
-function hasUserActivation(): boolean {
-  return navigator.userActivation?.isActive ?? false;
-}
+import type { AINamespace } from "./types.ts";
 
 export interface Snapshot {
   status: Status;
@@ -43,19 +41,12 @@ function wrap(error: unknown): BuiltInAIError {
   );
 }
 
-function readQuota(instance: unknown): number {
-  const value = (instance as { inputQuota?: unknown }).inputQuota;
-  return typeof value === "number" ? value : 0;
-}
-
-function destroyQuietly(
-  instance: DestroyableInstance | null | undefined,
-): void {
+function destroyQuietly(instance: DestroyableModel | null | undefined): void {
   if (!instance) {
     return;
   }
   try {
-    instance.destroy?.();
+    instance.destroy();
   } catch {
     // Best-effort during teardown — a throw here has nowhere to go.
   }
@@ -63,8 +54,11 @@ function destroyQuietly(
 
 export function createStore<
   Options extends object,
-  Instance extends DestroyableInstance,
->(globalName: string) {
+  Instance extends DestroyableModel,
+>(
+  globalName: BuiltInAIName,
+  readQuota: (instance: Instance) => number = () => 0,
+) {
   let snapshot: Snapshot = INITIAL;
   const listeners = new Set<() => void>();
 

--- a/src/shared/built-in-ai/internal/lifecycle/types.ts
+++ b/src/shared/built-in-ai/internal/lifecycle/types.ts
@@ -1,10 +1,7 @@
-/** @internal */
-export interface DestroyableInstance {
-  destroy?(): void;
-}
+import type { BuiltInAIName } from "../../is-supported.ts";
 
 /** @internal */
-export interface AINamespace<Options, Instance> {
+export interface AINamespace<Options, Instance extends DestroyableModel> {
   availability(options?: Options): Promise<Availability>;
   create(
     options?: Options & {
@@ -12,4 +9,13 @@ export interface AINamespace<Options, Instance> {
       monitor?: CreateMonitorCallback;
     },
   ): Promise<Instance>;
+}
+
+/** @internal */
+export function getNamespace<Options, Instance extends DestroyableModel>(
+  name: BuiltInAIName,
+): AINamespace<Options, Instance> | undefined {
+  return (globalThis as Record<string, unknown>)[name] as
+    | AINamespace<Options, Instance>
+    | undefined;
 }

--- a/src/shared/built-in-ai/internal/lifecycle/use-lifecycle.test.tsx
+++ b/src/shared/built-in-ai/internal/lifecycle/use-lifecycle.test.tsx
@@ -16,6 +16,7 @@ import {
   UnavailableError,
   UnsupportedError,
 } from "../../errors.ts";
+import type { BuiltInAIName } from "../../is-supported.ts";
 import { snapshotProgressFor } from "../progress-store.ts";
 import { makeAIFake } from "../testing/ai-namespace-fake.ts";
 import { useLifecycle } from "./use-lifecycle.ts";
@@ -30,7 +31,9 @@ interface TestInstance {
   marker?: string;
 }
 
-const NAMESPACE = "__TestAI";
+// Cast: useLifecycle restricts `globalName` to the BuiltInAIName union, but this
+// suite exercises the generic lifecycle with a stubbed-in fake.
+const NAMESPACE = "__TestAI" as BuiltInAIName;
 
 function buildInstance(overrides: Partial<TestInstance> = {}): TestInstance {
   return { destroy: vi.fn<() => void>(), inputQuota: 1024, ...overrides };
@@ -72,7 +75,11 @@ describe("useLifecycle", () => {
     vi.stubGlobal(NAMESPACE, Fake);
 
     const { result } = await renderHook(() =>
-      useLifecycle<TestOptions, TestInstance>(NAMESPACE, { mode: "a" }),
+      useLifecycle<TestOptions, TestInstance>(
+        NAMESPACE,
+        { mode: "a" },
+        (instance) => instance.inputQuota ?? 0,
+      ),
     );
 
     await vi.waitFor(() => expect(result.current.status).toBe("ready"));

--- a/src/shared/built-in-ai/internal/lifecycle/use-lifecycle.ts
+++ b/src/shared/built-in-ai/internal/lifecycle/use-lifecycle.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState, useSyncExternalStore } from "react";
+import type { BuiltInAIName } from "../../is-supported.ts";
 import { createStore } from "./store.ts";
-import type { AINamespace, DestroyableInstance } from "./types.ts";
+import { getNamespace } from "./types.ts";
 
 function shallowEqualOptions<T extends object>(
   a: T | undefined,
@@ -40,14 +41,18 @@ function useStableOptions<T extends object>(
 /** Shared lifecycle for every built-in AI namespace. Function refs are stable across renders. */
 export function useLifecycle<
   Options extends object,
-  Instance extends DestroyableInstance,
->(globalName: string, options: Options | undefined) {
+  Instance extends DestroyableModel,
+>(
+  globalName: BuiltInAIName,
+  options: Options | undefined,
+  readQuota?: (instance: Instance) => number,
+) {
   const stableOptions = useStableOptions(options);
-  const namespace = (globalThis as Record<string, unknown>)[globalName] as
-    | AINamespace<Options, Instance>
-    | undefined;
+  const namespace = getNamespace<Options, Instance>(globalName);
 
-  const [store] = useState(() => createStore<Options, Instance>(globalName));
+  const [store] = useState(() =>
+    createStore<Options, Instance>(globalName, readQuota),
+  );
 
   useEffect(() => {
     store.start(namespace, stableOptions);

--- a/src/shared/built-in-ai/internal/user-activation.ts
+++ b/src/shared/built-in-ai/internal/user-activation.ts
@@ -1,0 +1,3 @@
+export function hasUserActivation(): boolean {
+  return navigator.userActivation?.isActive ?? false;
+}

--- a/src/shared/built-in-ai/proofreader/use-proofreader.ts
+++ b/src/shared/built-in-ai/proofreader/use-proofreader.ts
@@ -8,25 +8,10 @@ import type { BaseHookReturn } from "../types.ts";
  *
  * @see https://developer.chrome.com/docs/ai/proofreader-api
  */
-export interface ProofreaderOptions {
-  /** Tag each correction with its kind (spelling, grammar, …). */
-  includeCorrectionTypes?: boolean;
-  /** Include a human-readable rationale on each correction. */
-  includeCorrectionExplanations?: boolean;
-  /** BCP-47 tag of the language used for explanations. */
-  correctionExplanationLanguage?: string;
-  /**
-   * BCP-47 tags of input languages this instance will receive. Affects
-   * `availability()` — unsupported languages can make the model unavailable.
-   */
-  expectedInputLanguages?: readonly string[];
-}
+export type ProofreaderOptions = ProofreaderCreateCoreOptions;
 
 /** Per-call options for {@link useProofreader} action methods. */
-export interface ProofreadCallOptions {
-  /** Cancels this call only; does not destroy the shared instance. */
-  signal?: AbortSignal;
-}
+export type ProofreadCallOptions = ProofreaderProofreadOptions;
 
 /**
  * Return value of {@link useProofreader}. Extends {@link BaseHookReturn} with

--- a/src/shared/built-in-ai/rewriter/use-rewriter.ts
+++ b/src/shared/built-in-ai/rewriter/use-rewriter.ts
@@ -4,41 +4,16 @@ import { streamChunks } from "../internal/stream.ts";
 import type { BaseHookReturn } from "../types.ts";
 
 /**
- * Options for {@link useRewriter}. Mirrors `Rewriter.create()`. Compared
- * shallowly — memoize array values to avoid spurious re-creation.
+ * Options for {@link useRewriter}. Mirrors `Rewriter.create()` minus the
+ * hook-managed `signal` and `monitor`. Compared shallowly — memoize array
+ * values to avoid spurious re-creation.
  *
  * @see https://developer.chrome.com/docs/ai/rewriter-api
  */
-export interface RewriterOptions {
-  /** Voice adjustment relative to the input. `"as-is"` preserves the original tone. */
-  tone?: "as-is" | "more-formal" | "more-casual";
-  /** Output format. `"as-is"` preserves the input's format. */
-  format?: "as-is" | "plain-text" | "markdown";
-  /** Length adjustment relative to the input. */
-  length?: "as-is" | "shorter" | "longer";
-  /** Context shared across every call on this instance. */
-  sharedContext?: string;
-  /**
-   * BCP-47 tags of input languages this instance will receive. Affects
-   * `availability()` — unsupported languages can make the model unavailable.
-   */
-  expectedInputLanguages?: readonly string[];
-  /**
-   * BCP-47 tags of context languages this instance will receive. Affects
-   * `availability()` — unsupported languages can make the model unavailable.
-   */
-  expectedContextLanguages?: readonly string[];
-  /** BCP-47 tag of the desired output language. */
-  outputLanguage?: string;
-}
+export type RewriterOptions = Omit<RewriterCreateOptions, "signal" | "monitor">;
 
 /** Per-call options for {@link useRewriter} action methods. */
-export interface RewriteCallOptions {
-  /** Context specific to this call, in addition to `sharedContext`. */
-  context?: string;
-  /** Cancels this call only; does not destroy the shared instance. */
-  signal?: AbortSignal;
-}
+export type RewriteCallOptions = RewriterRewriteOptions;
 
 /**
  * Return value of {@link useRewriter}. Extends {@link BaseHookReturn} with the
@@ -95,7 +70,11 @@ export interface RewriterHookReturn extends BaseHookReturn {
  */
 export function useRewriter(options?: RewriterOptions): RewriterHookReturn {
   const { status, progress, error, prepare, inputQuota, acquire } =
-    useLifecycle<RewriterOptions, Rewriter>("Rewriter", options);
+    useLifecycle<RewriterOptions, Rewriter>(
+      "Rewriter",
+      options,
+      (instance) => instance.inputQuota,
+    );
 
   const [actions] = useState(() => ({
     async rewrite(input: string, opts?: RewriteCallOptions) {

--- a/src/shared/built-in-ai/translator/create-translator.ts
+++ b/src/shared/built-in-ai/translator/create-translator.ts
@@ -1,14 +1,11 @@
 import { createInstance } from "../internal/lifecycle/create-instance.ts";
+import type { TranslatorOptions } from "./use-translator.ts";
 
 /**
- * Options for {@link createTranslator}. Same shape as {@link TranslatorOptions}
- * plus an optional cancellation signal.
+ * Options for {@link createTranslator}. Mirrors {@link TranslatorOptions} plus
+ * an optional cancellation signal.
  */
-export interface CreateTranslatorOptions {
-  /** BCP-47 language tag of the source text (e.g. `"en"`, `"fr"`). */
-  sourceLanguage: string;
-  /** BCP-47 language tag of the target text (e.g. `"es"`, `"ja"`). */
-  targetLanguage: string;
+export interface CreateTranslatorOptions extends TranslatorOptions {
   /** Cancels both the (optional) download and `Translator.create()` call. */
   signal?: AbortSignal;
 }

--- a/src/shared/built-in-ai/translator/use-translator.ts
+++ b/src/shared/built-in-ai/translator/use-translator.ts
@@ -9,18 +9,10 @@ import type { BaseHookReturn } from "../types.ts";
  *
  * @see https://developer.chrome.com/docs/ai/translator-api
  */
-export interface TranslatorOptions {
-  /** BCP-47 tag of the source text (e.g. `"en"`, `"fr"`). */
-  sourceLanguage: string;
-  /** BCP-47 tag of the target text (e.g. `"es"`, `"ja"`). */
-  targetLanguage: string;
-}
+export type TranslatorOptions = TranslatorCreateCoreOptions;
 
 /** Per-call options for {@link useTranslator} action methods. */
-export interface TranslateCallOptions {
-  /** Cancels this call only; does not destroy the shared instance. */
-  signal?: AbortSignal;
-}
+export type TranslateCallOptions = TranslatorTranslateOptions;
 
 /**
  * Return value of {@link useTranslator}. Extends {@link BaseHookReturn} with the
@@ -79,7 +71,11 @@ export function useTranslator(
   options: TranslatorOptions,
 ): TranslatorHookReturn {
   const { status, progress, error, prepare, inputQuota, acquire } =
-    useLifecycle<TranslatorOptions, Translator>("Translator", options);
+    useLifecycle<TranslatorOptions, Translator>(
+      "Translator",
+      options,
+      (instance) => instance.inputQuota,
+    );
 
   const [actions] = useState(() => ({
     async translate(input: string, opts?: TranslateCallOptions) {


### PR DESCRIPTION
## Summary

Two-part cleanup of `src/shared/built-in-ai`:

**1. Strip boilerplate from hook option types.** The `XxxOptions` / `XxxCallOptions` interfaces in [use-proofreader.ts](src/shared/built-in-ai/proofreader/use-proofreader.ts), [use-rewriter.ts](src/shared/built-in-ai/rewriter/use-rewriter.ts), and [use-translator.ts](src/shared/built-in-ai/translator/use-translator.ts) re-declared every field of their upstream Chrome type just to attach JSDoc — which mostly rephrased the field name. Chrome's `@types/dom-chromium-ai` has no docstrings, so the redeclarations only delivered hover-docs of marginal value. Replaced with one-line type aliases; kept the interface-level JSDoc (Chrome docs URL + shallow-comparison note).

**2. Dedupe and tighten internal lifecycle plumbing.**
- `hasUserActivation` was defined verbatim in [create-instance.ts](src/shared/built-in-ai/internal/lifecycle/create-instance.ts) and [store.ts](src/shared/built-in-ai/internal/lifecycle/store.ts). Extracted to [internal/user-activation.ts](src/shared/built-in-ai/internal/user-activation.ts).
- Local `DestroyableInstance` (with optional `destroy?`) replaced by Chrome's ambient `DestroyableModel` (required `destroy`). Dropped 2 defensive `?.` calls — every Chrome AI primitive `implements DestroyableModel`, so `destroy` is never actually missing.
- `globalName` / `name` parameters typed as `BuiltInAIName` instead of `string`. Typos at call sites are now compile errors.
- The three `globalThis[name]` lookups consolidated into a single typed `getNamespace<O, I>()` helper in [types.ts](src/shared/built-in-ai/internal/lifecycle/types.ts).
- `readQuota` switched from a hidden `instance as { inputQuota?: unknown }` cast inside [store.ts](src/shared/built-in-ai/internal/lifecycle/store.ts) to a caller-provided callback. Translator/Rewriter pass `(i) => i.inputQuota`; Proofreader omits it (defaults to `0`), making the API asymmetry visible at the hook level instead of buried in lifecycle internals.

Net: **75 insertions, 107 deletions** across 10 files. No behavior changes.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint -- src/shared/built-in-ai` clean
- [x] `npx vitest run src/shared/built-in-ai` — 81/81 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)