### PR TITLE
fix: cast fake namespace in create-instance test to BuiltInAIName

### DIFF
--- a/src/shared/built-in-ai/internal/lifecycle/create-instance.test.ts
+++ b/src/shared/built-in-ai/internal/lifecycle/create-instance.test.ts
@@ -4,6 +4,7 @@ import {
   UnavailableError,
   UnsupportedError,
 } from "../../errors.ts";
+import type { BuiltInAIName } from "../../is-supported.ts";
 import {
   clearDownloadProgress,
   setDownloadProgress,
@@ -20,7 +21,7 @@ interface TestInstance {
   marker?: string;
 }
 
-const NAMESPACE = "__TestAI";
+const NAMESPACE = "__TestAI" as BuiltInAIName;
 
 function setUserActivation(isActive: boolean): void {
   Object.defineProperty(navigator, "userActivation", {


### PR DESCRIPTION
## Summary
- The lifecycle refactor in #276 tightened `CreateInstanceOptions.name` from `string` to the `BuiltInAIName` union, breaking the `create-instance.test.ts` fake `"__TestAI"` namespace with `ts(2322)`.
- Adds a `BuiltInAIName` import and casts `NAMESPACE` the same way the sibling [use-lifecycle.test.tsx:36](src/shared/built-in-ai/internal/lifecycle/use-lifecycle.test.tsx#L36) already does.

## Test plan
- [ ] `npx tsc --noEmit` is clean
- [ ] `npm run -s lint -- src/shared/built-in-ai/internal/lifecycle/create-instance.test.ts` is clean
- [ ] `npx vitest run src/shared/built-in-ai/internal/lifecycle/create-instance.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)