### PR TITLE
fix: relax overly strict types for label and unsupported languages

### DIFF
--- a/src/features/board/message/use-message.test.tsx
+++ b/src/features/board/message/use-message.test.tsx
@@ -86,9 +86,9 @@ describe("useMessage", () => {
     await rerender();
 
     expect(result.current.parts.length).toBeGreaterThan(1);
-    expect(result.current.parts.every((part) => part.label.length > 0)).toBe(
-      true,
-    );
+    expect(
+      result.current.parts.every((part) => (part.label?.length ?? 0) > 0),
+    ).toBe(true);
   });
 
   test("clears all existing parts when called with an empty string", async () => {

--- a/src/shared/language/language-provider.tsx
+++ b/src/shared/language/language-provider.tsx
@@ -8,7 +8,7 @@ export interface LanguageProviderProps {
   children: ReactNode;
 }
 
-const UNSUPPORTED_LANGUAGES = ["ca", "ms", "nb", "yue"] as const;
+const UNSUPPORTED_LANGUAGES: readonly string[] = ["ca", "ms", "nb", "yue"];
 
 export function LanguageProvider({ children }: LanguageProviderProps) {
   const { locales, voicesByLanguage, setVoiceURI } = useSpeech();


### PR DESCRIPTION
## Summary
- Widen `UNSUPPORTED_LANGUAGES` from a literal tuple (`as const`) to `readonly string[]` so it composes cleanly with general string comparisons in [language-provider.tsx](src/shared/language/language-provider.tsx)
- Use optional chaining on `part.label` in [use-message.test.tsx](src/features/board/message/use-message.test.tsx) to match the now-optional `label` field

## Test plan
- [ ] `npm run lint`
- [ ] `npm test -- use-message`
- [ ] Verify language provider still filters out `ca`, `ms`, `nb`, `yue`

🤖 Generated with [Claude Code](https://claude.com/claude-code)