### PR TITLE
Fold pages/library/components/ into @features/board

### DIFF
--- a/src/app/app-routes.tsx
+++ b/src/app/app-routes.tsx
@@ -6,7 +6,7 @@ import { lazy } from "react";
 import { BrowserRouter, Route, Routes } from "react-router";
 
 const BoardPage = lazy(() => import("@pages/board-page"));
-const LibraryPage = lazy(() => import("@pages/library/library-page"));
+const LibraryPage = lazy(() => import("@pages/library-page"));
 const AboutPage = lazy(() => import("@pages/about-page"));
 
 export function AppRoutes() {

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -1,4 +1,7 @@
 export { BoardViewer } from "./board-viewer";
+export { BoardSetDeleteDialog } from "./library/board-set-delete-dialog";
+export { BoardSetInfoDialog } from "./library/board-set-info-dialog";
+export { BoardSetList } from "./library/board-set-list";
 export type { BoardRouteParams } from "./navigation/use-board-navigation";
 export {
   getBoardSets,

--- a/src/features/board/library/board-set-delete-dialog.tsx
+++ b/src/features/board/library/board-set-delete-dialog.tsx
@@ -1,10 +1,11 @@
-import type { BoardSetRecord } from "@features/board";
 import Button from "@mui/material/Button";
 import Dialog from "@mui/material/Dialog";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
+import type { BoardSetRecord } from "../storage/boards-db";
+
 export interface BoardSetDeleteDialogProps {
   boardSet: BoardSetRecord | null;
   onConfirm: () => void;

--- a/src/features/board/library/board-set-info-dialog.tsx
+++ b/src/features/board/library/board-set-info-dialog.tsx
@@ -1,4 +1,3 @@
-import type { BoardSetRecord } from "@features/board";
 import Button from "@mui/material/Button";
 import Chip from "@mui/material/Chip";
 import Dialog from "@mui/material/Dialog";
@@ -8,6 +7,7 @@ import DialogTitle from "@mui/material/DialogTitle";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { getLocaleDisplayName } from "@shared/language/locale";
+import type { BoardSetRecord } from "../storage/boards-db";
 
 export interface BoardSetInfoDialogProps {
   boardSet: BoardSetRecord | null;

--- a/src/features/board/library/board-set-list.tsx
+++ b/src/features/board/library/board-set-list.tsx
@@ -1,4 +1,3 @@
-import type { BoardSetRecord } from "@features/board";
 import DeleteOutlinedIcon from "@mui/icons-material/DeleteOutlined";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
@@ -12,6 +11,7 @@ import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import Tooltip from "@mui/material/Tooltip";
 import { useState } from "react";
+import type { BoardSetRecord } from "../storage/boards-db";
 
 export interface BoardSetListProps {
   boardSets: BoardSetRecord[];

--- a/src/pages/library-page.tsx
+++ b/src/pages/library-page.tsx
@@ -1,5 +1,8 @@
 import { useDeclareHeaderTitle } from "@app/use-header-title";
 import {
+  BoardSetDeleteDialog,
+  BoardSetInfoDialog,
+  BoardSetList,
   removeBoardSet,
   useBoardSets,
   useImportBoardFiles,
@@ -15,9 +18,6 @@ import { PageContainer } from "@shared/components/page-container";
 import { useSnackbar } from "@shared/snackbar/use-snackbar";
 import { useState } from "react";
 import { generatePath, useNavigate } from "react-router";
-import { BoardSetDeleteDialog } from "./components/board-set-delete-dialog";
-import { BoardSetInfoDialog } from "./components/board-set-info-dialog";
-import { BoardSetList } from "./components/board-set-list";
 
 function LibraryPage() {
   const { boardSets, isLoading } = useBoardSets();


### PR DESCRIPTION
Closes #284

## Summary
- Moved `board-set-list`, `board-set-info-dialog`, `board-set-delete-dialog` from `pages/library/components/` into `features/board/library/` and exported them from `@features/board`.
- Flattened `pages/library/library-page.tsx` to `pages/library-page.tsx`; updated the lazy import in `app-routes.tsx`.
- `LibraryPage` now imports the three components from `@features/board` and only owns page-level concerns (title, container, snackbar, navigation, dialog view-state).

## Test plan
- [ ] `npm run lint` passes
- [ ] `npx tsc --noEmit` passes
- [ ] `/library` route renders the board-set list, info dialog, and delete dialog
- [ ] Import, select, info, and delete flows still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)