### PR TITLE
polish: align empty/error state spacing and typography

### DIFF
--- a/src/pages/library-page.tsx
+++ b/src/pages/library-page.tsx
@@ -84,7 +84,7 @@ function LibraryPage() {
               startIcon={<AddIcon />}
               onClick={() => void pickAndImportBoardFiles()}
             >
-              Import board set
+              Import boards
             </Button>
           }
         />

--- a/src/shared/components/empty-state.tsx
+++ b/src/shared/components/empty-state.tsx
@@ -18,34 +18,42 @@ export function EmptyState({
 }: EmptyStateProps) {
   return (
     <Stack
-      spacing={1}
       sx={{
         py: 8,
         height: "100%",
         alignItems: "center",
         justifyContent: "center",
         textAlign: "center",
+        gap: 2,
       }}
     >
       {icon && (
-        <Box sx={{ color: "text.disabled", "& svg": { fontSize: 64, mb: 1 } }}>
+        <Box
+          sx={{
+            width: 64,
+            height: 64,
+            color: "text.disabled",
+            "& svg": { fontSize: 64 },
+          }}
+        >
           {icon}
         </Box>
       )}
 
-      <Typography variant="h6">{title}</Typography>
+      <Box sx={{ my: 1 }}>
+        <Typography variant="h5">{title}</Typography>
 
-      {description && (
-        <Typography
-          variant="body2"
-          color="text.secondary"
-          sx={{ maxWidth: "sm" }}
-        >
-          {description}
-        </Typography>
-      )}
+        {description && (
+          <Typography
+            variant="body1"
+            sx={{ maxWidth: "sm", color: "text.secondary" }}
+          >
+            {description}
+          </Typography>
+        )}
+      </Box>
 
-      {action && <Box sx={{ mt: 2 }}>{action}</Box>}
+      {action && <Box>{action}</Box>}
     </Stack>
   );
 }

--- a/src/shared/components/error-state.tsx
+++ b/src/shared/components/error-state.tsx
@@ -19,36 +19,42 @@ export function ErrorState({
 }: ErrorStateProps) {
   return (
     <Stack
-      spacing={1}
       sx={{
         py: 8,
         height: "100%",
         alignItems: "center",
         justifyContent: "center",
         textAlign: "center",
+        gap: 2,
       }}
     >
       {icon && (
-        <Box sx={{ color: "error.main", "& svg": { fontSize: 64, mb: 1 } }}>
+        <Box
+          sx={{
+            width: 64,
+            height: 64,
+            color: "error.main",
+            "& svg": { fontSize: 64 },
+          }}
+        >
           {icon}
         </Box>
       )}
 
-      <Typography variant="h6" color="error.main">
-        {title}
-      </Typography>
+      <Box sx={{ my: 1 }}>
+        <Typography variant="h5">{title}</Typography>
 
-      {description && (
-        <Typography
-          variant="body2"
-          color="text.secondary"
-          sx={{ maxWidth: "sm" }}
-        >
-          {description}
-        </Typography>
-      )}
+        {description && (
+          <Typography
+            variant="body1"
+            sx={{ maxWidth: "sm", color: "text.secondary" }}
+          >
+            {description}
+          </Typography>
+        )}
+      </Box>
 
-      {action && <Box sx={{ mt: 2 }}>{action}</Box>}
+      {action && <Box>{action}</Box>}
     </Stack>
   );
 }


### PR DESCRIPTION
## Summary
- Match `EmptyState` and `ErrorState` layouts: `gap: 2`, fixed 64×64 icon box, title+description wrapped in `Box sx={{ my: 1 }}`, `h5`/`body1` typography, no `mt: 2` on action
- Keep error-specific tone on the icon only; title uses default text color so headers stay consistent across screens
- Rename library "Import board set" button to "Import boards"

## Test plan
- [ ] Visit Library when empty — empty state spacing/typography looks right
- [ ] Trigger a board load error — icon is red, title is default color, spacing matches empty state
- [ ] Confirm "Import boards" button label in Library header

🤖 Generated with [Claude Code](https://claude.com/claude-code)