### PR TITLE
refactor: use logical CSS properties for RTL support

### DIFF
--- a/src/features/board/message/backspace-button.tsx
+++ b/src/features/board/message/backspace-button.tsx
@@ -68,7 +68,7 @@ export function BackspaceButton({
           sx={{
             position: "absolute",
             top: 0,
-            left: 0,
+            insetInlineStart: 0,
             zIndex: 1,
             pointerEvents: "none",
           }}

--- a/src/features/board/pictogram/pictogram.tsx
+++ b/src/features/board/pictogram/pictogram.tsx
@@ -30,7 +30,7 @@ export function Pictogram({ src, label }: PictogramProps) {
               objectFit: "contain",
               position: "absolute",
               top: 0,
-              left: 0,
+              insetInlineStart: 0,
             }}
           />
         </Box>

--- a/src/features/board/tile/tile.tsx
+++ b/src/features/board/tile/tile.tsx
@@ -68,10 +68,10 @@ export function Tile({
           display: variant === "folder" ? "block" : "none",
           position: "absolute",
           top: -2,
-          right: -2,
+          insetInlineEnd: -2,
           width: 0,
           height: 0,
-          borderRight: `32px solid ${borderColor ?? "#000"}`,
+          borderInlineEnd: `32px solid ${borderColor ?? "#000"}`,
           borderBottom: "32px solid transparent",
         },
       })}


### PR DESCRIPTION
## Summary
- Convert physical `left`/`right`/`borderRight` in sx props to logical `insetInlineStart`/`insetInlineEnd`/`borderInlineEnd` so absolutely-positioned decorations mirror correctly under RTL.
- Affects three spots: the backspace progress ring overlay, the pictogram image fill, and the tile folder-corner triangle (both its position and the colored edge flip together).
- `top`/`borderBottom` left unchanged — they're on the block axis and don't flip under horizontal-tb RTL.

## Test plan
- [ ] Visual check in LTR: backspace progress, pictogram image, and folder-tile corner render unchanged.
- [ ] Visual check in RTL: folder-corner triangle appears on the top-inline-end (visually top-left under RTL); pictogram/backspace overlays anchor to the inline-start edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)