### PR TITLE
Polish: message bar layout and PWA theme colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,12 +13,12 @@
 
     <meta
       name="theme-color"
-      content="#ffffff"
+      content="#1b75d2"
       media="(prefers-color-scheme: light)"
     />
     <meta
       name="theme-color"
-      content="#121212"
+      content="#272727"
       media="(prefers-color-scheme: dark)"
     />
 

--- a/src/features/board/message/message-bar.tsx
+++ b/src/features/board/message/message-bar.tsx
@@ -47,24 +47,18 @@ export function MessageBar({
   }, [parts]);
 
   return (
-    <Stack direction="row" sx={{ p: 2, gap: 2 }}>
+    <Stack direction="row" sx={{ p: 2 }}>
       <Stack
         direction="row"
         sx={(theme) => ({
+          height: 104,
           flexGrow: 2,
           gap: 2,
           paddingInlineEnd: 2,
           borderRadius: 18,
           overflow: "hidden",
           backgroundColor:
-            theme.palette.mode === "dark"
-              ? theme.palette.grey[800]
-              : theme.palette.grey[200],
-          border: `1px solid ${
-            theme.palette.mode === "dark"
-              ? theme.palette.grey[700]
-              : theme.palette.grey[400]
-          }`,
+            theme.palette.mode === "dark" ? "#363b41" : "#e2e6ea",
         })}
       >
         <Stack
@@ -83,13 +77,12 @@ export function MessageBar({
           onPress={onBackspacePress}
           onLongPress={onBackspaceLongPress}
         />
+        <PlayButton
+          isPlaying={isPlaying}
+          onPlayClick={onPlayClick}
+          onStopClick={onStopClick}
+        />
       </Stack>
-
-      <PlayButton
-        isPlaying={isPlaying}
-        onPlayClick={onPlayClick}
-        onStopClick={onStopClick}
-      />
     </Stack>
   );
 }

--- a/src/features/board/message/play-button.tsx
+++ b/src/features/board/message/play-button.tsx
@@ -22,15 +22,15 @@ export function PlayButton({
 
   return (
     <Tooltip title={playButtonLabel}>
-      <Box>
+      <Box sx={{ alignSelf: "center" }}>
         <IconButton
           aria-label={playButtonLabel}
           size="large"
           disabled={disabled}
           onClick={isPlaying ? onStopClick : onPlayClick}
           sx={{
-            width: 104,
-            height: 104,
+            width: 72,
+            height: 72,
             backgroundColor: (theme) => theme.palette.primary.main,
             color: (theme) => theme.palette.primary.contrastText,
             "&:hover": {
@@ -38,11 +38,7 @@ export function PlayButton({
             },
           }}
         >
-          {isPlaying ? (
-            <StopIcon sx={{ width: 48, height: 48 }} />
-          ) : (
-            <PlayArrowIcon sx={[flipForRtl, { width: 48, height: 48 }]} />
-          )}
+          {isPlaying ? <StopIcon /> : <PlayArrowIcon sx={flipForRtl} />}
         </IconButton>
       </Box>
     </Tooltip>


### PR DESCRIPTION
## Summary
- Reworked message bar layout: fixed height, single solid background per mode (`#e2e6ea` / `#363b41`), PlayButton moved inside the bar, dropped the border and the now-redundant outer gap.
- Resized PlayButton to 72×72 with default icon size to align with the BackspaceButton (which got `alignSelf: "center"` pairing earlier).
- Updated PWA `theme-color` meta tags: light `#1b75d2`, dark `#272727`.

## Test plan
- [ ] Verify message bar renders correctly in light and dark mode with new backgrounds and no border.
- [ ] Confirm PlayButton and BackspaceButton are vertically aligned and same size inside the bar.
- [ ] Open the app in a Chromium browser and confirm the address-bar color matches the new light/dark theme colors.
- [ ] Run `npm run lint` and `npm test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)