### PR TITLE
Polish: snackbar positioning, theme colors, and dark mode background

### DIFF
--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -48,11 +48,11 @@ export function BoardViewer({ board }: BoardViewerProps) {
       direction="column"
       sx={(theme) => ({
         height: "100%",
-        backgroundRepeat: "no-repeat",
-        backgroundImage:
-          theme.palette.mode === "dark"
-            ? "radial-gradient(80% 50% at 50% -20%, rgb(0, 41, 82), transparent)"
-            : "radial-gradient(80% 50% at 50% -20%, rgb(204, 230, 255), transparent)",
+        ...theme.applyStyles("dark", {
+          backgroundRepeat: "no-repeat",
+          backgroundImage:
+            "radial-gradient(80% 50% at 50% -20%, rgb(0, 41, 82), transparent)",
+        }),
       })}
     >
       <MessageBar

--- a/src/features/board/message/message-bar.tsx
+++ b/src/features/board/message/message-bar.tsx
@@ -58,7 +58,7 @@ export function MessageBar({
           borderRadius: 18,
           overflow: "hidden",
           backgroundColor:
-            theme.palette.mode === "dark" ? "#363b41" : "#e2e6ea",
+            theme.palette.mode === "dark" ? "#383838" : "#ebebeb",
         })}
       >
         <Stack

--- a/src/shared/snackbar/snackbar-provider.tsx
+++ b/src/shared/snackbar/snackbar-provider.tsx
@@ -119,7 +119,6 @@ export function SnackbarProvider({ children }: SnackbarProviderProps) {
         slotProps={{ transition: { onExited: handleExited } }}
       >
         <Alert
-          onClose={handleClose}
           severity={state.current?.severity ?? DEFAULT_SNACKBAR_SEVERITY}
           sx={{ width: "100%" }}
         >

--- a/src/shared/snackbar/snackbar-provider.tsx
+++ b/src/shared/snackbar/snackbar-provider.tsx
@@ -1,5 +1,6 @@
 import Alert from "@mui/material/Alert";
 import Snackbar, { type SnackbarCloseReason } from "@mui/material/Snackbar";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import { type ReactNode, useReducer, useRef } from "react";
 import {
   DEFAULT_SNACKBAR_SEVERITY,
@@ -70,6 +71,7 @@ function snackbarReducer(
 export function SnackbarProvider({ children }: SnackbarProviderProps) {
   const [state, dispatch] = useReducer(snackbarReducer, initialState);
   const nextKeyRef = useRef(0);
+  const isSmallScreen = useMediaQuery((theme) => theme.breakpoints.down("sm"));
 
   const showSnackbar = (options: SnackbarOptions | string) => {
     const snackbarOptions: SnackbarOptions =
@@ -109,14 +111,16 @@ export function SnackbarProvider({ children }: SnackbarProviderProps) {
         key={state.current?.key}
         open={state.open}
         autoHideDuration={state.current?.duration ?? 4000}
-        anchorOrigin={{ vertical: "top", horizontal: "center" }}
+        anchorOrigin={{
+          vertical: isSmallScreen ? "bottom" : "top",
+          horizontal: "center",
+        }}
         onClose={handleClose}
         slotProps={{ transition: { onExited: handleExited } }}
       >
         <Alert
           onClose={handleClose}
           severity={state.current?.severity ?? DEFAULT_SNACKBAR_SEVERITY}
-          variant="filled"
           sx={{ width: "100%" }}
         >
           {state.current?.message}


### PR DESCRIPTION
## Summary
- Adjust snackbar positioning to bottom on small screens for better mobile UX, and simplify the Alert (remove close button + filled variant)
- Tweak message bar background colors in light and dark modes
- Use `theme.applyStyles` for the dark-mode radial gradient on the board viewer and drop the light-mode variant

## Test plan
- [ ] Verify snackbar appears at the bottom on small screens and top on larger screens
- [ ] Verify message bar colors look correct in both light and dark mode
- [ ] Verify board viewer background gradient only renders in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)