### PR TITLE
refactor: SRP cleanups across board, speech, snackbar

### DIFF
--- a/src/app/drawers/settings/ai-settings.tsx
+++ b/src/app/drawers/settings/ai-settings.tsx
@@ -1,4 +1,4 @@
-import { useCustomInstructions } from "@features/board/suggestions/use-custom-instructions";
+import { useCustomInstructions } from "@features/board";
 import CancelIcon from "@mui/icons-material/Cancel";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import List from "@mui/material/List";

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -11,4 +11,5 @@ export {
 export type { BoardSetRecord } from "./storage/boards-db";
 export { useBoardSets } from "./storage/use-board-sets";
 export { useImportBoardFiles } from "./storage/use-import-board-files";
+export { useCustomInstructions } from "./suggestions/use-custom-instructions";
 export { useBoard } from "./use-board";

--- a/src/features/board/message/use-message-playback.ts
+++ b/src/features/board/message/use-message-playback.ts
@@ -1,7 +1,7 @@
 import { useAudio } from "@shared/hooks/use-audio";
 import { speak, stop as stopSpeaking } from "@shared/speech/speech-store";
 import { useState } from "react";
-import type { MessagePart } from "./use-message";
+import { getSpokenText, type MessagePart } from "./use-message";
 
 interface PlaybackSegment {
   type: "text" | "sound";
@@ -61,7 +61,7 @@ function convertPartsToSegments(parts: MessagePart[]): PlaybackSegment[] {
       return { type: "sound" as const, data: part.soundSrc };
     }
 
-    const text = part.vocalization ?? part.label;
+    const text = getSpokenText(part);
     if (text) {
       return { type: "text" as const, data: text };
     }

--- a/src/features/board/message/use-message.ts
+++ b/src/features/board/message/use-message.ts
@@ -6,6 +6,12 @@ export type MessagePart = Pick<
   "id" | "label" | "vocalization" | "imageSrc" | "soundSrc"
 >;
 
+export function getSpokenText(
+  part: Pick<MessagePart, "vocalization" | "label">,
+): string | undefined {
+  return part.vocalization ?? part.label;
+}
+
 export interface UseMessageReturn {
   parts: MessagePart[];
   text: string;

--- a/src/features/board/use-button-activation.ts
+++ b/src/features/board/use-button-activation.ts
@@ -1,6 +1,10 @@
 import { useAudio } from "@shared/hooks/use-audio";
 import { speak } from "@shared/speech/speech-store";
-import type { MessagePart, UseMessageReturn } from "./message/use-message";
+import {
+  getSpokenText,
+  type MessagePart,
+  type UseMessageReturn,
+} from "./message/use-message";
 import type { UseMessagePlaybackReturn } from "./message/use-message-playback";
 import type { UseBoardNavigationReturn } from "./navigation/use-board-navigation";
 import type { BoardAction, BoardButton } from "./types";
@@ -94,7 +98,7 @@ export function useButtonActivation({
       return;
     }
 
-    const text = button.vocalization ?? button.label;
+    const text = getSpokenText(button);
 
     if (text) {
       void speak(text.toLowerCase());

--- a/src/shared/built-in-ai/internal/testing/instance-fakes.ts
+++ b/src/shared/built-in-ai/internal/testing/instance-fakes.ts
@@ -1,11 +1,6 @@
 import { vi } from "vitest";
 import { makeChunkStream } from "./ai-namespace-fake.ts";
 
-// Context-bearing fakes echo `context` into the output — tests prove forwarding from the resolved value alone.
-interface ContextOpts {
-  context?: string;
-}
-
 export function buildTranslatorInstance() {
   return {
     translate: vi.fn((input: string) => Promise.resolve(`T:${input}`)),
@@ -18,7 +13,7 @@ export function buildTranslatorInstance() {
 
 export function buildRewriterInstance() {
   return {
-    rewrite: vi.fn((input: string, opts?: ContextOpts) =>
+    rewrite: vi.fn((input: string, opts?: RewriterRewriteOptions) =>
       Promise.resolve(`R(${opts?.context ?? ""}):${input}`),
     ),
     rewriteStreaming: vi.fn(() => makeChunkStream(["R:", "alt"])),

--- a/src/shared/language/language-provider.tsx
+++ b/src/shared/language/language-provider.tsx
@@ -1,9 +1,5 @@
 import { usePersistentState } from "@shared/hooks/use-persistent-state";
-import {
-  getDefaultVoice,
-  setVoiceURI,
-  useVoicesByLanguage,
-} from "@shared/speech/speech-store";
+import { setVoiceURI, useVoicesByLanguage } from "@shared/speech/speech-store";
 import { useEffect, type ReactNode } from "react";
 import { LanguageContext, type LanguageContextValue } from "./language-context";
 import { getNativeLanguageName, getTextDirection } from "@shared/utils/locale";
@@ -37,7 +33,8 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
   };
 
   useEffect(() => {
-    const defaultVoice = getDefaultVoice(voicesByLanguage[language]);
+    const voices = voicesByLanguage[language];
+    const defaultVoice = voices?.find((voice) => voice.default) ?? voices?.[0];
     if (defaultVoice) {
       setVoiceURI(defaultVoice.voiceURI);
     }

--- a/src/shared/snackbar/snackbar-context.ts
+++ b/src/shared/snackbar/snackbar-context.ts
@@ -2,8 +2,6 @@ import { createContext, type ReactNode } from "react";
 
 export type SnackbarSeverity = "success" | "error" | "info" | "warning";
 
-export const DEFAULT_SNACKBAR_SEVERITY: SnackbarSeverity = "info";
-
 export interface SnackbarOptions {
   message: string;
   severity?: SnackbarSeverity;

--- a/src/shared/snackbar/snackbar-provider.tsx
+++ b/src/shared/snackbar/snackbar-provider.tsx
@@ -3,11 +3,13 @@ import Snackbar, { type SnackbarCloseReason } from "@mui/material/Snackbar";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { type ReactNode, useReducer, useRef } from "react";
 import {
-  DEFAULT_SNACKBAR_SEVERITY,
   SnackbarContext,
   type SnackbarContextValue,
   type SnackbarOptions,
+  type SnackbarSeverity,
 } from "./snackbar-context";
+
+const DEFAULT_SNACKBAR_SEVERITY: SnackbarSeverity = "info";
 
 export interface SnackbarProviderProps {
   children: ReactNode;

--- a/src/shared/speech/speech-store.ts
+++ b/src/shared/speech/speech-store.ts
@@ -103,12 +103,6 @@ export function stop(): void {
   synthesis?.cancel();
 }
 
-export function getDefaultVoice(
-  voices: SpeechSynthesisVoice[] | undefined,
-): SpeechSynthesisVoice | undefined {
-  return voices?.find((voice) => voice.default) ?? voices?.[0];
-}
-
 export function useVoicesByLanguage(): VoicesByLanguage {
   return useSyncExternalStore(
     voiceCatalogStore.subscribe,


### PR DESCRIPTION
## Summary
- Extract `getSpokenText(part)` helper for the `vocalization ?? label` pattern; reuse in `use-message-playback` and `use-button-activation`
- Inline `getDefaultVoice` at its single call site in `language-provider`; drop the export from `speech-store`
- Drop unused `DEFAULT_SNACKBAR_SEVERITY` export from `snackbar-context`; keep it as a local const in `snackbar-provider`
- Re-export `useCustomInstructions` from the `board` barrel so `ai-settings` imports through the public surface
- Replace ad-hoc `ContextOpts` in test fakes with the built-in `RewriterRewriteOptions`; drop a stale top-of-file comment

## Test plan
- [x] `npm run lint` on touched files
- [ ] Verify board playback still speaks the right text (vocalization overrides label)
- [ ] Verify changing language picks a default voice

🤖 Generated with [Claude Code](https://claude.com/claude-code)