### PR TITLE
refactor: move getSpokenText to board domain

### DIFF
--- a/src/features/board/message/use-message-playback.ts
+++ b/src/features/board/message/use-message-playback.ts
@@ -1,7 +1,8 @@
 import { useAudio } from "@shared/hooks/use-audio";
 import { speak, stop as stopSpeaking } from "@shared/speech/speech-store";
 import { useState } from "react";
-import { getSpokenText, type MessagePart } from "./use-message";
+import { getSpokenText } from "../types";
+import type { MessagePart } from "./use-message";
 
 interface PlaybackSegment {
   type: "text" | "sound";

--- a/src/features/board/message/use-message.ts
+++ b/src/features/board/message/use-message.ts
@@ -6,12 +6,6 @@ export type MessagePart = Pick<
   "id" | "label" | "vocalization" | "imageSrc" | "soundSrc"
 >;
 
-export function getSpokenText(
-  part: Pick<MessagePart, "vocalization" | "label">,
-): string | undefined {
-  return part.vocalization ?? part.label;
-}
-
 export interface UseMessageReturn {
   parts: MessagePart[];
   text: string;

--- a/src/features/board/types.ts
+++ b/src/features/board/types.ts
@@ -27,6 +27,12 @@ export interface BoardButton {
   loadBoard?: BoardLink;
 }
 
+export function getSpokenText(
+  button: Pick<BoardButton, "vocalization" | "label">,
+): string | undefined {
+  return button.vocalization ?? button.label;
+}
+
 export interface BoardLicense {
   type: string;
   authorName?: string;

--- a/src/features/board/use-button-activation.ts
+++ b/src/features/board/use-button-activation.ts
@@ -1,13 +1,9 @@
 import { useAudio } from "@shared/hooks/use-audio";
 import { speak } from "@shared/speech/speech-store";
-import {
-  getSpokenText,
-  type MessagePart,
-  type UseMessageReturn,
-} from "./message/use-message";
+import type { MessagePart, UseMessageReturn } from "./message/use-message";
 import type { UseMessagePlaybackReturn } from "./message/use-message-playback";
 import type { UseBoardNavigationReturn } from "./navigation/use-board-navigation";
-import type { BoardAction, BoardButton } from "./types";
+import { getSpokenText, type BoardAction, type BoardButton } from "./types";
 
 export interface UseButtonActivationOptions {
   message: UseMessageReturn;


### PR DESCRIPTION
## Summary

- Move `getSpokenText` from `message/use-message.ts` to `board/types.ts`, next to the `BoardButton` interface whose `vocalization ?? label` invariant it encodes.
- `MessagePart` only carries the shape because its parts are minted from buttons — the rule belongs with the button, not with the message module.
- Removes the uphill import from `use-button-activation.ts` into `message/` for a rule that isn't about messages.
- Typed against `Pick<BoardButton, "vocalization" | "label">` so any future button consumer (history, suggestions, etc.) lands at the helper just by following the type.

## Test plan

- [ ] `npm run lint` clean
- [ ] Existing message + button activation tests pass
- [ ] Manual: tap a button with a `vocalization` and confirm the spoken phrase, not the label, is uttered
- [ ] Manual: tap a button with only a `label` and confirm it speaks the label

🤖 Generated with [Claude Code](https://claude.com/claude-code)