### PR TITLE
refactor: rename useHeaderTitle to useAppHeaderTitle

### DIFF
--- a/src/app/layouts/app-header-title.ts
+++ b/src/app/layouts/app-header-title.ts
@@ -3,11 +3,11 @@ import { useEffect, useSyncExternalStore } from "react";
 
 const store = createExternalStore("");
 
-export function useHeaderTitle(): string {
+export function useAppHeaderTitle(): string {
   return useSyncExternalStore(store.subscribe, store.getSnapshot);
 }
 
-export function useDeclareHeaderTitle(title: string | undefined): void {
+export function useDeclareAppHeaderTitle(title: string | undefined): void {
   useEffect(() => {
     const next = title ?? "";
     if (store.getSnapshot() !== next) {

--- a/src/app/layouts/app-header.tsx
+++ b/src/app/layouts/app-header.tsx
@@ -1,4 +1,4 @@
-import { useHeaderTitle } from "@app/use-header-title";
+import { useAppHeaderTitle } from "./app-header-title";
 import MenuIcon from "@mui/icons-material/Menu";
 import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
 import AppBar from "@mui/material/AppBar";
@@ -13,7 +13,7 @@ export interface AppHeaderProps {
 }
 
 export function AppHeader({ onMenuClick, onSettingsClick }: AppHeaderProps) {
-  const headerTitle = useHeaderTitle();
+  const headerTitle = useAppHeaderTitle();
 
   return (
     <AppBar position="static">

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -1,6 +1,6 @@
 import { APP_NAME } from "@app/app-info";
 import { Title } from "@app/title";
-import { useDeclareHeaderTitle } from "@app/use-header-title";
+import { useDeclareAppHeaderTitle } from "@app/layouts/app-header-title";
 import GitHubIcon from "@mui/icons-material/GitHub";
 import Button from "@mui/material/Button";
 import Link from "@mui/material/Link";
@@ -9,7 +9,7 @@ import Typography from "@mui/material/Typography";
 import { PageContainer } from "@shared/components/page-container";
 
 function AboutPage() {
-  useDeclareHeaderTitle("About");
+  useDeclareAppHeaderTitle("About");
 
   return (
     <>

--- a/src/pages/board-page.tsx
+++ b/src/pages/board-page.tsx
@@ -1,5 +1,5 @@
 import { Title } from "@app/title";
-import { useDeclareHeaderTitle } from "@app/use-header-title";
+import { useDeclareAppHeaderTitle } from "@app/layouts/app-header-title";
 import { BoardViewer, useBoard, type BoardRouteParams } from "@features/board";
 import { ErrorState } from "@shared/components/error-state";
 import { LoadingState } from "@shared/components/loading-state";
@@ -9,7 +9,7 @@ function BoardPage() {
   const { setId = "", boardId = "" } = useParams<BoardRouteParams>();
   const { board, error } = useBoard({ setId, boardId });
 
-  useDeclareHeaderTitle(board?.name);
+  useDeclareAppHeaderTitle(board?.name);
 
   if (error) {
     return (

--- a/src/pages/library-page.tsx
+++ b/src/pages/library-page.tsx
@@ -1,5 +1,5 @@
 import { Title } from "@app/title";
-import { useDeclareHeaderTitle } from "@app/use-header-title";
+import { useDeclareAppHeaderTitle } from "@app/layouts/app-header-title";
 import {
   BoardSetDeleteDialog,
   BoardSetInfoDialog,
@@ -26,7 +26,7 @@ function LibraryPage() {
   const { showSnackbar } = useSnackbar();
   const navigate = useNavigate();
 
-  useDeclareHeaderTitle("Library");
+  useDeclareAppHeaderTitle("Library");
 
   const [deleteTarget, setDeleteTarget] = useState<BoardSetRecord | null>(null);
   const [infoTarget, setInfoTarget] = useState<BoardSetRecord | null>(null);


### PR DESCRIPTION
## Summary
- Move `src/app/use-header-title.ts` → `src/app/layouts/app-header-title.ts`, next to the `AppHeader` that consumes it (mirrors `dialogs/use-onboarding.ts` co-location pattern)
- Rename exports `useHeaderTitle` / `useDeclareHeaderTitle` → `useAppHeaderTitle` / `useDeclareAppHeaderTitle` to disambiguate the in-app header title from the document `<title>` set by `<Title>`
- Update 4 importers (`AppHeader`, 3 pages)

## Test plan
- [x] `npm run -s lint` passes on all touched files
- [ ] App header still renders the current page name on Library / Board / About routes
- [ ] Header clears when navigating away from a titled route

🤖 Generated with [Claude Code](https://claude.com/claude-code)