### PR TITLE
refactor: migrate router from declarative to data mode

### DIFF
--- a/src/app/app-routes.tsx
+++ b/src/app/app-routes.tsx
@@ -1,52 +1,98 @@
 import { AppShell } from "@app/layouts/app-shell";
-import { BoardSetRootRedirect } from "@pages/board-set-root-redirect";
-import { HomePage } from "@pages/home-page";
-import { AsyncBoundary } from "@shared/components/async-boundary";
-import { lazy } from "react";
-import { BrowserRouter, Route, Routes } from "react-router";
+import { boardSetRootLoader } from "@app/loaders/board-set-root-loader";
+import { homeLoader } from "@app/loaders/home-loader";
+import { boardLoader } from "@features/board";
+import { ErrorState } from "@shared/components/error-state";
+import { LoadingState } from "@shared/components/loading-state";
+import {
+  createBrowserRouter,
+  isRouteErrorResponse,
+  useRouteError,
+} from "react-router";
+import { RouterProvider } from "react-router/dom";
 
-const BoardPage = lazy(() => import("@pages/board-page"));
-const LibraryPage = lazy(() => import("@pages/library-page"));
-const AboutPage = lazy(() => import("@pages/about-page"));
+function RootErrorBoundary() {
+  const error = useRouteError();
+  if (isRouteErrorResponse(error)) {
+    return (
+      <ErrorState
+        title={`${error.status} ${error.statusText}`}
+        description={typeof error.data === "string" ? error.data : undefined}
+      />
+    );
+  }
+  return <ErrorState title="Something went wrong" />;
+}
+
+function BoardSetErrorBoundary() {
+  const error = useRouteError();
+  if (isRouteErrorResponse(error) && error.status === 404) {
+    return (
+      <ErrorState
+        title="Board set not found"
+        description="This board set may have been deleted."
+      />
+    );
+  }
+  if (isRouteErrorResponse(error) && error.status === 422) {
+    return (
+      <ErrorState
+        title="Board set incomplete"
+        description="This board set has no starting board."
+      />
+    );
+  }
+  return <ErrorState title="Something went wrong" />;
+}
+
+function BoardErrorBoundary() {
+  const error = useRouteError();
+  if (isRouteErrorResponse(error) && error.status === 404) {
+    return (
+      <ErrorState
+        title="Board not found"
+        description="This board may have been deleted or is missing assets."
+      />
+    );
+  }
+  return (
+    <ErrorState
+      title="Couldn't load board"
+      description="Try returning to the library."
+    />
+  );
+}
+
+function PageHydrateFallback() {
+  return <LoadingState />;
+}
+
+const router = createBrowserRouter([
+  {
+    Component: AppShell,
+    ErrorBoundary: RootErrorBoundary,
+    HydrateFallback: PageHydrateFallback,
+    children: [
+      { index: true, loader: homeLoader },
+      {
+        path: "sets/:setId",
+        ErrorBoundary: BoardSetErrorBoundary,
+        children: [
+          { index: true, loader: boardSetRootLoader },
+          {
+            path: "boards/:boardId",
+            loader: boardLoader,
+            lazy: async () => import("@pages/board-page"),
+            ErrorBoundary: BoardErrorBoundary,
+          },
+        ],
+      },
+      { path: "library", lazy: async () => import("@pages/library-page") },
+      { path: "about", lazy: async () => import("@pages/about-page") },
+    ],
+  },
+]);
 
 export function AppRoutes() {
-  return (
-    <BrowserRouter>
-      <Routes>
-        <Route element={<AppShell />}>
-          <Route index element={<HomePage />} />
-          <Route path="sets/:setId">
-            <Route index element={<BoardSetRootRedirect />} />
-
-            <Route
-              path="boards/:boardId"
-              element={
-                <AsyncBoundary>
-                  <BoardPage />
-                </AsyncBoundary>
-              }
-            />
-          </Route>
-
-          <Route
-            path="library"
-            element={
-              <AsyncBoundary>
-                <LibraryPage />
-              </AsyncBoundary>
-            }
-          />
-
-          <Route
-            path="about"
-            element={
-              <AsyncBoundary>
-                <AboutPage />
-              </AsyncBoundary>
-            }
-          />
-        </Route>
-      </Routes>
-    </BrowserRouter>
-  );
+  return <RouterProvider router={router} />;
 }

--- a/src/app/layouts/app-shell.tsx
+++ b/src/app/layouts/app-shell.tsx
@@ -7,7 +7,7 @@ import Box from "@mui/material/Box";
 import Fade from "@mui/material/Fade";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { useState } from "react";
-import { Outlet, useLocation } from "react-router";
+import { Outlet, ScrollRestoration, useLocation } from "react-router";
 
 const FADE_DURATION_MS = 400;
 
@@ -31,6 +31,8 @@ export function AppShell() {
 
   return (
     <Box sx={{ height: "100svh", display: "flex", flexDirection: "column" }}>
+      <ScrollRestoration />
+
       <AppHeader
         onMenuClick={() => setIsMenuOpen(true)}
         onSettingsClick={() => setIsSettingsOpen(true)}

--- a/src/app/loaders/board-set-root-loader.test.ts
+++ b/src/app/loaders/board-set-root-loader.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import type { LoaderFunctionArgs } from "react-router";
+import {
+  resetBoardsDB,
+  seedBoardSets,
+} from "@features/board/storage/test-helpers";
+import { boardSetRootLoader } from "./board-set-root-loader";
+
+function callLoader(setId: string): Promise<Response> {
+  const args = {
+    request: new Request("http://localhost/"),
+    params: { setId },
+  } as unknown as LoaderFunctionArgs;
+  return boardSetRootLoader(args);
+}
+
+async function expectThrown(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (err) {
+    return err;
+  }
+  throw new Error("Expected loader to throw, but it resolved");
+}
+
+// `throw data(...)` produces a DataWithResponseInit instance — checking its
+// shape directly. `isRouteErrorResponse` only matches the router's internal
+// ErrorResponse wrapper, which is applied at the boundary, not at the throw
+// site reached by direct loader calls.
+function expectThrownStatus(error: unknown, status: number): void {
+  expect(error).toBeTruthy();
+  expect(error).toHaveProperty("init");
+  const init = (error as { init: ResponseInit | null }).init;
+  expect(init?.status).toBe(status);
+}
+
+describe("boardSetRootLoader", () => {
+  beforeEach(async () => {
+    await resetBoardsDB();
+  });
+
+  afterEach(async () => {
+    await resetBoardsDB();
+  });
+
+  test("redirects to the root board route on the happy path", async () => {
+    await seedBoardSets([{ setId: "set-1", rootBoardId: "root-1" }]);
+
+    const response = await callLoader("set-1");
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("/sets/set-1/boards/root-1");
+  });
+
+  test("throws 404 when the board set is missing", async () => {
+    await seedBoardSets([]);
+
+    const error = await expectThrown(callLoader("missing-set"));
+
+    expectThrownStatus(error, 404);
+  });
+
+  test("throws 422 when the board set has no root board", async () => {
+    await seedBoardSets([{ setId: "set-1" }]);
+
+    const error = await expectThrown(callLoader("set-1"));
+
+    expectThrownStatus(error, 422);
+  });
+});

--- a/src/app/loaders/board-set-root-loader.ts
+++ b/src/app/loaders/board-set-root-loader.ts
@@ -1,0 +1,33 @@
+import { getBoardSets } from "@features/board";
+import {
+  data,
+  generatePath,
+  redirect,
+  type LoaderFunctionArgs,
+} from "react-router";
+
+export async function boardSetRootLoader({
+  params,
+}: LoaderFunctionArgs): Promise<Response> {
+  const setId = params.setId ?? "";
+  const sets = await getBoardSets();
+  const set = sets.find((s) => s.setId === setId);
+
+  if (!set) {
+    // React Router catches thrown `data()` and routes it to ErrorBoundary as
+    // a route error response — the v7-canonical way to signal an expected 4xx.
+    // eslint-disable-next-line @typescript-eslint/only-throw-error
+    throw data("Board set not found", { status: 404 });
+  }
+  if (!set.rootBoardId) {
+    // eslint-disable-next-line @typescript-eslint/only-throw-error
+    throw data("Board set incomplete", { status: 422 });
+  }
+
+  return redirect(
+    generatePath("/sets/:setId/boards/:boardId", {
+      setId,
+      boardId: set.rootBoardId,
+    }),
+  );
+}

--- a/src/app/loaders/home-loader.test.ts
+++ b/src/app/loaders/home-loader.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import type { LoaderFunctionArgs } from "react-router";
+import { invalidateBoardSets } from "@features/board/storage/board-sets-store";
+import { listBoardSets, withBoardsDB } from "@features/board/storage/boards-db";
+import {
+  resetBoardsDB,
+  seedBoardSets,
+} from "@features/board/storage/test-helpers";
+import { homeLoader } from "./home-loader";
+
+const FIXTURE_BOARD_URL = "/src/shared/testing/sample-boards/lots_of_stuff.obz";
+const DEFAULT_BOARD_PATH = "/quick-core-24.obz";
+
+function callLoader(searchParams = ""): Promise<Response> {
+  const args = {
+    request: new Request(`http://localhost/${searchParams}`),
+    params: {},
+  } as unknown as LoaderFunctionArgs;
+  return homeLoader(args);
+}
+
+describe("homeLoader", () => {
+  beforeEach(async () => {
+    await resetBoardsDB();
+    // resetBoardsDB clears IDB but the board-sets-store keeps its cached
+    // snapshot from prior tests — explicitly invalidate so getBoardSets()
+    // reads fresh from the now-empty DB.
+    await invalidateBoardSets();
+  });
+
+  afterEach(async () => {
+    await resetBoardsDB();
+  });
+
+  test("imports the URL from ?board and redirects to its board route", async () => {
+    const response = await callLoader(
+      `?board=${encodeURIComponent(FIXTURE_BOARD_URL)}`,
+    );
+
+    expect(response.status).toBe(302);
+    const location = response.headers.get("Location");
+    expect(location).toMatch(/^\/sets\/[^/]+\/boards\/[^/]+$/);
+
+    const sets = await withBoardsDB((db) => listBoardSets(db));
+    expect(sets).toHaveLength(1);
+  });
+
+  test("redirects to the most recently updated board set when no param is given", async () => {
+    // seedBoardSets inserts sequentially; listBoardSets orders by updatedAt
+    // descending, so set-2 (inserted last) ends up first.
+    await seedBoardSets([
+      { setId: "set-1", rootBoardId: "root-1" },
+      { setId: "set-2", rootBoardId: "root-2" },
+    ]);
+
+    const response = await callLoader();
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("/sets/set-2");
+  });
+
+  test("imports the default board when no param is given and IDB is empty", async () => {
+    const probe = await fetch(DEFAULT_BOARD_PATH);
+    if (!probe.ok) {
+      throw new Error(`Default board fixture missing at ${DEFAULT_BOARD_PATH}`);
+    }
+
+    const response = await callLoader();
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toMatch(
+      /^\/sets\/[^/]+\/boards\/[^/]+$/,
+    );
+
+    const sets = await withBoardsDB((db) => listBoardSets(db));
+    expect(sets).toHaveLength(1);
+  });
+});

--- a/src/app/loaders/home-loader.ts
+++ b/src/app/loaders/home-loader.ts
@@ -1,0 +1,27 @@
+import { getBoardSets, importBoardFromUrl } from "@features/board";
+import { generatePath, redirect, type LoaderFunctionArgs } from "react-router";
+
+const DEFAULT_BOARD_URL = `${import.meta.env.BASE_URL}quick-core-24.obz`;
+
+async function resolveInitialBoard(boardUrl: string | null): Promise<string> {
+  if (boardUrl) {
+    const { setId, boardId } = await importBoardFromUrl(boardUrl);
+    return generatePath("/sets/:setId/boards/:boardId", { setId, boardId });
+  }
+
+  const existingSets = await getBoardSets();
+  if (existingSets.length > 0) {
+    return generatePath("/sets/:setId", { setId: existingSets[0].setId });
+  }
+
+  const { setId, boardId } = await importBoardFromUrl(DEFAULT_BOARD_URL);
+  return generatePath("/sets/:setId/boards/:boardId", { setId, boardId });
+}
+
+export async function homeLoader({
+  request,
+}: LoaderFunctionArgs): Promise<Response> {
+  const boardUrl = new URL(request.url).searchParams.get("board");
+  const path = await resolveInitialBoard(boardUrl);
+  return redirect(path);
+}

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -3,6 +3,7 @@ export { BoardSetDeleteDialog } from "./library/board-set-delete-dialog";
 export { BoardSetInfoDialog } from "./library/board-set-info-dialog";
 export { BoardSetList } from "./library/board-set-list";
 export type { BoardRouteParams } from "./navigation/use-board-navigation";
+export { boardLoader, type BoardLoaderData } from "./storage/board-loader";
 export {
   getBoardSets,
   importBoardFromUrl,

--- a/src/features/board/storage/board-loader.test.ts
+++ b/src/features/board/storage/board-loader.test.ts
@@ -1,0 +1,159 @@
+import type { OBFBoard } from "open-board-format";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import type { LoaderFunctionArgs } from "react-router";
+import { boardLoader, type BoardLoaderData } from "./board-loader";
+import { invalidateBoardSets } from "./board-sets-store";
+import {
+  putAssets,
+  putBoards,
+  upsertBoardSet,
+  withBoardsDB,
+} from "./boards-db";
+import { resetBoardsDB } from "./test-helpers";
+
+const SET_ID = "loader-test-set";
+const BOARD_ID = "loader-test-board";
+const IMAGE_PATH = "images/test.png";
+const REAL_PNG_URL = "/pwa-192x192.png";
+
+// Seed a minimal board with one path-based image, using a real PNG blob so
+// the loader's hydration produces an Image-loadable blob URL. Going direct to
+// the storage layer (vs. importBoardFiles) keeps the test independent of OBZ
+// fixture shape — the only thing under test here is boardLoader's behavior.
+async function seedTestBoard(): Promise<void> {
+  const pngResponse = await fetch(REAL_PNG_URL);
+  if (!pngResponse.ok) {
+    throw new Error(`Could not fetch ${REAL_PNG_URL} for fixture image`);
+  }
+  const pngBlob = await pngResponse.blob();
+
+  const obfBoard: OBFBoard = {
+    format: "open-board-0.1",
+    id: BOARD_ID,
+    name: "Test Board",
+    grid: { rows: 1, columns: 1, order: [["btn-1"]] },
+    buttons: [{ id: "btn-1", label: "test", image_id: "img-1" }],
+    images: [{ id: "img-1", path: IMAGE_PATH, content_type: "image/png" }],
+  };
+
+  await withBoardsDB(async (db) => {
+    await upsertBoardSet(db, {
+      setId: SET_ID,
+      name: "Loader Test",
+      rootBoardId: BOARD_ID,
+    });
+    await putBoards(db, SET_ID, [
+      { boardId: BOARD_ID, name: "Test Board", obf: obfBoard },
+    ]);
+    await putAssets(db, SET_ID, [
+      { path: IMAGE_PATH, blob: pngBlob, mime: "image/png" },
+    ]);
+  });
+
+  await invalidateBoardSets();
+}
+
+function callLoader(setId: string, boardId: string): Promise<BoardLoaderData> {
+  const args = {
+    request: new Request("http://localhost/"),
+    params: { setId, boardId },
+  } as unknown as LoaderFunctionArgs;
+  return boardLoader(args);
+}
+
+async function expectThrown(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (err) {
+    return err;
+  }
+  throw new Error("Expected loader to throw, but it resolved");
+}
+
+// `throw data(...)` produces a DataWithResponseInit instance — the router
+// wraps it into an ErrorResponse only at the boundary. Check the shape
+// directly when calling loaders straight.
+function expectThrownStatus(error: unknown, status: number): void {
+  expect(error).toBeTruthy();
+  expect(error).toHaveProperty("init");
+  const init = (error as { init: ResponseInit | null }).init;
+  expect(init?.status).toBe(status);
+}
+
+// A blob URL is "alive" while its registry hasn't revoked it. Loading it as
+// an Image is the most reliable cross-browser probe — the fixture asset is a
+// PNG, so a live URL fires `load` and a revoked one fires `error`.
+function isObjectUrlAlive(url: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    const settle = (result: boolean) => {
+      img.onload = null;
+      img.onerror = null;
+      resolve(result);
+    };
+    img.onload = () => settle(true);
+    img.onerror = () => settle(false);
+    img.src = url;
+  });
+}
+
+describe("boardLoader", () => {
+  beforeEach(async () => {
+    await resetBoardsDB();
+    await invalidateBoardSets();
+  });
+
+  afterEach(async () => {
+    await resetBoardsDB();
+  });
+
+  test("returns a hydrated board on the happy path", async () => {
+    await seedTestBoard();
+
+    const result = await callLoader(SET_ID, BOARD_ID);
+
+    expect(result.setId).toBe(SET_ID);
+    expect(result.board.id).toBe(BOARD_ID);
+
+    const imageSrc = result.board.buttons[0].imageSrc;
+    expect(imageSrc).toBeDefined();
+    expect(imageSrc!.startsWith("blob:")).toBe(true);
+    expect(await isObjectUrlAlive(imageSrc!)).toBe(true);
+  });
+
+  test("throws 404 when the board is not in IDB", async () => {
+    await seedTestBoard();
+
+    const error = await expectThrown(callLoader(SET_ID, "missing-board"));
+
+    expectThrownStatus(error, 404);
+  });
+
+  test("revokes the previous registry on the next loader run", async () => {
+    await seedTestBoard();
+
+    const first = await callLoader(SET_ID, BOARD_ID);
+    const firstUrl = first.board.buttons[0].imageSrc;
+    expect(firstUrl).toBeDefined();
+    expect(await isObjectUrlAlive(firstUrl!)).toBe(true);
+
+    const second = await callLoader(SET_ID, BOARD_ID);
+    const secondUrl = second.board.buttons[0].imageSrc;
+    expect(secondUrl).toBeDefined();
+
+    expect(await isObjectUrlAlive(firstUrl!)).toBe(false);
+    expect(await isObjectUrlAlive(secondUrl!)).toBe(true);
+  });
+
+  test("a 404 does not poison the module state for a later happy path", async () => {
+    await seedTestBoard();
+
+    await expectThrown(callLoader(SET_ID, "missing-board"));
+
+    const result = await callLoader(SET_ID, BOARD_ID);
+    const url = result.board.buttons[0].imageSrc;
+
+    expect(url).toBeDefined();
+    expect(await isObjectUrlAlive(url!)).toBe(true);
+  });
+});

--- a/src/features/board/storage/board-loader.ts
+++ b/src/features/board/storage/board-loader.ts
@@ -1,0 +1,112 @@
+import {
+  createObjectUrlRegistry,
+  type ObjectUrlRegistry,
+} from "@shared/utils/object-url";
+import type { OBFBoard, OBFMedia } from "open-board-format";
+import { data, type LoaderFunctionArgs } from "react-router";
+import { obfToBoard } from "../obf/mapper";
+import type { Board } from "../types";
+import {
+  getAssetBlob,
+  getBoard,
+  withBoardsDB,
+  type BoardsDB,
+} from "./boards-db";
+
+export interface BoardLoaderData {
+  setId: string;
+  board: Board;
+}
+
+// Module-scoped pointer to the registry the previous loader call created.
+// Revoking on the next loader run (rather than on React unmount) keeps URL
+// lifecycle outside React entirely — required because StrictMode dev double-
+// invokes effect cleanups, which would otherwise revoke URLs the component
+// is still about to render.
+let previousRegistry: ObjectUrlRegistry | null = null;
+
+export async function boardLoader({
+  params,
+}: LoaderFunctionArgs): Promise<BoardLoaderData> {
+  const setId = params.setId ?? "";
+  const boardId = params.boardId ?? "";
+  if (!setId || !boardId) {
+    // React Router catches thrown `data()` and routes it to ErrorBoundary as
+    // a route error response — the v7-canonical way to signal an expected 4xx.
+    // eslint-disable-next-line @typescript-eslint/only-throw-error
+    throw data("Missing route params", { status: 400 });
+  }
+
+  previousRegistry?.revokeAll();
+  previousRegistry = null;
+
+  const registry = createObjectUrlRegistry();
+  try {
+    const board = await withBoardsDB(async (db) => {
+      const obf = await fetchOBFBoard(db, setId, boardId);
+      const hydrated = await hydrateBoard(db, setId, obf, registry);
+      return obfToBoard(hydrated);
+    });
+    previousRegistry = registry;
+    return { setId, board };
+  } catch (err) {
+    registry.revokeAll();
+    if (err instanceof Error && err.message.startsWith("Board not found")) {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error
+      throw data("Board not found", { status: 404 });
+    }
+    throw err;
+  }
+}
+
+async function fetchOBFBoard(
+  db: BoardsDB,
+  setId: string,
+  boardId: string,
+): Promise<OBFBoard> {
+  const record = await getBoard(db, setId, boardId);
+  if (!record) {
+    throw new Error(`Board not found: ${setId}/${boardId}`);
+  }
+  return record.obf;
+}
+
+async function hydrateBoard(
+  db: BoardsDB,
+  setId: string,
+  board: OBFBoard,
+  registry: ObjectUrlRegistry,
+): Promise<OBFBoard> {
+  const [images, sounds] = await Promise.all([
+    hydrateAssets(db, setId, board.images, registry),
+    hydrateAssets(db, setId, board.sounds, registry),
+  ]);
+  return { ...board, images, sounds };
+}
+
+async function hydrateAssets(
+  db: BoardsDB,
+  setId: string,
+  assets: OBFMedia[] | undefined,
+  registry: ObjectUrlRegistry,
+): Promise<OBFMedia[] | undefined> {
+  if (!assets?.length) {
+    return assets;
+  }
+
+  return Promise.all(
+    assets.map(async (asset) => {
+      if (!asset.path) {
+        return asset;
+      }
+
+      try {
+        const blob = await getAssetBlob(db, setId, asset.path);
+        const url = blob ? registry.create(blob) : null;
+        return url ? { ...asset, data: url } : asset;
+      } catch {
+        return asset;
+      }
+    }),
+  );
+}

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -8,7 +8,7 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { PageContainer } from "@shared/components/page-container";
 
-function AboutPage() {
+export const Component = function AboutPage() {
   useDeclareAppHeaderTitle("About");
 
   return (
@@ -89,6 +89,4 @@ function AboutPage() {
       </PageContainer>
     </>
   );
-}
-
-export default AboutPage;
+};

--- a/src/pages/board-page.tsx
+++ b/src/pages/board-page.tsx
@@ -1,35 +1,27 @@
 import { Title } from "@app/title";
 import { useDeclareAppHeaderTitle } from "@app/layouts/app-header-title";
-import { BoardViewer, useBoard, type BoardRouteParams } from "@features/board";
-import { ErrorState } from "@shared/components/error-state";
+import { BoardViewer, type BoardLoaderData } from "@features/board";
+import { useBoardTranslation } from "@features/board/use-board-translation";
 import { LoadingState } from "@shared/components/loading-state";
-import { useParams } from "react-router";
+import { useLoaderData } from "react-router";
 
-function BoardPage() {
-  const { setId = "", boardId = "" } = useParams<BoardRouteParams>();
-  const { board, error } = useBoard({ setId, boardId });
+export const Component = function BoardPage() {
+  const { setId, board } = useLoaderData<BoardLoaderData>();
+  const { translatedBoard } = useBoardTranslation({ setId, board });
 
-  useDeclareAppHeaderTitle(board?.name);
+  // Hooks must run unconditionally — keep the title declaration above the
+  // early return. The untranslated name carries the header until translation
+  // settles, so it never flickers blank.
+  useDeclareAppHeaderTitle(translatedBoard?.name ?? board.name);
 
-  if (error) {
-    return (
-      <ErrorState
-        title="Couldn't load board"
-        description="This board may be missing or corrupted."
-      />
-    );
-  }
-
-  if (!board) {
+  if (!translatedBoard) {
     return <LoadingState message="Loading board..." />;
   }
 
   return (
     <>
-      <Title>{board.name}</Title>
-      <BoardViewer board={board} />
+      <Title>{translatedBoard.name}</Title>
+      <BoardViewer board={translatedBoard} />
     </>
   );
-}
-
-export default BoardPage;
+};

--- a/src/pages/library-page.tsx
+++ b/src/pages/library-page.tsx
@@ -20,7 +20,7 @@ import { useSnackbar } from "@shared/snackbar/use-snackbar";
 import { useState } from "react";
 import { generatePath, useNavigate } from "react-router";
 
-function LibraryPage() {
+export const Component = function LibraryPage() {
   const { boardSets, isLoading } = useBoardSets();
   const { pickAndImportBoardFiles } = useImportBoardFiles();
   const { showSnackbar } = useSnackbar();
@@ -130,6 +130,4 @@ function LibraryPage() {
       </PageContainer>
     </>
   );
-}
-
-export default LibraryPage;
+};


### PR DESCRIPTION
## Summary

Move from `BrowserRouter` + `<Routes>` to `createBrowserRouter` + `RouterProvider`. The two ghost pages that ran async logic in `useEffect` and navigated away become loaders that throw `redirect()` directly. The board route's data fetching (`useLoadBoard`, ~80 lines of cancellation flags and registry refs) becomes `boardLoader`.

- **`HomePage` → `homeLoader`** — picks the initial board (URL param, existing IDB sets, or default OBZ) and redirects. Page file no longer exists in PR 2.
- **`BoardSetRootRedirect` → `boardSetRootLoader`** — resolves a set's root board and redirects, or throws 404/422. Page file no longer exists in PR 2.
- **`useLoadBoard` → `boardLoader`** — IDB read + asset hydration + URL creation. The object URL registry is held at **module scope**, not in React state — `previousRegistry?.revokeAll()` runs at the start of each loader call, sidestepping React 19 StrictMode's dev-mode effect-cleanup double-invoke that would otherwise revoke URLs the component is still rendering.
- **Route Module shape for all three lazy pages** — every `lazy:` line is a plain `import()`, no per-page adapter.
- **Per-route error boundaries** — `RootErrorBoundary`, `BoardSetErrorBoundary`, `BoardErrorBoundary` inline in `app-routes.tsx`. Preserves app shell on partial failures.
- **`ScrollRestoration` in `AppShell`** — single instance at the root layout.

A separate PR will follow that deletes the now-dead files (`home-page.tsx`, `board-set-root-redirect.tsx`, `use-load-board.ts`, `use-board.ts`, `async-boundary.tsx`).

## Test plan

- [x] `tsc -b` clean
- [x] `npm run lint` clean
- [x] `npm test` — 322 passing (10 new + 312 existing)
- [ ] Manual dev walkthrough (clear IDB):
  - [ ] `/` cold start → root `HydrateFallback` → default OBZ download → board renders
  - [ ] `/` with existing IDB → redirect → board renders
  - [ ] `/?board=<url>` → import + redirect
  - [ ] Direct refresh on `/sets/:setId/boards/:boardId` → board renders, no flicker
  - [ ] **StrictMode dev: images load and stay loaded** (no broken-image flash on simulated remount)
  - [ ] Back/forward across two boards → no orphaned blob URLs in DevTools Memory
  - [ ] Language switch on a board → spinner during translation, then translated, no image flicker
  - [ ] `/sets/<deleted-id>` → `BoardSetErrorBoundary` 404, app shell preserved
  - [ ] `/sets/<good>/boards/<deleted>` → `BoardErrorBoundary` 404, app shell preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)