### PR TITLE
refactor: split storage queries from router loaders

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -48,4 +48,10 @@ export default defineConfig([
       curly: ["error"],
     },
   },
+  {
+    files: ["src/app/loaders/**/*-loader.ts"],
+    rules: {
+      "@typescript-eslint/only-throw-error": "off",
+    },
+  },
 ]);

--- a/src/app/app-routes.tsx
+++ b/src/app/app-routes.tsx
@@ -1,7 +1,7 @@
 import { AppShell } from "@app/layouts/app-shell";
-import { boardSetRootLoader } from "@app/loaders/board-set-root-loader";
-import { homeLoader } from "@app/loaders/home-loader";
-import { boardLoader } from "@features/board";
+import { boardLoader } from "@app/loaders/board-loader";
+import { boardSetIndexLoader } from "@app/loaders/board-set-index-loader";
+import { rootIndexLoader } from "@app/loaders/root-index-loader";
 import Button from "@mui/material/Button";
 import { ErrorState } from "@shared/components/error-state";
 import { LoadingState } from "@shared/components/loading-state";
@@ -27,11 +27,11 @@ const router = createBrowserRouter([
     ErrorBoundary: RouteErrorBoundary,
     HydrateFallback: LoadingState,
     children: [
-      { index: true, loader: homeLoader },
+      { index: true, loader: rootIndexLoader },
       {
         path: "sets/:setId",
         children: [
-          { index: true, loader: boardSetRootLoader },
+          { index: true, loader: boardSetIndexLoader },
           {
             path: "boards/:boardId",
             loader: boardLoader,

--- a/src/app/loaders/board-loader.ts
+++ b/src/app/loaders/board-loader.ts
@@ -1,0 +1,19 @@
+import { BoardNotFoundError, loadBoard, type Board } from "@features/board";
+import { data, type LoaderFunctionArgs } from "react-router";
+
+export async function boardLoader({
+  params,
+  request,
+}: LoaderFunctionArgs): Promise<Board> {
+  const setId = params.setId!;
+  const boardId = params.boardId!;
+
+  try {
+    return await loadBoard(setId, boardId, request.signal);
+  } catch (err) {
+    if (err instanceof BoardNotFoundError) {
+      throw data("Board not found", { status: 404 });
+    }
+    throw err;
+  }
+}

--- a/src/app/loaders/board-set-index-loader.test.ts
+++ b/src/app/loaders/board-set-index-loader.test.ts
@@ -1,17 +1,17 @@
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import type { LoaderFunctionArgs } from "react-router";
 import {
   resetBoardsDB,
   seedBoardSets,
 } from "@features/board/storage/test-helpers";
-import { boardSetRootLoader } from "./board-set-root-loader";
+import type { LoaderFunctionArgs } from "react-router";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { boardSetIndexLoader } from "./board-set-index-loader";
 
 function callLoader(setId: string): Promise<Response> {
   const args = {
     request: new Request("http://localhost/"),
     params: { setId },
   } as unknown as LoaderFunctionArgs;
-  return boardSetRootLoader(args);
+  return boardSetIndexLoader(args);
 }
 
 async function expectThrown(promise: Promise<unknown>): Promise<unknown> {
@@ -34,7 +34,7 @@ function expectThrownStatus(error: unknown, status: number): void {
   expect(init?.status).toBe(status);
 }
 
-describe("boardSetRootLoader", () => {
+describe("boardSetIndexLoader", () => {
   beforeEach(async () => {
     await resetBoardsDB();
   });

--- a/src/app/loaders/board-set-index-loader.ts
+++ b/src/app/loaders/board-set-index-loader.ts
@@ -1,4 +1,4 @@
-import { getBoardSets } from "@features/board";
+import { getBoardSet } from "@features/board";
 import {
   data,
   generatePath,
@@ -6,21 +6,16 @@ import {
   type LoaderFunctionArgs,
 } from "react-router";
 
-export async function boardSetRootLoader({
+export async function boardSetIndexLoader({
   params,
 }: LoaderFunctionArgs): Promise<Response> {
   const setId = params.setId ?? "";
-  const sets = await getBoardSets();
-  const set = sets.find((s) => s.setId === setId);
+  const set = await getBoardSet(setId);
 
   if (!set) {
-    // React Router catches thrown `data()` and routes it to ErrorBoundary as
-    // a route error response — the v7-canonical way to signal an expected 4xx.
-    // eslint-disable-next-line @typescript-eslint/only-throw-error
     throw data("Board set not found", { status: 404 });
   }
   if (!set.rootBoardId) {
-    // eslint-disable-next-line @typescript-eslint/only-throw-error
     throw data("Board set incomplete", { status: 422 });
   }
 

--- a/src/app/loaders/root-index-loader.test.ts
+++ b/src/app/loaders/root-index-loader.test.ts
@@ -6,7 +6,7 @@ import {
   resetBoardsDB,
   seedBoardSets,
 } from "@features/board/storage/test-helpers";
-import { homeLoader } from "./home-loader";
+import { rootIndexLoader } from "./root-index-loader";
 
 const FIXTURE_BOARD_URL = "/src/shared/testing/sample-boards/lots_of_stuff.obz";
 const DEFAULT_BOARD_PATH = "/quick-core-24.obz";
@@ -16,10 +16,10 @@ function callLoader(searchParams = ""): Promise<Response> {
     request: new Request(`http://localhost/${searchParams}`),
     params: {},
   } as unknown as LoaderFunctionArgs;
-  return homeLoader(args);
+  return rootIndexLoader(args);
 }
 
-describe("homeLoader", () => {
+describe("rootIndexLoader", () => {
   beforeEach(async () => {
     await resetBoardsDB();
     // resetBoardsDB clears IDB but the board-sets-store keeps its cached

--- a/src/app/loaders/root-index-loader.ts
+++ b/src/app/loaders/root-index-loader.ts
@@ -18,7 +18,7 @@ async function resolveInitialBoard(boardUrl: string | null): Promise<string> {
   return generatePath("/sets/:setId/boards/:boardId", { setId, boardId });
 }
 
-export async function homeLoader({
+export async function rootIndexLoader({
   request,
 }: LoaderFunctionArgs): Promise<Response> {
   const boardUrl = new URL(request.url).searchParams.get("board");

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -3,13 +3,14 @@ export { BoardSetDeleteDialog } from "./library/board-set-delete-dialog";
 export { BoardSetInfoDialog } from "./library/board-set-info-dialog";
 export { BoardSetList } from "./library/board-set-list";
 export type { BoardRouteParams } from "./navigation/use-board-navigation";
-export { boardLoader, type BoardLoaderData } from "./storage/board-loader";
 export {
   getBoardSets,
   importBoardFromUrl,
   removeBoardSet,
 } from "./storage/board-sets-store";
 export type { BoardSetRecord } from "./storage/boards-db";
+export { BoardNotFoundError, getBoardSet, loadBoard } from "./storage/queries";
 export { useBoardSets } from "./storage/use-board-sets";
 export { useImportBoardFiles } from "./storage/use-import-board-files";
 export { useCustomInstructions } from "./suggestions/use-custom-instructions";
+export type { Board } from "./types";

--- a/src/features/board/storage/boards-db.ts
+++ b/src/features/board/storage/boards-db.ts
@@ -159,6 +159,14 @@ export async function upsertBoardSet(
   await tx.done;
 }
 
+export async function getBoardSet(
+  db: BoardsDB,
+  setId: string,
+): Promise<BoardSetRecord | undefined> {
+  validateId(setId, "setId");
+  return db.get("boardSets", setId);
+}
+
 export async function listBoardSets(db: BoardsDB): Promise<BoardSetRecord[]> {
   const tx = db.transaction("boardSets", "readonly");
   const index = tx.store.index("byUpdatedAt");

--- a/src/features/board/storage/queries.test.ts
+++ b/src/features/board/storage/queries.test.ts
@@ -1,7 +1,5 @@
 import type { OBFBoard } from "open-board-format";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import type { LoaderFunctionArgs } from "react-router";
-import { boardLoader, type BoardLoaderData } from "./board-loader";
 import { invalidateBoardSets } from "./board-sets-store";
 import {
   putAssets,
@@ -9,6 +7,7 @@ import {
   upsertBoardSet,
   withBoardsDB,
 } from "./boards-db";
+import { BoardNotFoundError, loadBoard } from "./queries";
 import { resetBoardsDB } from "./test-helpers";
 
 const SET_ID = "loader-test-set";
@@ -17,9 +16,9 @@ const IMAGE_PATH = "images/test.png";
 const REAL_PNG_URL = "/pwa-192x192.png";
 
 // Seed a minimal board with one path-based image, using a real PNG blob so
-// the loader's hydration produces an Image-loadable blob URL. Going direct to
-// the storage layer (vs. importBoardFiles) keeps the test independent of OBZ
-// fixture shape — the only thing under test here is boardLoader's behavior.
+// hydration produces an Image-loadable blob URL. Going direct to the storage
+// layer (vs. importBoardFiles) keeps the test independent of OBZ fixture
+// shape — the only thing under test here is loadBoard's behavior.
 async function seedTestBoard(): Promise<void> {
   const pngResponse = await fetch(REAL_PNG_URL);
   if (!pngResponse.ok) {
@@ -53,31 +52,13 @@ async function seedTestBoard(): Promise<void> {
   await invalidateBoardSets();
 }
 
-function callLoader(setId: string, boardId: string): Promise<BoardLoaderData> {
-  const args = {
-    request: new Request("http://localhost/"),
-    params: { setId, boardId },
-  } as unknown as LoaderFunctionArgs;
-  return boardLoader(args);
-}
-
 async function expectThrown(promise: Promise<unknown>): Promise<unknown> {
   try {
     await promise;
   } catch (err) {
     return err;
   }
-  throw new Error("Expected loader to throw, but it resolved");
-}
-
-// `throw data(...)` produces a DataWithResponseInit instance — the router
-// wraps it into an ErrorResponse only at the boundary. Check the shape
-// directly when calling loaders straight.
-function expectThrownStatus(error: unknown, status: number): void {
-  expect(error).toBeTruthy();
-  expect(error).toHaveProperty("init");
-  const init = (error as { init: ResponseInit | null }).init;
-  expect(init?.status).toBe(status);
+  throw new Error("Expected loadBoard to throw, but it resolved");
 }
 
 // A blob URL is "alive" while its registry hasn't revoked it. Loading it as
@@ -97,7 +78,7 @@ function isObjectUrlAlive(url: string): Promise<boolean> {
   });
 }
 
-describe("boardLoader", () => {
+describe("loadBoard", () => {
   beforeEach(async () => {
     await resetBoardsDB();
     await invalidateBoardSets();
@@ -110,48 +91,47 @@ describe("boardLoader", () => {
   test("returns a hydrated board on the happy path", async () => {
     await seedTestBoard();
 
-    const result = await callLoader(SET_ID, BOARD_ID);
+    const board = await loadBoard(SET_ID, BOARD_ID);
 
-    expect(result.setId).toBe(SET_ID);
-    expect(result.board.id).toBe(BOARD_ID);
+    expect(board.id).toBe(BOARD_ID);
 
-    const imageSrc = result.board.buttons[0].imageSrc;
+    const imageSrc = board.buttons[0].imageSrc;
     expect(imageSrc).toBeDefined();
     expect(imageSrc!.startsWith("blob:")).toBe(true);
     expect(await isObjectUrlAlive(imageSrc!)).toBe(true);
   });
 
-  test("throws 404 when the board is not in IDB", async () => {
+  test("throws BoardNotFoundError when the board is not in IDB", async () => {
     await seedTestBoard();
 
-    const error = await expectThrown(callLoader(SET_ID, "missing-board"));
+    const error = await expectThrown(loadBoard(SET_ID, "missing-board"));
 
-    expectThrownStatus(error, 404);
+    expect(error).toBeInstanceOf(BoardNotFoundError);
   });
 
-  test("revokes the previous registry on the next loader run", async () => {
+  test("revokes the previous registry on the next loadBoard call", async () => {
     await seedTestBoard();
 
-    const first = await callLoader(SET_ID, BOARD_ID);
-    const firstUrl = first.board.buttons[0].imageSrc;
+    const first = await loadBoard(SET_ID, BOARD_ID);
+    const firstUrl = first.buttons[0].imageSrc;
     expect(firstUrl).toBeDefined();
     expect(await isObjectUrlAlive(firstUrl!)).toBe(true);
 
-    const second = await callLoader(SET_ID, BOARD_ID);
-    const secondUrl = second.board.buttons[0].imageSrc;
+    const second = await loadBoard(SET_ID, BOARD_ID);
+    const secondUrl = second.buttons[0].imageSrc;
     expect(secondUrl).toBeDefined();
 
     expect(await isObjectUrlAlive(firstUrl!)).toBe(false);
     expect(await isObjectUrlAlive(secondUrl!)).toBe(true);
   });
 
-  test("a 404 does not poison the module state for a later happy path", async () => {
+  test("a missing-board error does not poison module state for a later success", async () => {
     await seedTestBoard();
 
-    await expectThrown(callLoader(SET_ID, "missing-board"));
+    await expectThrown(loadBoard(SET_ID, "missing-board"));
 
-    const result = await callLoader(SET_ID, BOARD_ID);
-    const url = result.board.buttons[0].imageSrc;
+    const board = await loadBoard(SET_ID, BOARD_ID);
+    const url = board.buttons[0].imageSrc;
 
     expect(url).toBeDefined();
     expect(await isObjectUrlAlive(url!)).toBe(true);

--- a/src/features/board/storage/queries.ts
+++ b/src/features/board/storage/queries.ts
@@ -3,32 +3,40 @@ import {
   type ObjectUrlRegistry,
 } from "@shared/utils/object-url";
 import type { OBFBoard, OBFMedia } from "open-board-format";
-import { data, type LoaderFunctionArgs } from "react-router";
 import { obfToBoard } from "../obf/mapper";
 import type { Board } from "../types";
 import {
   getAssetBlob,
   getBoard,
+  getBoardSet as dbGetBoardSet,
   withBoardsDB,
+  type BoardSetRecord,
   type BoardsDB,
 } from "./boards-db";
 
-export interface BoardLoaderData {
-  setId: string;
-  board: Board;
+export class BoardNotFoundError extends Error {
+  constructor(setId: string, boardId: string) {
+    super(`Board not found: ${setId}/${boardId}`);
+    this.name = "BoardNotFoundError";
+  }
 }
 
-// Revoke on the next loader run, not on unmount — StrictMode double-invokes
-// effect cleanups and would revoke URLs still in use.
+export async function getBoardSet(
+  setId: string,
+): Promise<BoardSetRecord | undefined> {
+  return withBoardsDB((db) => dbGetBoardSet(db, setId));
+}
+
+// Single concurrent caller assumed — the only consumer is boardLoader.
+// Revoke on the next call rather than from the caller: the consumer can't
+// know when its URLs are safe to release; the next load defines that boundary.
 let previousRegistry: ObjectUrlRegistry | null = null;
 
-export async function boardLoader({
-  params,
-  request,
-}: LoaderFunctionArgs): Promise<BoardLoaderData> {
-  const setId = params.setId ?? "";
-  const boardId = params.boardId ?? "";
-
+export async function loadBoard(
+  setId: string,
+  boardId: string,
+  signal?: AbortSignal,
+): Promise<Board> {
   const registry = createObjectUrlRegistry();
   try {
     const board = await withBoardsDB(async (db) => {
@@ -38,7 +46,7 @@ export async function boardLoader({
     });
 
     // Don't promote a superseded registry — it would orphan the live one.
-    if (request.signal.aborted) {
+    if (signal?.aborted) {
       registry.revokeAll();
       throw new DOMException("Aborted", "AbortError");
     }
@@ -47,13 +55,9 @@ export async function boardLoader({
     previousRegistry = registry;
     previous?.revokeAll();
 
-    return { setId, board };
+    return board;
   } catch (err) {
     registry.revokeAll();
-    if (err instanceof Error && err.message.startsWith("Board not found")) {
-      // eslint-disable-next-line @typescript-eslint/only-throw-error
-      throw data("Board not found", { status: 404 });
-    }
     throw err;
   }
 }
@@ -65,7 +69,7 @@ async function fetchOBFBoard(
 ): Promise<OBFBoard> {
   const record = await getBoard(db, setId, boardId);
   if (!record) {
-    throw new Error(`Board not found: ${setId}/${boardId}`);
+    throw new BoardNotFoundError(setId, boardId);
   }
   return record.obf;
 }

--- a/src/pages/board-page.tsx
+++ b/src/pages/board-page.tsx
@@ -1,17 +1,19 @@
-import { Title } from "@app/title";
 import { useDeclareAppHeaderTitle } from "@app/layouts/app-header-title";
-import { BoardViewer, type BoardLoaderData } from "@features/board";
+import { Title } from "@app/title";
+import {
+  BoardViewer,
+  type Board,
+  type BoardRouteParams,
+} from "@features/board";
 import { useBoardTranslation } from "@features/board/use-board-translation";
 import { LoadingState } from "@shared/components/loading-state";
-import { useLoaderData } from "react-router";
+import { useLoaderData, useParams } from "react-router";
 
 export const Component = function BoardPage() {
-  const { setId, board } = useLoaderData<BoardLoaderData>();
-  const { translatedBoard } = useBoardTranslation({ setId, board });
+  const board = useLoaderData<Board>();
+  const { setId } = useParams<BoardRouteParams>();
+  const { translatedBoard } = useBoardTranslation({ setId: setId!, board });
 
-  // Hooks must run unconditionally — keep the title declaration above the
-  // early return. The untranslated name carries the header until translation
-  // settles, so it never flickers blank.
   useDeclareAppHeaderTitle(translatedBoard?.name ?? board.name);
 
   if (!translatedBoard) {


### PR DESCRIPTION
## Summary
- Decouples board storage from `react-router`: extracts `loadBoard` / `getBoardSet` into `features/board/storage/queries.ts` (no router imports). Router glue moves to a thin `src/app/loaders/board-loader.ts`.
- Replaces `err.message.startsWith("Board not found")` with a typed `BoardNotFoundError`.
- Renames `homeLoader` → `rootIndexLoader` and `boardSetRootLoader` → `boardSetIndexLoader` to match React Router v7 index-route idiom.
- Swaps `getBoardSets().find(...)` for a direct IDB `get(setId)` in the set-index loader.
- Polish: drops defensive `?? ""` param defaults (route guarantees them), fixes a stale StrictMode comment on `previousRegistry`, scopes the `only-throw-error` exception to loader files instead of inline disable comments.

## Test plan
- [x] `npm run lint` clean on changed files
- [x] `npx tsc --noEmit` clean
- [x] `vitest run` — 10/10 affected tests pass (queries, root-index-loader, board-set-index-loader)
- [ ] Smoke: navigate home → set → board, refresh on a deep link, hit a missing-board URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)