### PR TITLE
refactor: extract importBoardFromUrl into its own module

### DIFF
--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -4,12 +4,9 @@ export { BoardSetInfoDialog } from "./library/board-set-info-dialog";
 export { BoardSetList } from "./library/board-set-list";
 export type { BoardRouteParams } from "./navigation/use-board-navigation";
 export { boardPath, boardSetPath } from "./paths";
-export {
-  getBoardSets,
-  importBoardFromUrl,
-  removeBoardSet,
-} from "./storage/board-sets-store";
+export { getBoardSets, removeBoardSet } from "./storage/board-sets-store";
 export type { BoardSetRecord } from "./storage/boards-db";
+export { importBoardFromUrl } from "./storage/import-from-url";
 export { BoardNotFoundError, getBoardSet, loadBoard } from "./storage/queries";
 export { useBoardSets } from "./storage/use-board-sets";
 export { useImportBoardFiles } from "./storage/use-import-board-files";

--- a/src/features/board/storage/board-sets-store.ts
+++ b/src/features/board/storage/board-sets-store.ts
@@ -88,25 +88,6 @@ export async function importBoardFiles(
   return results;
 }
 
-export async function importBoardFromUrl(url: string): Promise<ImportResult> {
-  const response = await fetch(url);
-
-  if (!response.ok) {
-    throw new Error(`Failed to fetch board: HTTP ${response.status}`);
-  }
-
-  const blob = await response.blob();
-  const pathname = new URL(url, window.location.origin).pathname;
-  const filename = pathname.split("/").at(-1) ?? "board.obz";
-
-  const file = new File([blob], filename, {
-    type: blob.type || "application/octet-stream",
-  });
-
-  const [result] = await importBoardFiles(file);
-  return result;
-}
-
 export async function removeBoardSet(setId: string): Promise<void> {
   await withBoardsDB((db) => deleteBoardSet(db, setId));
   await reloadAndBroadcast();

--- a/src/features/board/storage/import-from-url.ts
+++ b/src/features/board/storage/import-from-url.ts
@@ -1,0 +1,21 @@
+import type { ImportResult } from "./board-import";
+import { importBoardFiles } from "./board-sets-store";
+
+export async function importBoardFromUrl(url: string): Promise<ImportResult> {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch board: HTTP ${response.status}`);
+  }
+
+  const blob = await response.blob();
+  const pathname = new URL(url, window.location.origin).pathname;
+  const filename = pathname.split("/").at(-1) ?? "board.obz";
+
+  const file = new File([blob], filename, {
+    type: blob.type || "application/octet-stream",
+  });
+
+  const [result] = await importBoardFiles(file);
+  return result;
+}


### PR DESCRIPTION
## Summary
- Move `importBoardFromUrl` out of `board-sets-store.ts` into a dedicated `storage/import-from-url.ts`
- `board-sets-store` now contains only external-store state + DB CRUD; the network-fetch utility was the outlier
- Public API surface unchanged — the `@features/board` barrel re-exports the function from its new location

## Test plan
- [ ] App boots and the root index loader still imports a default board on first launch
- [ ] `npm run lint` / `npm run typecheck` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)