### PR TITLE
feat: scope route error boundary to keep AppShell visible

### DIFF
--- a/src/app/app-routes.tsx
+++ b/src/app/app-routes.tsx
@@ -5,13 +5,24 @@ import { rootIndexLoader } from "@app/loaders/root-index-loader";
 import Button from "@mui/material/Button";
 import { ErrorState } from "@shared/components/error-state";
 import { LoadingState } from "@shared/components/loading-state";
-import { createBrowserRouter, Link } from "react-router";
+import {
+  createBrowserRouter,
+  isRouteErrorResponse,
+  Link,
+  useRouteError,
+} from "react-router";
 import { RouterProvider } from "react-router/dom";
 
 function RouteErrorBoundary() {
+  const error = useRouteError();
+  const title =
+    isRouteErrorResponse(error) && typeof error.data === "string"
+      ? error.data
+      : "Something went wrong";
+
   return (
     <ErrorState
-      title="Something went wrong"
+      title={title}
       action={
         <Button component={Link} to="/" variant="contained">
           Go home
@@ -24,23 +35,27 @@ function RouteErrorBoundary() {
 const router = createBrowserRouter([
   {
     Component: AppShell,
-    ErrorBoundary: RouteErrorBoundary,
     HydrateFallback: LoadingState,
     children: [
-      { index: true, loader: rootIndexLoader },
       {
-        path: "sets/:setId",
+        ErrorBoundary: RouteErrorBoundary,
         children: [
-          { index: true, loader: boardSetIndexLoader },
+          { index: true, loader: rootIndexLoader },
           {
-            path: "boards/:boardId",
-            loader: boardLoader,
-            lazy: async () => import("@pages/board-page"),
+            path: "sets/:setId",
+            children: [
+              { index: true, loader: boardSetIndexLoader },
+              {
+                path: "boards/:boardId",
+                loader: boardLoader,
+                lazy: async () => import("@pages/board-page"),
+              },
+            ],
           },
+          { path: "library", lazy: async () => import("@pages/library-page") },
+          { path: "about", lazy: async () => import("@pages/about-page") },
         ],
       },
-      { path: "library", lazy: async () => import("@pages/library-page") },
-      { path: "about", lazy: async () => import("@pages/about-page") },
     ],
   },
 ]);


### PR DESCRIPTION
## Summary
- Wrap child routes in a pathless layout route that owns the single `ErrorBoundary`, so page errors render inside `AppShell`'s `<Outlet />` instead of blanking out header + drawers.
- Drop the root `ErrorBoundary` — `AppShell` render bugs now fall through to React Router's default UI with the real stack visible (don't mask bugs).
- Read `useRouteError` + `isRouteErrorResponse` so the title comes from the `data()` payload thrown by loaders (404 "Board not found", 422 "Board set incomplete"). Falls back to "Something went wrong" otherwise.

## Test plan
- [ ] Navigate to `/sets/does-not-exist/boards/anything` → header + menu stay visible, main area shows "Board not found" with "Go home" button.
- [ ] Navigate to a board set with no `rootBoardId` via `/sets/:setId` → shell stays, main area shows "Board set incomplete".
- [ ] `/library` and `/about` render normally (no regression from the pathless wrapper).
- [ ] Temporarily throw in `AppShell`'s render → React Router's default error UI renders with the raw stack (intentional: bugs stay loud).

🤖 Generated with [Claude Code](https://claude.com/claude-code)