### PR TITLE
refactor: remove page fade transition from AppShell

### DIFF
--- a/src/app/layouts/app-shell.tsx
+++ b/src/app/layouts/app-shell.tsx
@@ -1,33 +1,16 @@
+import { AppHeader } from "@app/layouts/app-header";
 import { MenuDrawer } from "@app/menu/menu-drawer";
 import { OnboardingDialog } from "@app/onboarding/onboarding-dialog";
 import { useOnboarding } from "@app/onboarding/use-onboarding";
 import { SettingsDrawer } from "@app/settings/settings-drawer";
-import { AppHeader } from "@app/layouts/app-header";
 import Box from "@mui/material/Box";
-import Fade from "@mui/material/Fade";
-import useMediaQuery from "@mui/material/useMediaQuery";
 import { useState } from "react";
-import { Outlet, ScrollRestoration, useLocation } from "react-router";
-
-const FADE_DURATION_MS = 400;
-
-// Collapse all in-board navigation to one key so switching between boards
-// does not re-trigger the page fade.
-function getFadeKey(pathname: string): string {
-  if (pathname.startsWith("/sets/")) {
-    return "/sets";
-  }
-  return pathname;
-}
+import { Outlet, ScrollRestoration } from "react-router";
 
 export function AppShell() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const onboarding = useOnboarding();
-  const location = useLocation();
-  const prefersReducedMotion = useMediaQuery(
-    "(prefers-reduced-motion: reduce)",
-  );
 
   return (
     <Box sx={{ height: "100svh", display: "flex", flexDirection: "column" }}>
@@ -38,15 +21,9 @@ export function AppShell() {
         onSettingsClick={() => setIsSettingsOpen(true)}
       />
 
-      <Fade
-        key={getFadeKey(location.pathname)}
-        in
-        timeout={prefersReducedMotion ? 0 : FADE_DURATION_MS}
-      >
-        <Box component="main" sx={{ flexGrow: 1, overflow: "auto" }}>
-          <Outlet />
-        </Box>
-      </Fade>
+      <Box component="main" sx={{ flexGrow: 1, overflow: "auto" }}>
+        <Outlet />
+      </Box>
 
       <MenuDrawer open={isMenuOpen} onClose={() => setIsMenuOpen(false)} />
 


### PR DESCRIPTION
## Summary
- Drop the `Fade` wrapper around `<Outlet />` in `AppShell` along with its `getFadeKey`, `useLocation`, and reduced-motion plumbing.

## Test plan
- [ ] Navigate between routes and boards; verify no visual regressions.
- [ ] Confirm prefers-reduced-motion users see no change in behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)