### PR TITLE
feat: add Paraglide JS for UI i18n

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ coverage
 *.njsproj
 *.sln
 *.sw?
+
+# Paraglide compiler output
+src/paraglide/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   "recommendations": [
     "dbaeumer.vscode-eslint",
     "vitest.explorer",
-    "esbenp.prettier-vscode"
+    "esbenp.prettier-vscode",
+    "inlang.vs-code-extension"
   ]
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,7 +10,7 @@ import globals from "globals";
 import tseslint from "typescript-eslint";
 
 export default defineConfig([
-  globalIgnores(["dist", "coverage"]),
+  globalIgnores(["dist", "coverage", "src/paraglide"]),
   {
     files: ["**/*.{ts,tsx}"],
     extends: [

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://inlang.com/schema/inlang-message-format",
+  "example_message": "Hello world",
+  "error_generic_title": "Something went wrong"
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-  "error_generic_title": "Something went wrong"
+  "errorGenericTitle": "Something went wrong"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,5 +1,4 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-  "example_message": "Hello world",
   "error_generic_title": "Something went wrong"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       "devDependencies": {
         "@babel/core": "^7.29.0",
         "@eslint/js": "^10.0.1",
+        "@inlang/paraglide-js": "^2.18.1",
         "@rolldown/plugin-babel": "^0.2.3",
         "@types/babel__core": "^7.20.5",
         "@types/dom-chromium-ai": "^0.0.16",
@@ -2134,6 +2135,70 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inlang/paraglide-js": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/@inlang/paraglide-js/-/paraglide-js-2.18.1.tgz",
+      "integrity": "sha512-YzIrJ34KbsJwzvVKBzcBEgp4AqmhNYD1EF2pOV+g87L024XTFmcmikI4/NMfb63H9zJ6UeEPTOmEK7Nzu/4E2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inlang/recommend-sherlock": "^0.2.1",
+        "@inlang/sdk": "^2.9.3",
+        "commander": "11.1.0",
+        "consola": "3.4.0",
+        "json5": "2.2.3",
+        "unplugin": "^2.1.2",
+        "urlpattern-polyfill": "^10.0.0"
+      },
+      "bin": {
+        "paraglide-js": "bin/run.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inlang/paraglide-js/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@inlang/recommend-sherlock": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@inlang/recommend-sherlock/-/recommend-sherlock-0.2.1.tgz",
+      "integrity": "sha512-ckv8HvHy/iTqaVAEKrr+gnl+p3XFNwe5D2+6w6wJk2ORV2XkcRkKOJ/XsTUJbPSiyi4PI+p+T3bqbmNx/rDUlg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "comment-json": "^4.2.3"
+      }
+    },
+    "node_modules/@inlang/sdk": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/@inlang/sdk/-/sdk-2.9.3.tgz",
+      "integrity": "sha512-E/SxcSji8WIt4DqQG9APlOs6tVtJxrrOUS3dE4ho3pWRCLLIY0PIVzgNwSukuFT+m8LuJDFwpRY5VY3ryzyGWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lix-js/sdk": "0.4.10",
+        "@sinclair/typebox": "^0.31.17",
+        "kysely": "^0.28.12",
+        "sqlite-wasm-kysely": "0.3.0",
+        "uuid": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@internationalized/date": {
       "version": "3.12.1",
       "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.1.tgz",
@@ -2227,6 +2292,32 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lix-js/sdk": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/@lix-js/sdk/-/sdk-0.4.10.tgz",
+      "integrity": "sha512-0dMInAJK/67guTG5rRZaCEhvzC5cCXENOjaePA5AqMXrCE97kaY7SRor9e2vnoGsFIiGqXKlT0MCIoZj36G0gg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@lix-js/server-protocol-schema": "0.1.1",
+        "dedent": "1.5.1",
+        "human-id": "^4.1.1",
+        "js-sha256": "^0.11.0",
+        "kysely": "^0.28.12",
+        "sqlite-wasm-kysely": "0.3.0",
+        "uuid": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@lix-js/server-protocol-schema": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@lix-js/server-protocol-schema/-/server-protocol-schema-0.1.1.tgz",
+      "integrity": "sha512-jBeALB6prAbtr5q4vTuxnRZZv1M2rKe8iNqRQhFJ4Tv7150unEa0vKyz0hs8Gl3fUGsWaNJBh3J8++fpbrpRBQ==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "9.0.1",
@@ -3381,6 +3472,23 @@
         "win32"
       ]
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.31.28",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.31.28.tgz",
+      "integrity": "sha512-/s55Jujywdw/Jpan+vsy6JZs1z2ZTGxTmbZTPiuSL2wz9mfzA2gN1zzaqmvfi4pq+uOt7Du85fkiwv5ymW84aQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sqlite.org/sqlite-wasm": {
+      "version": "3.48.0-build4",
+      "resolved": "https://registry.npmjs.org/@sqlite.org/sqlite-wasm/-/sqlite-wasm-3.48.0-build4.tgz",
+      "integrity": "sha512-hI6twvUkzOmyGZhQMza1gpfqErZxXRw6JEsiVjUbo7tFanVD+8Oil0Ih3l2nGzHdxPI41zFmfUQG7GHqhciKZQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "sqlite-wasm": "bin/index.js"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -4157,6 +4265,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array-timsort": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
+      "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
@@ -4534,6 +4649,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/comment-json": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.6.2.tgz",
+      "integrity": "sha512-R2rze/hDX30uul4NZoIZ76ImSJLFxn/1/ZxtKC1L77y2X1k+yYu1joKbAtMA2Fg3hZrTOiw0I5mwVMo0cf250w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-timsort": "^1.0.3",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/common-tags": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
@@ -4550,6 +4679,16 @@
       "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.0.tgz",
+      "integrity": "sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -4717,6 +4856,21 @@
       },
       "peerDependenciesMeta": {
         "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+      "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
           "optional": true
         }
       }
@@ -5252,6 +5406,20 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/esquery": {
@@ -5920,6 +6088,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/human-id": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.1.3.tgz",
+      "integrity": "sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "human-id": "dist/cli.js"
+      }
+    },
     "node_modules/husky": {
       "version": "9.1.7",
       "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
@@ -6523,6 +6701,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/js-sha256": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.1.tgz",
+      "integrity": "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6612,6 +6797,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kysely": {
+      "version": "0.28.17",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.17.tgz",
+      "integrity": "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/leven": {
@@ -8357,6 +8552,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sqlite-wasm-kysely": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/sqlite-wasm-kysely/-/sqlite-wasm-kysely-0.3.0.tgz",
+      "integrity": "sha512-TzjBNv7KwRw6E3pdKdlRyZiTmUIE0UttT/Sl56MVwVARl/u5gp978KepazCJZewFUnlWHz9i3NQd4kOtP/Afdg==",
+      "dev": true,
+      "dependencies": {
+        "@sqlite.org/sqlite-wasm": "^3.48.0-build2"
+      },
+      "peerDependencies": {
+        "kysely": "*"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -8952,6 +9159,22 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unplugin": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "acorn": "^8.15.0",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
     "node_modules/upath": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
@@ -9004,6 +9227,13 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
+      "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -9011,6 +9241,20 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vite": {
@@ -9577,6 +9821,13 @@
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/whatwg-url": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@babel/core": "^7.29.0",
     "@eslint/js": "^10.0.1",
+    "@inlang/paraglide-js": "^2.18.1",
     "@rolldown/plugin-babel": "^0.2.3",
     "@types/babel__core": "^7.20.5",
     "@types/dom-chromium-ai": "^0.0.16",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "preview": "vite preview",
     "test": "vitest run",
     "coverage": "vitest run --coverage",
-    "prepare": "husky"
+    "prepare": "husky && paraglide-js compile --project ./project.inlang --outdir ./src/paraglide"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/project.inlang/settings.json
+++ b/project.inlang/settings.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://inlang.com/schema/project-settings",
+  "baseLocale": "en",
+  "locales": ["en"],
+  "modules": [
+    "https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@latest/dist/index.js"
+  ],
+  "plugin.inlang.messageFormat": {
+    "pathPattern": "./messages/{locale}.json"
+  }
+}

--- a/src/app/app-routes.tsx
+++ b/src/app/app-routes.tsx
@@ -12,13 +12,14 @@ import {
   useRouteError,
 } from "react-router";
 import { RouterProvider } from "react-router/dom";
+import { m } from "../paraglide/messages.js";
 
 function RouteErrorBoundary() {
   const error = useRouteError();
   const title =
     isRouteErrorResponse(error) && typeof error.data === "string"
       ? error.data
-      : "Something went wrong";
+      : m.error_generic_title();
 
   return (
     <ErrorState

--- a/src/app/app-routes.tsx
+++ b/src/app/app-routes.tsx
@@ -3,6 +3,7 @@ import { boardLoader } from "@app/loaders/board-loader";
 import { boardSetIndexLoader } from "@app/loaders/board-set-index-loader";
 import { rootIndexLoader } from "@app/loaders/root-index-loader";
 import Button from "@mui/material/Button";
+import { m } from "@paraglide/messages.js";
 import { ErrorState } from "@shared/components/error-state";
 import { LoadingState } from "@shared/components/loading-state";
 import {
@@ -12,14 +13,13 @@ import {
   useRouteError,
 } from "react-router";
 import { RouterProvider } from "react-router/dom";
-import { m } from "../paraglide/messages.js";
 
 function RouteErrorBoundary() {
   const error = useRouteError();
   const title =
     isRouteErrorResponse(error) && typeof error.data === "string"
       ? error.data
-      : m.error_generic_title();
+      : m.errorGenericTitle();
 
   return (
     <ErrorState

--- a/src/shared/language/language-provider.tsx
+++ b/src/shared/language/language-provider.tsx
@@ -1,12 +1,7 @@
 import { usePersistentState } from "@shared/hooks/use-persistent-state";
 import { setVoiceURI, useVoicesByLanguage } from "@shared/speech/speech-store";
-import {
-  getLanguageCode,
-  getNativeLanguageName,
-  getTextDirection,
-} from "@shared/utils/locale";
+import { getNativeLanguageName, getTextDirection } from "@shared/utils/locale";
 import { useEffect, type ReactNode } from "react";
-import { isLocale, setLocale } from "../../paraglide/runtime.js";
 import { LanguageContext, type LanguageContextValue } from "./language-context";
 
 export interface LanguageProviderProps {
@@ -30,9 +25,6 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
 
   const direction = getTextDirection(language);
 
-  const paraglideLocale = getLanguageCode(language);
-  const knownLocale = isLocale(paraglideLocale);
-
   const contextValue: LanguageContextValue = {
     languages,
     language,
@@ -53,17 +45,5 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
     document.documentElement.lang = language;
   }, [direction, language]);
 
-  useEffect(() => {
-    if (knownLocale) {
-      void setLocale(paraglideLocale, { reload: false });
-    }
-  }, [paraglideLocale, knownLocale]);
-
-  return (
-    <LanguageContext value={contextValue}>
-      <div key={paraglideLocale} style={{ display: "contents" }}>
-        {children}
-      </div>
-    </LanguageContext>
-  );
+  return <LanguageContext value={contextValue}>{children}</LanguageContext>;
 }

--- a/src/shared/language/language-provider.tsx
+++ b/src/shared/language/language-provider.tsx
@@ -1,8 +1,13 @@
 import { usePersistentState } from "@shared/hooks/use-persistent-state";
 import { setVoiceURI, useVoicesByLanguage } from "@shared/speech/speech-store";
+import {
+  getLanguageCode,
+  getNativeLanguageName,
+  getTextDirection,
+} from "@shared/utils/locale";
 import { useEffect, type ReactNode } from "react";
+import { isLocale, setLocale } from "../../paraglide/runtime.js";
 import { LanguageContext, type LanguageContextValue } from "./language-context";
-import { getNativeLanguageName, getTextDirection } from "@shared/utils/locale";
 
 export interface LanguageProviderProps {
   children: ReactNode;
@@ -25,6 +30,9 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
 
   const direction = getTextDirection(language);
 
+  const paraglideLocale = getLanguageCode(language);
+  const knownLocale = isLocale(paraglideLocale);
+
   const contextValue: LanguageContextValue = {
     languages,
     language,
@@ -45,5 +53,17 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
     document.documentElement.lang = language;
   }, [direction, language]);
 
-  return <LanguageContext value={contextValue}>{children}</LanguageContext>;
+  useEffect(() => {
+    if (knownLocale) {
+      void setLocale(paraglideLocale, { reload: false });
+    }
+  }, [paraglideLocale, knownLocale]);
+
+  return (
+    <LanguageContext value={contextValue}>
+      <div key={paraglideLocale} style={{ display: "contents" }}>
+        {children}
+      </div>
+    </LanguageContext>
+  );
 }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -7,6 +7,8 @@
     "module": "ESNext",
     "types": ["vite/client", "dom-chromium-ai"],
     "skipLibCheck": true,
+    "allowJs": true,
+    "checkJs": false,
 
     "paths": {
       "@app/*": ["./src/app/*"],

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -13,7 +13,8 @@
       "@app/*": ["./src/app/*"],
       "@features/*": ["./src/features/*"],
       "@shared/*": ["./src/shared/*"],
-      "@pages/*": ["./src/pages/*"]
+      "@pages/*": ["./src/pages/*"],
+      "@paraglide/*": ["./src/paraglide/*"]
     },
 
     /* Bundler mode */

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -8,7 +8,6 @@
     "types": ["vite/client", "dom-chromium-ai"],
     "skipLibCheck": true,
     "allowJs": true,
-    "checkJs": false,
 
     "paths": {
       "@app/*": ["./src/app/*"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -56,6 +56,7 @@ export default defineConfig({
       "@features": path.resolve(__dirname, "./src/features"),
       "@shared": path.resolve(__dirname, "./src/shared"),
       "@pages": path.resolve(__dirname, "./src/pages"),
+      "@paraglide": path.resolve(__dirname, "./src/paraglide"),
     },
   },
   optimizeDeps: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 /// <reference types="vitest/config" />
+import { paraglideVitePlugin } from "@inlang/paraglide-js";
 import babel from "@rolldown/plugin-babel";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import { playwright } from "@vitest/browser-playwright";
@@ -11,6 +12,11 @@ export default defineConfig({
   plugins: [
     react(),
     babel({ presets: [reactCompilerPreset()] }),
+    paraglideVitePlugin({
+      project: "./project.inlang",
+      outdir: "./src/paraglide",
+      strategy: ["baseLocale"],
+    }),
     VitePWA({
       registerType: "autoUpdate",
       includeAssets: ["board.svg", "apple-touch-icon-180x180.png"],


### PR DESCRIPTION
Closes #309

## Summary
- Wire up Paraglide JS (via `@inlang/paraglide-js` Vite plugin) for typed UI i18n; messages live in `messages/{locale}.json`
- Use the new `m.errorGenericTitle()` message in `RouteErrorBoundary` as the first call site
- Add `@paraglide/*` path alias (matched in `tsconfig.app.json` and `vite.config.ts`)

## Test plan
- [ ] App builds and loads without console errors
- [ ] Trigger a route error (or hit a bad route) and confirm the generic title renders
- [ ] `npm run lint` and `tsc` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)