### PR TITLE
fix: improve Hebrew UI translations

### DIFF
--- a/messages/he.json
+++ b/messages/he.json
@@ -59,7 +59,7 @@
   "speechVoicePreview": "שלום, זה הקול שלי!",
 
   "aiCustomInstructions": "הוראות מותאמות אישית",
-  "aiCustomInstructionsPlaceholder": "למשל: צינית, מנומסת.",
+  "aiCustomInstructionsPlaceholder": "למשל: ציני, מנומס.",
   "aiCustomInstructionsHelper": "התאם הצעות AI אישית",
   "aiBuiltInSupport": "תמיכת AI מובנית",
 
@@ -87,7 +87,7 @@
   "aboutViewSource": "צפה בקוד המקור ב-GitHub",
 
   "onboardingTagline": "תקשר בקלות ובאופן טבעי.",
-  "onboardingSmartRewritingTitle": "כתיבה חכמה",
+  "onboardingSmartRewritingTitle": "שכתוב חכם",
   "onboardingSmartRewritingDescription": "הפוך ביטויים קצרים למשפטים ברורים.",
   "onboardingTranslationTitle": "תרגום בזמן אמת",
   "onboardingTranslationDescription": "תרגם הודעות באופן מיידי.",


### PR DESCRIPTION
Improves Hebrew translation strings in `messages/he.json` to be more grammatically accurate and consistent with the rest of the application:

1. Updates `aiCustomInstructionsPlaceholder` to use masculine-singular forms to match other tone keys (`ציני, מנומס` instead of `צינית, מנומסת`).
2. Updates `onboardingSmartRewritingTitle` to use the accurate word for rewriting (`שכתוב חכם` instead of `כתיבה חכמה`).