### PR TITLE
feat: localize AI capability labels in settings

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/da.json
+++ b/messages/da.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/de.json
+++ b/messages/de.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/el.json
+++ b/messages/el.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/en.json
+++ b/messages/en.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/es.json
+++ b/messages/es.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/he.json
+++ b/messages/he.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "למשל: ציני, מנומס.",
   "aiCustomInstructionsHelper": "התאמה אישית של הצעות ה-AI",
   "aiBuiltInSupport": "תמיכת AI מובנית",
+  "aiFeatureProofreading": "הגהה",
+  "aiFeatureRewriting": "שכתוב",
+  "aiFeatureTranslation": "תרגום",
 
   "navBack": "חזור",
   "navHome": "לעמוד הבית",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/id.json
+++ b/messages/id.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/it.json
+++ b/messages/it.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/te.json
+++ b/messages/te.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/th.json
+++ b/messages/th.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -62,6 +62,9 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions",
   "aiBuiltInSupport": "Built-in AI Support",
+  "aiFeatureProofreading": "Proofreading",
+  "aiFeatureRewriting": "Rewriting",
+  "aiFeatureTranslation": "Translation",
 
   "navBack": "Go back",
   "navHome": "Go home",

--- a/src/app/settings/ai-settings.tsx
+++ b/src/app/settings/ai-settings.tsx
@@ -11,14 +11,26 @@ import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
 import { type BuiltInAIName, isSupported } from "@shared/built-in-ai";
 
-const AI_FEATURES = [
-  "Proofreader",
-  "Rewriter",
-  "Translator",
-] as const satisfies readonly BuiltInAIName[];
-
 export function AISettings() {
   const [sharedContext, setSharedContext] = useCustomInstructions();
+
+  const capabilities: {
+    apiName: BuiltInAIName;
+    title: string;
+  }[] = [
+    {
+      apiName: "Proofreader",
+      title: m.aiFeatureProofreading(),
+    },
+    {
+      apiName: "Rewriter",
+      title: m.aiFeatureRewriting(),
+    },
+    {
+      apiName: "Translator",
+      title: m.aiFeatureTranslation(),
+    },
+  ];
 
   return (
     <Stack spacing={3}>
@@ -43,16 +55,16 @@ export function AISettings() {
         </Typography>
 
         <List dense>
-          {AI_FEATURES.map((name) => (
-            <ListItem key={name}>
+          {capabilities.map(({ apiName, title }) => (
+            <ListItem key={apiName} sx={{ px: 0 }}>
               <ListItemIcon sx={{ minWidth: 36 }}>
-                {isSupported(name) ? (
+                {isSupported(apiName) ? (
                   <CheckCircleIcon color="success" fontSize="small" />
                 ) : (
                   <CancelIcon color="error" fontSize="small" />
                 )}
               </ListItemIcon>
-              <ListItemText primary={name} />
+              <ListItemText primary={title} />
             </ListItem>
           ))}
         </List>


### PR DESCRIPTION
## Summary
- Show translated descriptions (Proofreading/Rewriting/Translation) in the built-in AI capabilities list in [src/app/settings/ai-settings.tsx](src/app/settings/ai-settings.tsx) instead of raw API names. The typed `BuiltInAIName` constant still flows through code for `isSupported()` checks; only the visible label is localized.
- Adds `aiFeatureProofreading` / `aiFeatureRewriting` / `aiFeatureTranslation` keys to all 35 locale files — Hebrew translated (הגהה / שכתוב / תרגום), the other 33 locales seeded with English placeholders matching the convention used by the rest of the `ai*` keys in those files.

## Test plan
- [ ] Open Settings → AI section; verify the three capabilities now show "Proofreading", "Rewriting", "Translation" with their support icons
- [ ] Switch UI locale to Hebrew; verify the labels render as הגהה / שכתוב / תרגום
- [ ] Confirm `isSupported()` still receives the literal API names (`Proofreader` / `Rewriter` / `Translator`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)