### PR TITLE
refactor: wrap only proper nouns in links on About page

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/da.json
+++ b/messages/da.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/de.json
+++ b/messages/de.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/el.json
+++ b/messages/el.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/he.json
+++ b/messages/he.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "טעינת לוח...",
   "boardNotFound": "הלוח לא נמצא",
-
   "libraryLoading": "טעינת לוחות...",
   "libraryEmptyTitle": "הספרייה שלך ריקה",
   "libraryEmptyDescription": "כדי להתחיל, יש לייבא לוחות תקשורת.",
-
   "libraryImport": "ייבוא",
   "libraryImportBoards": "ייבוא לוחות",
   "libraryImportingBoard": "ייבוא לוח...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "הלוחות יובאו",
   "libraryImportFailedBoard": "ייבוא הלוח נכשל",
   "libraryImportFailedBoards": "ייבוא הלוחות נכשל",
-
   "libraryInfo": "פרטים",
   "libraryDelete": "מחיקה",
   "libraryCancel": "ביטול",
   "libraryClose": "סגירה",
-
   "libraryMoreOptions": "אפשרויות נוספות",
   "libraryMoreOptionsFor": "אפשרויות נוספות עבור {name}",
   "libraryByAuthor": "מאת {author}",
   "libraryGridDimensions": "רשת {rows}×{columns}",
-
   "libraryDeleteConfirmTitle": "למחוק את \"{name}\"?",
   "libraryDeleteIrreversible": "לא ניתן לבטל פעולה זו.",
   "libraryDeleted": "\"{name}\" נמחק",
   "libraryDeleteFailed": "מחיקת \"{name}\" נכשלה",
-
   "menuLabel": "תפריט",
   "menuOpen": "פתיחת התפריט",
   "menuHome": "בית",
   "menuLibrary": "ספרייה",
   "menuAbout": "אודות",
-
   "settingsTitle": "הגדרות",
   "settingsOpen": "פתיחת הגדרות",
   "settingsClose": "סגירת הגדרות",
-
   "themeLabel": "ערכת נושא",
   "themeSystem": "מערכת",
   "themeLight": "בהיר",
   "themeDark": "כהה",
-
   "languageLabel": "שפה",
   "languageDownloading": "הורדת שפה...",
   "languageDownloadProgress": "{progress}% הושלם...",
-
   "speechVoice": "קול",
   "speechRate": "קצב דיבור",
   "speechPitch": "גובה צליל",
   "speechVolume": "עוצמת שמע",
   "speechPreview": "השמעה",
   "speechVoicePreview": "שלום, זה הקול שלי!",
-
   "aiCustomInstructions": "הוראות מותאמות אישית",
   "aiCustomInstructionsPlaceholder": "למשל: ציני, מנומס.",
   "aiCustomInstructionsHelper": "התאמה אישית של הצעות ה-AI.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "הגהה",
   "aiFeatureRewriting": "שכתוב",
   "aiFeatureTranslation": "תרגום",
-
   "navBack": "חזרה",
   "navHome": "לעמוד הבית",
-
   "messageBackspace": "מחק",
   "messageBackspaceLongPressHint": "לחיצה ארוכה למחיקת ההודעה.",
   "messagePlay": "השמעת הודעה",
   "messageStop": "עצירה",
-
   "toneSelection": "בחירת סגנון",
   "toneDirect": "סגנון ישיר",
   "toneProfessional": "סגנון מקצועי",
   "toneFriendly": "סגנון ידידותי",
-
   "aboutHeading": "אודות",
   "aboutAppDescription": "{appName} מסייע לאנשים עם קשיי דיבור לתקשר בקלות ובאופן טבעי. האפליקציה משתמשת בבינה מלאכותית המופעלת ישירות מהמכשיר כדי לתקן את הדקדוק, להתאים את סגנון הניסוח ולתרגם הודעות – תוך שמירה מלאה על הפרטיות ועל מהירות התגובה.",
   "aboutAcknowledgmentsHeading": "תודות והכרה",
-  "aboutWinnerOfChallenge": "האפליקציה זכתה באתגר Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "היא מבוססת על פורמט Open Board",
+  "aboutWinnerOfChallengePrefix": "האפליקציה זכתה באתגר ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "היא מבוססת על ",
+  "aboutBuiltOnObfLink": "פורמט Open Board",
+  "aboutBuiltOnObfSuffix": " ",
   "aboutFeaturingQuickCore": "ומשלבת את אוצר המילים Quick Core 24 מבית ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "קוד פתוח",
   "aboutViewSource": "צפייה בקוד המקור ב-GitHub",
-
   "onboardingTagline": "לתקשר בקלות ובאופן טבעי.",
   "onboardingSmartRewritingTitle": "שכתוב חכם",
   "onboardingSmartRewritingDescription": "הפיכת ביטויים קצרים למשפטים מלאים וברורים.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "פרטיות מובנית",
   "onboardingPrivacyDescription": "עבודה מקומית על המכשיר, גם ללא חיבור לאינטרנט. המידע לא נשמר בענן.",
   "onboardingContinue": "המשך",
-
   "errorGenericTitle": "משהו השתבש",
   "errorGoHome": "חזרה לעמוד הבית",
   "errorBoardSetNotFound": "ערכת הלוחות לא נמצאה",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/id.json
+++ b/messages/id.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/it.json
+++ b/messages/it.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/te.json
+++ b/messages/te.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/th.json
+++ b/messages/th.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1,13 +1,10 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
-
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Your library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
-
   "libraryImport": "Import",
   "libraryImportBoards": "Import boards",
   "libraryImportingBoard": "Importing board...",
@@ -16,48 +13,39 @@
   "libraryImportedBoards": "Boards imported",
   "libraryImportFailedBoard": "Couldn't import board",
   "libraryImportFailedBoards": "Couldn't import boards",
-
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",
   "libraryClose": "Close",
-
   "libraryMoreOptions": "More options",
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} Grid",
-
   "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
   "libraryDeleteIrreversible": "This action cannot be undone.",
   "libraryDeleted": "\"{name}\" deleted",
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
-
   "menuLabel": "Menu",
   "menuOpen": "Open menu",
   "menuHome": "Home",
   "menuLibrary": "Library",
   "menuAbout": "About",
-
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",
-
   "themeLabel": "Theme",
   "themeSystem": "System",
   "themeLight": "Light",
   "themeDark": "Dark",
-
   "languageLabel": "Language",
   "languageDownloading": "Downloading language",
   "languageDownloadProgress": "{progress}% complete...",
-
   "speechVoice": "Voice",
   "speechRate": "Rate",
   "speechPitch": "Pitch",
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
-
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
@@ -65,30 +53,29 @@
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",
   "aiFeatureTranslation": "Translation",
-
   "navBack": "Go back",
   "navHome": "Go home",
-
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
   "messagePlay": "Play message",
   "messageStop": "Stop",
-
   "toneSelection": "Tone selection",
   "toneDirect": "Direct tone",
   "toneProfessional": "Professional tone",
   "toneFriendly": "Friendly tone",
-
   "aboutHeading": "About",
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages, keeping interactions private and fast.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
-  "aboutWinnerOfChallenge": "Winner of the Google Chrome Built-in AI Challenge 2025.",
-  "aboutBuiltOnObf": "Built on the Open Board Format.",
+  "aboutWinnerOfChallengePrefix": "Winner of the ",
+  "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
+  "aboutWinnerOfChallengeSuffix": ". ",
+  "aboutBuiltOnObfPrefix": "Built on the ",
+  "aboutBuiltOnObfLink": "Open Board Format",
+  "aboutBuiltOnObfSuffix": ". ",
   "aboutFeaturingQuickCore": "It features the Quick Core 24 vocabulary set by ",
   "aboutOpenAacLinkText": "OpenAAC",
   "aboutOpenSourceHeading": "Open source",
   "aboutViewSource": "View source code on GitHub",
-
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",
@@ -97,7 +84,6 @@
   "onboardingPrivacyTitle": "Private by design",
   "onboardingPrivacyDescription": "Works offline, on your device. No cloud.",
   "onboardingContinue": "Continue",
-
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardSetNotFound": "Board set not found",

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -39,22 +39,26 @@ export const Component = function AboutPage() {
               "& em": { fontStyle: "italic" },
             }}
           >
+            {m.aboutWinnerOfChallengePrefix()}
             <Link
               href="https://developer.chrome.com/blog/ai-challenge-winners-2025/"
               target="_blank"
               rel="noopener noreferrer"
               underline="hover"
             >
-              {m.aboutWinnerOfChallenge()}
-            </Link>{" "}
+              {m.aboutWinnerOfChallengeLink()}
+            </Link>
+            {m.aboutWinnerOfChallengeSuffix()}
+            {m.aboutBuiltOnObfPrefix()}
             <Link
               href="https://www.openboardformat.org/"
               target="_blank"
               rel="noopener noreferrer"
               underline="hover"
             >
-              {m.aboutBuiltOnObf()}
-            </Link>{" "}
+              {m.aboutBuiltOnObfLink()}
+            </Link>
+            {m.aboutBuiltOnObfSuffix()}
             {m.aboutFeaturingQuickCore()}
             <Link
               href="https://www.openaac.org"


### PR DESCRIPTION
Splits translation keys on the About page to render precise link wrappers around proper nouns only ('Google Chrome Built-in AI Challenge 2025' and 'Open Board Format'). Helper text like 'Winner of the ' and 'Built on the ' is kept as standard unlinked body text, resolving too-broad link wrapping feedback.