### PR TITLE
i18n: use English name for Open Board Format in Hebrew translation

### DIFF
--- a/messages/he.json
+++ b/messages/he.json
@@ -70,7 +70,7 @@
   "aboutWinnerOfChallengeLink": "Google Chrome Built-in AI Challenge 2025",
   "aboutWinnerOfChallengeSuffix": ". ",
   "aboutBuiltOnObfPrefix": "היא מבוססת על ",
-  "aboutBuiltOnObfLink": "פורמט Open Board",
+  "aboutBuiltOnObfLink": "Open Board Format",
   "aboutBuiltOnObfSuffix": " ",
   "aboutFeaturingQuickCore": "ומשלבת את אוצר המילים Quick Core 24 מבית ",
   "aboutOpenAacLinkText": "OpenAAC",


### PR DESCRIPTION
Refines the Hebrew translation for the OBF link text on the About page to display the exact English name 'Open Board Format' rather than the Hebrew transliteration 'פורמט Open Board', matching format naming best practices.