### PR TITLE
chore: post-language-cleanup follow-ups

### DIFF
--- a/src/app/loaders/board-loader.ts
+++ b/src/app/loaders/board-loader.ts
@@ -11,10 +11,10 @@ export async function boardLoader({
 
   try {
     return await loadBoard(setId, boardId, request.signal);
-  } catch (err) {
-    if (err instanceof BoardNotFoundError) {
+  } catch (error) {
+    if (error instanceof BoardNotFoundError) {
       throw data(m.boardNotFound(), { status: 404 });
     }
-    throw err;
+    throw error;
   }
 }

--- a/src/app/loaders/board-set-index-loader.test.ts
+++ b/src/app/loaders/board-set-index-loader.test.ts
@@ -17,8 +17,8 @@ function callLoader(setId: string): Promise<Response> {
 async function expectThrown(promise: Promise<unknown>): Promise<unknown> {
   try {
     await promise;
-  } catch (err) {
-    return err;
+  } catch (error) {
+    return error;
   }
   throw new Error("Expected loader to throw, but it resolved");
 }

--- a/src/features/board/storage/queries.test.ts
+++ b/src/features/board/storage/queries.test.ts
@@ -55,8 +55,8 @@ async function seedTestBoard(): Promise<void> {
 async function expectThrown(promise: Promise<unknown>): Promise<unknown> {
   try {
     await promise;
-  } catch (err) {
-    return err;
+  } catch (error) {
+    return error;
   }
   throw new Error("Expected loadBoard to throw, but it resolved");
 }

--- a/src/features/board/storage/queries.ts
+++ b/src/features/board/storage/queries.ts
@@ -56,9 +56,9 @@ export async function loadBoard(
     previous?.revokeAll();
 
     return board;
-  } catch (err) {
+  } catch (error) {
     registry.revokeAll();
-    throw err;
+    throw error;
   }
 }
 

--- a/src/shared/built-in-ai/internal/lifecycle/store.ts
+++ b/src/shared/built-in-ai/internal/lifecycle/store.ts
@@ -176,9 +176,9 @@ export function createStore<
     const merged = mergeSignals(abortController.signal, callerSignal);
     try {
       await raceAbort(activeTask, merged);
-    } catch (err) {
+    } catch (error) {
       if (merged.aborted) {
-        throw err;
+        throw error;
       }
       // Underlying rejections settle into snapshot.error; only caller-aborts surface here.
     }

--- a/src/shared/built-in-ai/internal/signal.test.ts
+++ b/src/shared/built-in-ai/internal/signal.test.ts
@@ -3,10 +3,10 @@ import { abortError, mergeSignals, raceAbort } from "./signal.ts";
 
 describe("abortError", () => {
   test("returns a DOMException with name 'AbortError' for a string reason", () => {
-    const err = abortError("nope");
-    expect(err).toBeInstanceOf(DOMException);
-    expect(err.name).toBe("AbortError");
-    expect(err.message).toBe("nope");
+    const error = abortError("nope");
+    expect(error).toBeInstanceOf(DOMException);
+    expect(error.name).toBe("AbortError");
+    expect(error.message).toBe("nope");
   });
 
   test("passes through an existing AbortError unchanged", () => {

--- a/src/shared/components/page-container.tsx
+++ b/src/shared/components/page-container.tsx
@@ -7,7 +7,7 @@ export interface PageContainerProps {
 
 export function PageContainer({ children }: PageContainerProps) {
   return (
-    <Container maxWidth="sm" sx={{ py: 6, minHeight: "100%" }}>
+    <Container maxWidth="sm" sx={{ height: "100%" }}>
       {children}
     </Container>
   );

--- a/src/shared/components/page-container.tsx
+++ b/src/shared/components/page-container.tsx
@@ -7,7 +7,7 @@ export interface PageContainerProps {
 
 export function PageContainer({ children }: PageContainerProps) {
   return (
-    <Container maxWidth="sm" sx={{ height: "100%" }}>
+    <Container maxWidth="sm" sx={{ height: "100%", py: 4 }}>
       {children}
     </Container>
   );

--- a/src/shared/language/language-provider.tsx
+++ b/src/shared/language/language-provider.tsx
@@ -4,7 +4,7 @@ import { setVoiceLanguage } from "@shared/speech/speech-store";
 import { getTextDirection } from "@shared/utils/locale";
 import { useEffect, useLayoutEffect, type ReactNode } from "react";
 import { LanguageContext, type LanguageContextValue } from "./language-context";
-import { useSupportedLanguages } from "./use-supported-languages";
+import { useAvailableLanguages } from "./use-available-languages";
 
 export interface LanguageProviderProps {
   children: ReactNode;
@@ -12,7 +12,7 @@ export interface LanguageProviderProps {
 
 export function LanguageProvider({ children }: LanguageProviderProps) {
   const [language, setLanguage] = usePersistentState<string>("language", "en");
-  const languages = useSupportedLanguages();
+  const languages = useAvailableLanguages();
   const direction = getTextDirection(language);
 
   // Sync Paraglide locale during render so children see translated strings on first paint.

--- a/src/shared/language/use-available-languages.ts
+++ b/src/shared/language/use-available-languages.ts
@@ -2,7 +2,7 @@ import { isSupportedLanguage } from "@shared/built-in-ai/translator/is-supported
 import { useVoicesByLanguage } from "@shared/speech/speech-store";
 import { getNativeLanguageName } from "@shared/utils/locale";
 
-export function useSupportedLanguages() {
+export function useAvailableLanguages() {
   const voicesByLanguage = useVoicesByLanguage();
 
   return Object.keys(voicesByLanguage)


### PR DESCRIPTION
## Summary
- Rename `useSupportedLanguages` → `useAvailableLanguages` to match what the hook returns (installed TTS voices ∩ Translator-supported).
- Rename catch-block `err` → `error` across 6 files.
- Tighten `PageContainer`: switch `minHeight` → `height`, add `py: 4`.

## Test plan
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] Smoke-check pages that use `PageContainer` (library, settings, about) render with expected vertical spacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)