### PR TITLE
polish: add dividers between board sets in library list

### DIFF
--- a/src/features/board/library/board-set-list.tsx
+++ b/src/features/board/library/board-set-list.tsx
@@ -82,8 +82,9 @@ export function BoardSetList({
       <List>
         {boardSets.map((boardSet) => (
           <ListItem
-            key={boardSet.setId}
+            divider
             disablePadding
+            key={boardSet.setId}
             secondaryAction={
               <Tooltip title={m.libraryMoreOptions()}>
                 <IconButton


### PR DESCRIPTION
## Summary
- Add `divider` to `<ListItem>` in `board-set-list.tsx` so adjacent board sets read as distinct rows
- Alphabetize the prop order while in the area

## Test plan
- [ ] Open `/library` with multiple board sets and confirm visible dividers between rows
- [ ] Confirm no divider after the last item is visually awkward (MUI's default trailing-divider behavior is fine)
- [ ] Verify RTL (Hebrew) renders the list correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)