### PR TITLE
refactor: move voice-language sync into a React hook

### DIFF
--- a/src/shared/language/language-provider.tsx
+++ b/src/shared/language/language-provider.tsx
@@ -1,8 +1,8 @@
 import { baseLocale, isLocale, setLocale } from "@paraglide/runtime";
 import { usePersistentState } from "@shared/hooks/use-persistent-state";
-import { setVoiceLanguage } from "@shared/speech/speech-store";
+import { useVoiceLanguageSync } from "@shared/speech/use-voice-language-sync";
 import { getTextDirection } from "@shared/utils/locale";
-import { useEffect, useLayoutEffect, type ReactNode } from "react";
+import { useLayoutEffect, type ReactNode } from "react";
 import { LanguageContext, type LanguageContextValue } from "./language-context";
 import { useAvailableLanguages } from "./use-available-languages";
 
@@ -23,9 +23,7 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
     document.documentElement.lang = language;
   }, [direction, language]);
 
-  useEffect(() => {
-    setVoiceLanguage(language);
-  }, [language]);
+  useVoiceLanguageSync({ language });
 
   const contextValue: LanguageContextValue = {
     languages,

--- a/src/shared/speech/speech-store.ts
+++ b/src/shared/speech/speech-store.ts
@@ -70,8 +70,6 @@ function buildVoiceCatalog(voices: SpeechSynthesisVoice[]): VoiceCatalogState {
 
 const synthesis: SpeechSynthesis | undefined = globalThis.speechSynthesis;
 
-let voiceLanguage: string | null = null;
-
 const voiceCatalogStore = createExternalStore<VoiceCatalogState>(
   buildVoiceCatalog(synthesis?.getVoices() ?? []),
 );
@@ -95,43 +93,16 @@ function updateConfig(patch: Partial<SpeechConfig>): void {
   speechConfigStore.setState({ ...speechConfigStore.getSnapshot(), ...patch });
 }
 
-function currentVoiceIsValidFor(language: string): boolean {
-  const { voices } = voiceCatalogStore.getSnapshot();
-  const { voiceURI } = speechConfigStore.getSnapshot();
-  if (!voiceURI) {
-    return false;
-  }
-  const match = voices.find((voice) => voice.voiceURI === voiceURI);
-  if (!match) {
-    return false;
-  }
-  return getLanguageCode(match.lang) === language;
-}
-
-function selectDefaultVoiceFor(language: string): void {
-  const voices = voiceCatalogStore.getSnapshot().voicesByLanguage[language];
-  const defaultVoice = voices?.find((voice) => voice.default) ?? voices?.[0];
-  if (defaultVoice) {
-    updateConfig({ voiceURI: defaultVoice.voiceURI });
-  }
-}
-
 synthesis?.addEventListener("voiceschanged", () => {
   voiceCatalogStore.setState(buildVoiceCatalog(synthesis.getVoices()));
-  if (voiceLanguage && !currentVoiceIsValidFor(voiceLanguage)) {
-    selectDefaultVoiceFor(voiceLanguage);
-  }
 });
+
+export function getSpeechConfig(): SpeechConfig {
+  return speechConfigStore.getSnapshot();
+}
 
 export function setVoiceURI(voiceURI: string | null): void {
   updateConfig({ voiceURI });
-}
-
-export function setVoiceLanguage(language: string): void {
-  voiceLanguage = language;
-  if (!currentVoiceIsValidFor(language)) {
-    selectDefaultVoiceFor(language);
-  }
 }
 
 export function setRate(rate: number): void {

--- a/src/shared/speech/use-voice-language-sync.ts
+++ b/src/shared/speech/use-voice-language-sync.ts
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import {
+  getSpeechConfig,
+  setVoiceURI,
+  useVoicesByLanguage,
+} from "./speech-store";
+
+export interface UseVoiceLanguageSyncOptions {
+  language: string;
+}
+
+export function useVoiceLanguageSync({
+  language,
+}: UseVoiceLanguageSyncOptions): void {
+  const voicesByLanguage = useVoicesByLanguage();
+
+  useEffect(() => {
+    const voices = voicesByLanguage[language];
+    if (!voices) {
+      return;
+    }
+
+    const { voiceURI } = getSpeechConfig();
+    const hasMatchingVoice = voices.some(
+      (voice) => voice.voiceURI === voiceURI,
+    );
+    if (hasMatchingVoice) {
+      return;
+    }
+
+    const fallbackVoice = voices.find((voice) => voice.default) ?? voices[0];
+    if (fallbackVoice) {
+      setVoiceURI(fallbackVoice.voiceURI);
+    }
+  }, [language, voicesByLanguage]);
+}


### PR DESCRIPTION
## Summary
- Extract voice-language reconciliation from the speech store into a new `useVoiceLanguageSync` hook.
- Drop the hidden `voiceLanguage` module variable and the imperative `currentVoiceIsValidFor` / `selectDefaultVoiceFor` helpers; the store is back to pure state.
- `LanguageProvider` now calls `useVoiceLanguageSync({ language })`, reading `voicesByLanguage` reactively via the existing external store.

## Test plan
- [ ] Switch UI language and confirm TTS voice updates to that language's default.
- [ ] Pick a non-default voice, switch language, confirm a new default is selected for the new language.
- [ ] Pick a voice, switch back to its language, confirm the manual choice is preserved.
- [ ] Reload the page mid-`voiceschanged` and confirm no flash or stale voice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)