### PR TITLE
refactor: parse OBF actions at the boundary, close BoardAction

### DIFF
--- a/src/features/board/obf/mapper.test.ts
+++ b/src/features/board/obf/mapper.test.ts
@@ -247,7 +247,32 @@ describe("obfToBoard", () => {
       };
 
       const board = obfToBoard(obfBoard);
-      expect(board.buttons[0]?.actions).toEqual([":speak", ":space", ":clear"]);
+      expect(board.buttons[0]?.actions).toEqual([
+        { kind: "speak" },
+        { kind: "space" },
+        { kind: "clear" },
+      ]);
+    });
+
+    test("parses spell actions and drops unknown ones", () => {
+      const obfBoard: OBFBoard = {
+        format: "open-board-0.1",
+        id: "board-actions-parse",
+        buttons: [
+          {
+            id: "btn-1",
+            label: "Spell",
+            actions: ["+ing", ":unknown", ":home"],
+          },
+        ],
+        grid: { rows: 1, columns: 1, order: [["btn-1"]] },
+      };
+
+      const board = obfToBoard(obfBoard);
+      expect(board.buttons[0]?.actions).toEqual([
+        { kind: "spell", text: "ing" },
+        { kind: "home" },
+      ]);
     });
   });
 

--- a/src/features/board/obf/mapper.ts
+++ b/src/features/board/obf/mapper.ts
@@ -117,9 +117,31 @@ function transformButton(
 }
 
 function collectActions(obfButton: OBFButton): BoardAction[] {
-  return [obfButton.action, ...(obfButton.actions ?? [])].filter(
-    (action): action is BoardAction => Boolean(action),
-  );
+  const raw = [obfButton.action, ...(obfButton.actions ?? [])];
+  return raw.flatMap((value) => {
+    const action = value ? parseAction(value) : null;
+    return action ? [action] : [];
+  });
+}
+
+function parseAction(raw: string): BoardAction | null {
+  if (raw.startsWith("+")) {
+    return { kind: "spell", text: raw.slice(1).trim() };
+  }
+  switch (raw) {
+    case ":space":
+      return { kind: "space" };
+    case ":backspace":
+      return { kind: "backspace" };
+    case ":clear":
+      return { kind: "clear" };
+    case ":home":
+      return { kind: "home" };
+    case ":speak":
+      return { kind: "speak" };
+    default:
+      return null;
+  }
 }
 
 function transformLoadBoard(obfLoadBoard: OBFLoadBoard): BoardLink {

--- a/src/features/board/types.ts
+++ b/src/features/board/types.ts
@@ -52,8 +52,10 @@ export interface BoardLink {
   dataUrl?: string;
 }
 
-export type BoardAction = SpecialtyAction | SpellingAction;
-
-type SpecialtyAction = ":space" | ":clear" | ":home" | ":speak" | ":backspace";
-
-type SpellingAction = `+${string}`;
+export type BoardAction =
+  | { kind: "space" }
+  | { kind: "backspace" }
+  | { kind: "clear" }
+  | { kind: "home" }
+  | { kind: "speak" }
+  | { kind: "spell"; text: string };

--- a/src/features/board/use-button-activation.test.tsx
+++ b/src/features/board/use-button-activation.test.tsx
@@ -5,10 +5,7 @@ import type { MessagePart, UseMessageReturn } from "./message/use-message";
 import type { UseMessagePlaybackReturn } from "./message/use-message-playback";
 import type { UseBoardNavigationReturn } from "./navigation/use-board-navigation";
 import type { BoardAction, BoardButton } from "./types";
-import {
-  resolveButtonIntent,
-  useButtonActivation,
-} from "./use-button-activation";
+import { useButtonActivation } from "./use-button-activation";
 
 function createMessageStub(parts: MessagePart[] = []): UseMessageReturn {
   return {
@@ -91,6 +88,21 @@ describe("useButtonActivation", () => {
     expect(audio.play).not.toHaveBeenCalled();
   });
 
+  test("navigates when loadBoard.id is set even if actions are also present", async () => {
+    const { result, message, playback, navigation } = await setup();
+
+    await result.current.activateButton({
+      id: "btn",
+      label: "Folder",
+      loadBoard: { id: "child-board" },
+      actions: [{ kind: "space" }],
+    });
+
+    expect(navigation.goToBoard).toHaveBeenCalledWith("child-board");
+    expect(message.addSpace).not.toHaveBeenCalled();
+    expect(playback.play).not.toHaveBeenCalled();
+  });
+
   test("runs each action in order for an actions array", async () => {
     const callOrder: string[] = [];
     const message = createMessageStub();
@@ -110,45 +122,54 @@ describe("useButtonActivation", () => {
 
     await result.current.activateButton({
       id: "btn",
-      actions: [":space", ":speak", ":clear"],
+      actions: [{ kind: "space" }, { kind: "speak" }, { kind: "clear" }],
     });
 
     expect(callOrder).toEqual(["addSpace", "play", "clear"]);
   });
 
   test.each([
-    [":space", "addSpace"],
-    [":backspace", "removeLastPart"],
-    [":clear", "clear"],
-  ] as const)("maps %s to message.%s", async (action, methodName) => {
+    ["space", "addSpace"],
+    ["backspace", "removeLastPart"],
+    ["clear", "clear"],
+  ] as const)("maps %s to message.%s", async (kind, methodName) => {
     const { result, message } = await setup();
 
-    await result.current.activateButton({ id: "btn", actions: [action] });
+    await result.current.activateButton({ id: "btn", actions: [{ kind }] });
 
     expect(message[methodName]).toHaveBeenCalledTimes(1);
   });
 
-  test("maps :speak to playback.play", async () => {
+  test("maps speak to playback.play", async () => {
     const { result, playback } = await setup();
 
-    await result.current.activateButton({ id: "btn", actions: [":speak"] });
+    await result.current.activateButton({
+      id: "btn",
+      actions: [{ kind: "speak" }],
+    });
 
     expect(playback.play).toHaveBeenCalledTimes(1);
   });
 
-  test("maps :home to navigation.goHome", async () => {
+  test("maps home to navigation.goHome", async () => {
     const { result, navigation } = await setup();
 
-    await result.current.activateButton({ id: "btn", actions: [":home"] });
+    await result.current.activateButton({
+      id: "btn",
+      actions: [{ kind: "home" }],
+    });
 
     expect(navigation.goHome).toHaveBeenCalledTimes(1);
   });
 
-  test("appends a spelling action's text to the last message part's label", async () => {
+  test("appends a spell action's text to the last message part's label", async () => {
     const message = createMessageStub([{ id: "ca", label: "ca" }]);
     const { result } = await setup({ message });
 
-    await result.current.activateButton({ id: "btn", actions: ["+t"] });
+    await result.current.activateButton({
+      id: "btn",
+      actions: [{ kind: "spell", text: "t" }],
+    });
 
     expect(message.updateLastPart).toHaveBeenCalledWith({
       id: "t",
@@ -156,23 +177,29 @@ describe("useButtonActivation", () => {
     });
   });
 
-  test("ignores unrecognized default actions", async () => {
-    const { result, message, playback, navigation } = await setup();
+  test("treats a loadBoard without an id as not navigable and utters instead", async () => {
+    const { result, message, navigation } = await setup();
 
     await result.current.activateButton({
       id: "btn",
-      actions: [":unknown" as BoardAction],
+      label: "hi",
+      loadBoard: { name: "Other" },
     });
 
-    expect(message.addPart).not.toHaveBeenCalled();
-    expect(message.addSpace).not.toHaveBeenCalled();
-    expect(message.removeLastPart).not.toHaveBeenCalled();
-    expect(message.updateLastPart).not.toHaveBeenCalled();
-    expect(message.clear).not.toHaveBeenCalled();
-    expect(playback.play).not.toHaveBeenCalled();
-    expect(navigation.goHome).not.toHaveBeenCalled();
-    expect(speech.speak).not.toHaveBeenCalled();
-    expect(audio.play).not.toHaveBeenCalled();
+    expect(navigation.goToBoard).not.toHaveBeenCalled();
+    expect(message.addPart).toHaveBeenCalledTimes(1);
+  });
+
+  test("treats an empty actions array as no actions and utters instead", async () => {
+    const { result, message } = await setup();
+
+    await result.current.activateButton({
+      id: "btn",
+      label: "hi",
+      actions: [] as BoardAction[],
+    });
+
+    expect(message.addPart).toHaveBeenCalledTimes(1);
   });
 
   test("adds the button as a message part when there are no actions and no loadBoard", async () => {
@@ -237,50 +264,5 @@ describe("useButtonActivation", () => {
     expect(message.addPart).toHaveBeenCalledTimes(1);
     expect(speech.speak).not.toHaveBeenCalled();
     expect(audio.play).not.toHaveBeenCalled();
-  });
-});
-
-describe("resolveButtonIntent", () => {
-  test("navigate takes precedence over actions and utter when loadBoard.id is set", () => {
-    expect(
-      resolveButtonIntent({
-        id: "btn",
-        label: "Folder",
-        loadBoard: { id: "child-board" },
-        actions: [":space"],
-      }),
-    ).toEqual({ kind: "navigate", boardId: "child-board" });
-  });
-
-  test("treats loadBoard without an id as not navigable", () => {
-    const button: BoardButton = {
-      id: "btn",
-      label: "hi",
-      loadBoard: { name: "Other" },
-    };
-
-    expect(resolveButtonIntent(button)).toEqual({ kind: "utter", button });
-  });
-
-  test("returns actions when there is no loadBoard.id and actions is non-empty", () => {
-    expect(
-      resolveButtonIntent({ id: "btn", actions: [":space", ":speak"] }),
-    ).toEqual({ kind: "actions", actions: [":space", ":speak"] });
-  });
-
-  test("falls through to utter when actions is an empty array", () => {
-    const button: BoardButton = { id: "btn", label: "hi", actions: [] };
-
-    expect(resolveButtonIntent(button)).toEqual({ kind: "utter", button });
-  });
-
-  test("returns utter with the original button when there is no loadBoard.id and no actions", () => {
-    const button: BoardButton = {
-      id: "btn",
-      label: "hi",
-      vocalization: "hello",
-    };
-
-    expect(resolveButtonIntent(button)).toEqual({ kind: "utter", button });
   });
 });

--- a/src/features/board/use-button-activation.ts
+++ b/src/features/board/use-button-activation.ts
@@ -15,11 +15,6 @@ export interface UseButtonActivationReturn {
   activateButton: (button: BoardButton) => Promise<void>;
 }
 
-export type ButtonIntent =
-  | { kind: "navigate"; boardId: string }
-  | { kind: "actions"; actions: BoardAction[] }
-  | { kind: "utter"; button: BoardButton };
-
 export function useButtonActivation({
   message,
   playback,
@@ -28,97 +23,65 @@ export function useButtonActivation({
   const audio = useAudio();
 
   async function activateButton(button: BoardButton) {
-    const intent = resolveButtonIntent(button);
-
-    switch (intent.kind) {
-      case "navigate":
-        navigation.goToBoard(intent.boardId);
-        return;
-      case "actions":
-        for (const action of intent.actions) {
-          await executeAction(action);
-        }
-        return;
-      case "utter":
-        message.addPart(toMessagePart(intent.button));
-        playButtonAudio(intent.button);
-        return;
-      default: {
-        const _exhaustive: never = intent;
-        throw new Error(
-          `Unhandled button intent: ${JSON.stringify(_exhaustive)}`,
-        );
-      }
-    }
-  }
-
-  async function executeAction(action: BoardAction) {
-    switch (action) {
-      case ":space":
-        message.addSpace();
-        return;
-      case ":backspace":
-        message.removeLastPart();
-        return;
-      case ":speak":
-        await playback.play();
-        return;
-      case ":clear":
-        message.clear();
-        return;
-      case ":home":
-        navigation.goHome();
-        return;
-      default:
-        handleSpellingAction(action);
-    }
-  }
-
-  function handleSpellingAction(action: string) {
-    if (!action.startsWith("+")) {
+    const folderId = button.loadBoard?.id;
+    if (folderId) {
+      navigation.goToBoard(folderId);
       return;
     }
 
-    const text = action.slice(1).trim();
-    const lastPart = message.parts.at(-1);
+    if (button.actions?.length) {
+      for (const action of button.actions) {
+        await runAction(action);
+      }
+      return;
+    }
 
+    message.addPart(asMessagePart(button));
+    utter(button);
+  }
+
+  async function runAction(action: BoardAction) {
+    switch (action.kind) {
+      case "space":
+        return message.addSpace();
+      case "backspace":
+        return message.removeLastPart();
+      case "clear":
+        return message.clear();
+      case "home":
+        return navigation.goHome();
+      case "speak":
+        await playback.play();
+        return;
+      case "spell":
+        return appendToLastPart(action.text);
+    }
+  }
+
+  function appendToLastPart(text: string) {
+    const lastPart = message.parts.at(-1);
     message.updateLastPart({
       id: text,
       label: `${lastPart?.label ?? ""}${text}`,
     });
   }
 
-  function playButtonAudio(button: BoardButton) {
+  function utter(button: BoardButton) {
     if (button.soundSrc) {
       void audio.play(button.soundSrc);
       return;
     }
 
     const text = getSpokenText(button);
-
     if (text) {
       void speak(text.toLowerCase());
     }
   }
 
-  return {
-    activateButton,
-  };
+  return { activateButton };
 }
 
-export function resolveButtonIntent(button: BoardButton): ButtonIntent {
-  if (button.loadBoard?.id) {
-    return { kind: "navigate", boardId: button.loadBoard.id };
-  }
-
-  if (button.actions?.length) {
-    return { kind: "actions", actions: button.actions };
-  }
-
-  return { kind: "utter", button };
-}
-
-function toMessagePart(button: BoardButton): MessagePart {
+function asMessagePart(button: BoardButton): MessagePart {
   return {
     id: button.id,
     label: button.label,


### PR DESCRIPTION
## Summary
- `BoardAction` becomes a closed tagged union (`{ kind: 'space' }`, `{ kind: 'spell'; text }`, …); the OBF wire format (`:space`, `+t`) is parsed once in the mapper.
- `useButtonActivation` no longer touches wire strings — the action switch dispatches on `kind` over a finite type, no `default: throw` ceremony needed.
- Unknown action strings are now dropped during board import instead of becoming silent no-ops at runtime.

## Test plan
- [x] `npx vitest run src/features/board/use-button-activation.test.tsx src/features/board/obf/mapper.test.ts` — 37 passed
- [x] `npm run typecheck`
- [x] `npm run lint -- <changed files>`
- [ ] Open a board, click a folder tile, navigate, hit a speak button, use a spelling key — verify behavior parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)