### PR TITLE
chore: declare MIT license in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "aac-board-ai",
       "version": "1.6.0",
+      "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "aac-board-ai",
   "private": true,
   "version": "1.6.0",
+  "license": "MIT",
   "type": "module",
   "engines": {
     "node": ">=24"


### PR DESCRIPTION
## Summary
- Adds `"license": "MIT"` to `package.json` (and the corresponding entry in `package-lock.json`) so the project's license is declared in package metadata.

## Test plan
- [x] `npm install` keeps the lockfile in sync
- [ ] CI passes