### PR TITLE
docs: restructure readme around moment-of-magic and audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,39 @@
 [![CI](https://github.com/shayc/aac-board-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/shayc/aac-board-ai/actions/workflows/ci.yml)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/d6e3dbf1-40d1-4343-9f56-3c9368d2fe56/deploy-status)](https://app.netlify.com/projects/aacboard/deploys)
 
-**Winner - [Google Chrome Built-in AI Challenge 2025](https://developer.chrome.com/blog/ai-challenge-winners-2025) (Most Helpful Application)**
+**Winner — [Google Chrome Built-in AI Challenge 2025](https://developer.chrome.com/blog/ai-challenge-winners-2025) (Most Helpful Application)**
 
-**AAC Board AI** is an Augmentative and Alternative Communication board that helps people who cannot rely on speech communicate more easily and naturally. It is enhanced with **Built-in AI** for on-device proofreading, rewriting, and board translation — keeping interactions private, fast, and reliable offline.
+**AAC Board AI** is an Augmentative and Alternative Communication (AAC) board for people who cannot rely on speech. It uses **Built-in AI** for on-device grammar correction, tone adjustment, and translation — keeping interactions private, fast, and reliable offline.
 
 ![Screenshot of AAC Board AI](screenshot.png)
 
-Try the live demo at [aacboard.app](https://aacboard.app). Core board features work without AI; Built-in AI enhancements require Chrome or Edge with [Built-in AI enabled](#enabling-built-in-ai).
+Try the live app at [aacboard.app](https://aacboard.app). Core board features work in any modern browser; Built-in AI enhancements require Chrome or Edge with [Built-in AI enabled](#enabling-built-in-ai).
 
-## Key Features
+## From taps to sentences
 
-- **Grammar Correction** – Turns telegraphic text into clear sentences ([Proofreader API](https://developer.chrome.com/docs/ai/proofreader-api)).
-- **Tone Adjustment** – Rewrites messages in direct, professional, or friendly tones ([Rewriter API](https://developer.chrome.com/docs/ai/rewriter-api)).
-- **Translation** – Translates board labels and vocalizations between languages ([Translator API](https://developer.chrome.com/docs/ai/translator-api)).
-- **Text to Speech** – Reads messages aloud ([Web Speech API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API)).
-- **Offline Ready** – Installs as a standalone app with automatic updates ([PWA](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps)).
-- **Open Board Format** – Imports `.obf` and `.obz` files ([example boards](https://www.openboardformat.org/examples)).
+Standard AAC boards require selecting tiles one at a time, which often produces telegraphic output. AAC Board AI expands those short inputs into natural sentences locally, on-device:
+
+```
+User selects:       [ Want ] → [ Eat ] → [ Pizza ] → [ Later ]
+Standard output:    "Want eat pizza later."
+AI-expanded output: "I would like to eat pizza later, please."
+```
+
+## Who it's for
+
+- **Individuals using AAC** — Communicate faster without typing complete sentences tile by tile.
+- **Speech-language pathologists and educators** — Deploy on school networks without cloud data agreements, subscriptions, or continuous internet access.
+- **Caregivers and families** — Install a customizable communication board onto personal tablets or phones.
+- **Developers** — Read an open-source reference implementation of browser-native, on-device language models in a real React 19 app.
+
+## Key features
+
+- **Grammar Correction** — Turns telegraphic text into clear sentences ([Proofreader API](https://developer.chrome.com/docs/ai/proofreader-api)).
+- **Tone Adjustment** — Rewrites messages in direct, professional, or friendly tones ([Rewriter API](https://developer.chrome.com/docs/ai/rewriter-api)).
+- **Translation** — Translates board labels and vocalizations between languages ([Translator API](https://developer.chrome.com/docs/ai/translator-api)).
+- **Text to Speech** — Reads messages aloud ([Web Speech API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API)).
+- **Offline Ready** — Installs as a standalone app with automatic updates ([PWA](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps)).
+- **Open Board Format** — Imports `.obf` and `.obz` files ([example boards](https://www.openboardformat.org/examples)).
 
 ## Enabling Built-in AI
 
@@ -37,7 +54,7 @@ chrome://flags/#rewriter-api-for-gemini-nano
 edge://flags/#edge-llm-rewriter-api-for-phi-mini
 ```
 
-## Quick Start
+## Quick start
 
 Requires Node.js 24+.
 
@@ -58,18 +75,18 @@ npm test                # Run tests
 npm run build           # Typecheck + production build
 ```
 
-## Technical Stack
+## Technical stack
 
-- **UI:** React 19, TypeScript, Material UI, React Router
-- **AI:** Gemini Nano (Chrome) / Phi 4 Mini (Edge)
+- **UI:** React 19 (with the React Compiler), TypeScript, Material UI, React Router
+- **AI:** Gemini Nano (Chrome) / Phi-4 Mini (Edge), via browser-native APIs
 - **Speech:** Web Speech API
-- **Storage:** IndexedDB
+- **Storage:** IndexedDB (offline-first PWA shell)
 - **Data:** open-board-format (OBF/OBZ file parsing)
 - **Tooling:** Vite, Vitest, Playwright
 
 See full architecture details in [docs/architecture.md](docs/architecture.md).
 
-## Loading a Board via URL
+## Loading a board via URL
 
 Load a board by passing an OBF or OBZ file URL as the `board` query parameter:
 


### PR DESCRIPTION
## Summary
- Reframe the README around a before/after example (telegraphic tiles → natural sentence) so the value lands in five seconds.
- Add a **Who it's for** section calling out AAC users, SLPs/educators, caregivers, and developers — each audience gets a concrete reason to read further.
- Normalize headings to sentence case and dashes to em-dashes throughout.
- Light polish: tighter intro, AAC acronym expansion, React Compiler / browser-native APIs mention in the stack.

## Test plan
- [ ] Render README on GitHub and visually scan: badges, hook, audience block, features, dev sections all in expected order.
- [ ] Verify the `#enabling-built-in-ai` anchor link from the intro still resolves.
- [ ] Confirm screenshot, badges, and external links render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)