### PR TITLE
chore: bump version to 1.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aac-board-ai",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aac-board-ai",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aac-board-ai",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "MIT",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Bump package version to 1.6.1

**Changes:**
- refactor: parse OBF actions at the boundary, close BoardAction (#331)
- refactor: split board storage/import folders, rename boards-db.ts and library/ (#332)
- refactor: move voice-language sync into a React hook (#330)
- refactor: merge about-page acknowledgments into one i18n markup message (#334)
- polish: naming, structure, and grid keyboard nav cleanups (#329)
- polish: drop .ts/.tsx import suffixes in built-in-ai, kebab-case OBF fixtures (#333)
- polish: tighten about-page copy and drop open-source heading (#337)
- docs: refresh architecture.md to match recent refactors (#336)
- docs: note ParaglideMessage pattern for sentences with inline links (#335)
- docs: replace screenshot.jpg with screenshot.png (#338)
- docs: restructure readme around moment-of-magic and audience (#340)
- chore: declare MIT license in package.json (#339)

🤖 Generated with [Claude Code](https://claude.com/claude-code)