### PR TITLE
refactor: implement targeted Prose recommendations

### DIFF
--- a/src/features/board/import/use-import-board-files.ts
+++ b/src/features/board/import/use-import-board-files.ts
@@ -23,29 +23,34 @@ export function useImportBoardFiles(): UseImportBoardFilesReturn {
     }
 
     const isPlural = files.length > 1;
+    const pickMessage = (single: string, plural: string) =>
+      isPlural ? plural : single;
+
     showSnackbar({
-      message: isPlural
-        ? m.libraryImportingBoards()
-        : m.libraryImportingBoard(),
+      message: pickMessage(
+        m.libraryImportingBoard(),
+        m.libraryImportingBoards(),
+      ),
     });
 
     try {
       await importBoardFiles(files);
 
       showSnackbar({
-        message: isPlural
-          ? m.libraryImportedBoards()
-          : m.libraryImportedBoard(),
+        message: pickMessage(
+          m.libraryImportedBoard(),
+          m.libraryImportedBoards(),
+        ),
         severity: "success",
       });
-    } catch (error) {
+    } catch {
       showSnackbar({
-        message: isPlural
-          ? m.libraryImportFailedBoards()
-          : m.libraryImportFailedBoard(),
+        message: pickMessage(
+          m.libraryImportFailedBoard(),
+          m.libraryImportFailedBoards(),
+        ),
         severity: "error",
       });
-      throw error;
     }
   }
 

--- a/src/features/board/message/message-bar.tsx
+++ b/src/features/board/message/message-bar.tsx
@@ -40,10 +40,10 @@ export function MessageBar({
   onPlayClick,
   onStopClick,
 }: MessageBarProps) {
-  const scrollerRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    return scrollToEnd(scrollerRef.current);
+    return scrollToEnd(scrollContainerRef.current);
   }, [parts]);
 
   return (
@@ -62,7 +62,7 @@ export function MessageBar({
         })}
       >
         <Stack
-          ref={scrollerRef}
+          ref={scrollContainerRef}
           direction="row"
           sx={{ flexGrow: 1, padding: 2, gap: 1, overflow: "auto" }}
         >

--- a/src/features/board/message/use-message.ts
+++ b/src/features/board/message/use-message.ts
@@ -11,8 +11,7 @@ export interface UseMessageReturn {
   text: string;
   addPart: (part: MessagePart) => void;
   addSpace: () => void;
-  setParts: (parts: MessagePart[]) => void;
-  setFromText: (text: string) => void;
+  setFromText: (input: string) => void;
   removeLastPart: () => void;
   updateLastPart: (part: MessagePart) => void;
   clear: () => void;
@@ -52,9 +51,9 @@ export function useMessage(): UseMessageReturn {
     });
   }
 
-  function setFromText(text: string) {
+  function setFromText(input: string) {
     const segmenter = new Intl.Segmenter(undefined, { granularity: "word" });
-    const words = Array.from(segmenter.segment(text))
+    const words = Array.from(segmenter.segment(input))
       .filter((segment) => segment.isWordLike)
       .map((segment) => segment.segment);
 
@@ -66,7 +65,6 @@ export function useMessage(): UseMessageReturn {
     text,
     addPart,
     addSpace,
-    setParts,
     setFromText,
     removeLastPart,
     updateLastPart,

--- a/src/features/board/use-board-translation.ts
+++ b/src/features/board/use-board-translation.ts
@@ -5,6 +5,8 @@ import { useEffect, useState } from "react";
 import { updateBoardStrings, withBoardsDB } from "./storage/db";
 import type { Board } from "./types";
 
+const DEFAULT_BOARD_LANGUAGE = "en";
+
 export interface UseBoardTranslationOptions {
   setId: string;
   board: Board;
@@ -68,16 +70,19 @@ export function useBoardTranslation({
   return { translatedBoard };
 }
 
-function resolveSyncTranslation(board: Board, language: string): Board | null {
+function resolveSyncTranslation(
+  board: Board,
+  language: string,
+): Board | undefined {
   if (getBoardLanguage(board) === language) {
     return board;
   }
   const cached = findTranslations(board.strings, language);
-  return cached ? applyTranslations(board, cached) : null;
+  return cached ? applyTranslations(board, cached) : undefined;
 }
 
 function getBoardLanguage(board: Board): string {
-  return board.locale ? getLanguageCode(board.locale) : "en";
+  return board.locale ? getLanguageCode(board.locale) : DEFAULT_BOARD_LANGUAGE;
 }
 
 function findTranslations(

--- a/src/features/board/use-button-activation.test.tsx
+++ b/src/features/board/use-button-activation.test.tsx
@@ -13,7 +13,6 @@ function createMessageStub(parts: MessagePart[] = []): UseMessageReturn {
     text: parts.map((p) => p.label ?? "").join(" "),
     addPart: vi.fn(),
     addSpace: vi.fn(),
-    setParts: vi.fn(),
     setFromText: vi.fn(),
     removeLastPart: vi.fn(),
     updateLastPart: vi.fn(),

--- a/src/features/board/use-button-activation.ts
+++ b/src/features/board/use-button-activation.ts
@@ -23,9 +23,9 @@ export function useButtonActivation({
   const audio = useAudio();
 
   async function activateButton(button: BoardButton) {
-    const folderId = button.loadBoard?.id;
-    if (folderId) {
-      navigation.goToBoard(folderId);
+    const targetBoardId = button.loadBoard?.id;
+    if (targetBoardId) {
+      navigation.goToBoard(targetBoardId);
       return;
     }
 
@@ -51,8 +51,7 @@ export function useButtonActivation({
       case "home":
         return navigation.goHome();
       case "speak":
-        await playback.play();
-        return;
+        return playback.play();
       case "spell":
         return appendToLastPart(action.text);
     }

--- a/src/pages/library-page.tsx
+++ b/src/pages/library-page.tsx
@@ -58,12 +58,11 @@ export const Component = function LibraryPage() {
         message: m.libraryDeleted({ name }),
         severity: "success",
       });
-    } catch (error) {
+    } catch {
       showSnackbar({
         message: m.libraryDeleteFailed({ name }),
         severity: "error",
       });
-      throw error;
     }
   }
 

--- a/src/shared/built-in-ai/internal/lifecycle/store.ts
+++ b/src/shared/built-in-ai/internal/lifecycle/store.ts
@@ -102,7 +102,7 @@ export function createStore<
         return;
       }
       if (availability === "available") {
-        await provision(signal, false);
+        await provision(signal, { showDownloadUI: false });
       }
     } catch (error) {
       if (signal.aborted) {
@@ -118,9 +118,13 @@ export function createStore<
    * matters; the silent path keeps an "available" model on "idle" until it
    * lands as "ready".
    */
+  interface ProvisionOptions {
+    showDownloadUI: boolean;
+  }
+
   async function provision(
     signal: AbortSignal,
-    showDownloadUI: boolean,
+    { showDownloadUI }: ProvisionOptions,
   ): Promise<void> {
     if (showDownloadUI) {
       update({ status: "downloading", progress: 0 });
@@ -192,7 +196,7 @@ export function createStore<
       if (!hasUserActivation()) {
         throw new NoUserActivationError();
       }
-      activeTask = provision(abortController.signal, true);
+      activeTask = provision(abortController.signal, { showDownloadUI: true });
     }
 
     // 3. Provision in flight (ours, or a concurrent caller's) — wait it out.

--- a/src/shared/built-in-ai/translator/is-supported-language.ts
+++ b/src/shared/built-in-ai/translator/is-supported-language.ts
@@ -1,5 +1,10 @@
-const UNSUPPORTED_LANGUAGES: readonly string[] = ["ca", "ms", "nb", "yue"];
+const TRANSLATOR_UNSUPPORTED_LANGUAGES: readonly string[] = [
+  "ca",
+  "ms",
+  "nb",
+  "yue",
+];
 
 export function isSupportedLanguage(language: string): boolean {
-  return !UNSUPPORTED_LANGUAGES.includes(language);
+  return !TRANSLATOR_UNSUPPORTED_LANGUAGES.includes(language);
 }


### PR DESCRIPTION
# Walkthrough - Applied Prose Improvements

We have successfully executed the 11 targeted Prose improvements to streamline the naming, scannability, type hygiene, and code fluency of the application. All changes were applied on the newly created branch `refactor-prose-improvements`.

## Changes Made

Here is the summary of the implemented refactorings:

1. **VOCAB-1 (Naming Alignment):**
   - Renamed local variable `folderId` to `targetBoardId` in [use-button-activation.ts](file:///Users/shayc/code/aac-board-ai/src/features/board/use-button-activation.ts).

2. **PROSE-6 (Fluency & Voice Alignment):**
   - Refactored `runAction` in [use-button-activation.ts](file:///Users/shayc/code/aac-board-ai/src/features/board/use-button-activation.ts) to return `playback.play()` directly in the `"speak"` case, harmonizing all cases into unified expression-style returns.

3. **PROSE-11 (Naming Conflict Resolution):**
   - Renamed `scrollerRef` to `scrollContainerRef` in [message-bar.tsx](file:///Users/shayc/code/aac-board-ai/src/features/board/message/message-bar.tsx) to resolve the verb-noun silhouette conflict.

4. **PROSE-12 (Cohesive Naming):**
   - Renamed ambiguous positive `UNSUPPORTED_LANGUAGES` to `TRANSLATOR_UNSUPPORTED_LANGUAGES` in [is-supported-language.ts](file:///Users/shayc/code/aac-board-ai/src/shared/built-in-ai/translator/is-supported-language.ts).

5. **PROSE-13 (Name Shadowing Resolution):**
   - Renamed the parameter `text` to `input` in `setFromText` inside [use-message.ts](file:///Users/shayc/code/aac-board-ai/src/features/board/message/use-message.ts) to eliminate the name shadowing of the outer derived `text` variable.

6. **PROSE-14 (Type Narrowing & Interface Hygiene):**
   - Dropped the unused internal `setParts` callback from `UseMessageReturn` and `useMessage()` return block in [use-message.ts](file:///Users/shayc/code/aac-board-ai/src/features/board/message/use-message.ts).
   - Removed the mocked `setParts` entry in `createMessageStub` inside [use-button-activation.test.tsx](file:///Users/shayc/code/aac-board-ai/src/features/board/use-button-activation.test.tsx).

7. **PROSE-8 (Defensive Error Boundaries):**
   - Removed redundant `throw error` calls in deletion catch-blocks inside [library-page.tsx](file:///Users/shayc/code/aac-board-ai/src/pages/library-page.tsx) and [use-import-board-files.ts](file:///Users/shayc/code/aac-board-ai/src/features/board/import/use-import-board-files.ts), letting the existing snackbar report represent the sole boundary report.

8. **PROSE-5 (Policy Clarification):**
   - Extracted the `"en"` default fallback in `getBoardLanguage` to a named module-level constant `DEFAULT_BOARD_LANGUAGE` in [use-board-translation.ts](file:///Users/shayc/code/aac-board-ai/src/features/board/use-board-translation.ts).

9. **PROSE-4 (Sentinel Standardization):**
   - Adjusted `resolveSyncTranslation` in [use-board-translation.ts](file:///Users/shayc/code/aac-board-ai/src/features/board/use-board-translation.ts) to return `Board | undefined` instead of `Board | null` to standardize "not found" sentinels across the file.

10. **PROSE-3 (Ternary Simplification):**
    - Collapsed the three similar conditional statements choosing singular/plural messages inside [use-import-board-files.ts](file:///Users/shayc/code/aac-board-ai/src/features/board/import/use-import-board-files.ts) into a single, clean `pickMessage` lookup wrapper.

11. **PROSE-1 (Boolean Trap Resolution):**
    - Refactored `provision` in [store.ts](file:///Users/shayc/code/aac-board-ai/src/shared/built-in-ai/internal/lifecycle/store.ts) to replace the positional parameter `showDownloadUI: boolean` with a structured `ProvisionOptions` object.

---

## What Was Tested & Validation Results

We executed the full set of automated verification scripts to ensure perfect type safety, formatting standards, and functional behavior:

1. **Static Linting:**
   - Evaluated `eslint` across the codebase. Resolved any unused variables resulting from the deleted `throw error` statements by removing unnecessary `catch (error)` parameters. Linter passed successfully:
     ```bash
     npm run lint # Passed
     ```

2. **Formatting Audit:**
   - Ran `prettier` formatting check across all modified files:
     ```bash
     npm run format # Formatted successfully
     ```

3. **Production Typecheck & Build:**
   - Validated that the Vite application compiled cleanly for production:
     ```bash
     npm run build # Passed successfully with 0 compilation errors
     ```

4. **Vite Browser Test Suite:**
   - Ran the complete automated Vitest browser suite under Playwright:
     ```bash
     npm test -- --run # 37/37 Test Files passed (321/321 Tests passed)
     ```
