### PR TITLE
refactor: vocabulary alignment, theme tokens, and MUI primitives

### DIFF
--- a/src/app/loaders/board-loader.ts
+++ b/src/app/loaders/board-loader.ts
@@ -1,4 +1,4 @@
-import { BoardNotFoundError, loadBoard, type Board } from "@features/board";
+import { BoardNotFoundError, hydrateBoard, type Board } from "@features/board";
 import { m } from "@paraglide/messages.js";
 import { data, type LoaderFunctionArgs } from "react-router";
 
@@ -10,7 +10,7 @@ export async function boardLoader({
   const boardId = params.boardId!;
 
   try {
-    return await loadBoard(setId, boardId, request.signal);
+    return await hydrateBoard(setId, boardId, request.signal);
   } catch (error) {
     if (error instanceof BoardNotFoundError) {
       throw data(m.boardNotFound(), { status: 404 });

--- a/src/app/menu/menu-drawer.tsx
+++ b/src/app/menu/menu-drawer.tsx
@@ -2,7 +2,6 @@ import { APP_NAME } from "@app/app-info";
 import FilterNoneOutlinedIcon from "@mui/icons-material/FilterNoneOutlined";
 import HomeOutlinedIcon from "@mui/icons-material/HomeOutlined";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
-import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
 import Drawer from "@mui/material/Drawer";
 import List from "@mui/material/List";
@@ -28,33 +27,36 @@ export function MenuDrawer({ open, onClose }: MenuDrawerProps) {
   ];
 
   return (
-    <Drawer anchor="left" open={open} onClose={onClose}>
-      <Box sx={{ width: 320 }}>
-        <Toolbar>
-          <Typography component="div" variant="h6" noWrap>
-            {APP_NAME}
-          </Typography>
-        </Toolbar>
+    <Drawer
+      anchor="left"
+      open={open}
+      onClose={onClose}
+      slotProps={{ paper: { sx: { width: 320 } } }}
+    >
+      <Toolbar>
+        <Typography component="div" variant="h6" noWrap>
+          {APP_NAME}
+        </Typography>
+      </Toolbar>
 
-        <Divider />
+      <Divider />
 
-        <List>
-          {menuItems.map((item) => (
-            <ListItem key={item.to} disablePadding>
-              <ListItemButton
-                component={RouterLink}
-                to={item.to}
-                onClick={onClose}
-              >
-                <ListItemIcon>
-                  <item.icon />
-                </ListItemIcon>
-                <ListItemText primary={item.label} />
-              </ListItemButton>
-            </ListItem>
-          ))}
-        </List>
-      </Box>
+      <List>
+        {menuItems.map((item) => (
+          <ListItem key={item.to} disablePadding>
+            <ListItemButton
+              component={RouterLink}
+              to={item.to}
+              onClick={onClose}
+            >
+              <ListItemIcon>
+                <item.icon />
+              </ListItemIcon>
+              <ListItemText primary={item.label} />
+            </ListItemButton>
+          </ListItem>
+        ))}
+      </List>
     </Drawer>
   );
 }

--- a/src/app/onboarding/onboarding-dialog.tsx
+++ b/src/app/onboarding/onboarding-dialog.tsx
@@ -51,7 +51,7 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
       slotProps={{
         paper: {
           sx: {
-            borderRadius: 6,
+            borderRadius: 1.5, // 6px (1.5 * theme.shape.borderRadius)
             p: 1,
           },
         },
@@ -61,11 +61,9 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
         id="welcome-dialog-title"
         variant="h4"
         sx={{
-          fontWeight: 800,
           textAlign: "center",
           mt: 3,
           mb: 1,
-          letterSpacing: "-0.02em",
           p: 0,
         }}
       >
@@ -76,7 +74,7 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
         <DialogContentText
           id="welcome-dialog-description"
           variant="body1"
-          sx={{ textAlign: "center", mb: 3, px: 2, lineHeight: 1.4 }}
+          sx={{ textAlign: "center", mb: 3, px: 2 }}
         >
           {m.onboardingTagline()}
         </DialogContentText>
@@ -97,11 +95,10 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
                 slotProps={{
                   primary: {
                     variant: "subtitle1",
-                    sx: { fontWeight: 700, mb: 0 },
+                    sx: { fontWeight: "bold", mb: 0 },
                   },
                   secondary: {
                     variant: "body2",
-                    sx: { lineHeight: 1.3 },
                   },
                 }}
               />
@@ -110,19 +107,8 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
         </List>
       </DialogContent>
 
-      <DialogActions sx={{ px: 3, py: 4 }}>
-        <Button
-          onClick={onClose}
-          variant="contained"
-          fullWidth
-          size="large"
-          sx={{
-            borderRadius: 4,
-            py: 1.5,
-            fontWeight: 800,
-            fontSize: "1.1rem",
-          }}
-        >
+      <DialogActions sx={{ px: 3, pb: 3 }}>
+        <Button onClick={onClose} variant="contained" fullWidth size="large">
           {m.onboardingContinue()}
         </Button>
       </DialogActions>

--- a/src/app/onboarding/onboarding-dialog.tsx
+++ b/src/app/onboarding/onboarding-dialog.tsx
@@ -51,7 +51,7 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
       slotProps={{
         paper: {
           sx: {
-            borderRadius: 1.5, // 6px (1.5 * theme.shape.borderRadius)
+            borderRadius: 6,
             p: 1,
           },
         },
@@ -108,7 +108,13 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
       </DialogContent>
 
       <DialogActions sx={{ px: 3, pb: 3 }}>
-        <Button onClick={onClose} variant="contained" fullWidth size="large">
+        <Button
+          onClick={onClose}
+          variant="contained"
+          fullWidth
+          size="large"
+          sx={{ borderRadius: 6 }}
+        >
           {m.onboardingContinue()}
         </Button>
       </DialogActions>

--- a/src/app/onboarding/onboarding-dialog.tsx
+++ b/src/app/onboarding/onboarding-dialog.tsx
@@ -57,21 +57,22 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
         },
       }}
     >
-      <DialogContent sx={{ pt: 4, pb: 4 }}>
-        <DialogTitle
-          id="welcome-dialog-title"
-          variant="h4"
-          sx={{
-            fontWeight: 800,
-            textAlign: "center",
-            mb: 1,
-            letterSpacing: "-0.02em",
-            p: 0,
-          }}
-        >
-          {APP_NAME}
-        </DialogTitle>
+      <DialogTitle
+        id="welcome-dialog-title"
+        variant="h4"
+        sx={{
+          fontWeight: 800,
+          textAlign: "center",
+          mt: 3,
+          mb: 1,
+          letterSpacing: "-0.02em",
+          p: 0,
+        }}
+      >
+        {APP_NAME}
+      </DialogTitle>
 
+      <DialogContent sx={{ pt: 0, pb: 4 }}>
         <DialogContentText
           id="welcome-dialog-description"
           variant="body1"

--- a/src/app/settings/settings-drawer.tsx
+++ b/src/app/settings/settings-drawer.tsx
@@ -1,5 +1,4 @@
 import CloseIcon from "@mui/icons-material/Close";
-import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
 import Drawer from "@mui/material/Drawer";
 import IconButton from "@mui/material/IconButton";
@@ -20,7 +19,12 @@ export interface SettingsDrawerProps {
 
 export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
   return (
-    <Drawer anchor="right" open={open} onClose={onClose}>
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={onClose}
+      slotProps={{ paper: { sx: { width: 320 } } }}
+    >
       <Toolbar>
         <Typography variant="h6" sx={{ flexGrow: 1 }}>
           {m.settingsTitle()}
@@ -39,22 +43,20 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
         </Tooltip>
       </Toolbar>
 
-      <Box sx={{ width: 320, px: 3, pb: 3 }}>
-        <Stack>
-          <AppearanceSettings />
+      <Stack sx={{ px: 3, pb: 3 }}>
+        <AppearanceSettings />
 
-          <Divider sx={{ my: 3 }} />
+        <Divider sx={{ my: 3 }} />
 
-          <Stack spacing={3}>
-            <LanguageSettings />
-            <SpeechSettings />
-          </Stack>
-
-          <Divider sx={{ my: 3 }} />
-
-          <AISettings />
+        <Stack spacing={3}>
+          <LanguageSettings />
+          <SpeechSettings />
         </Stack>
-      </Box>
+
+        <Divider sx={{ my: 3 }} />
+
+        <AISettings />
+      </Stack>
     </Drawer>
   );
 }

--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -46,14 +46,15 @@ export function BoardViewer({ board }: BoardViewerProps) {
   return (
     <Stack
       direction="column"
-      sx={(theme) => ({
-        height: "100%",
-        ...theme.applyStyles("dark", {
-          backgroundRepeat: "no-repeat",
-          backgroundImage:
-            "radial-gradient(80% 50% at 50% -20%, rgb(0, 41, 82), transparent)",
-        }),
-      })}
+      sx={[
+        { height: "100%" },
+        (theme) =>
+          theme.applyStyles("dark", {
+            backgroundRepeat: "no-repeat",
+            backgroundImage:
+              "radial-gradient(80% 50% at 50% -20%, rgb(0, 41, 82), transparent)",
+          }),
+      ]}
     >
       <MessageBar
         parts={message.parts}

--- a/src/features/board/grid/grid.test.tsx
+++ b/src/features/board/grid/grid.test.tsx
@@ -1,6 +1,6 @@
-import type { Locator } from "@vitest/browser/context";
 import { describe, expect, test } from "vitest";
 import { render } from "vitest-browser-react";
+import { userEvent, type Locator } from "vitest/browser";
 import { Grid } from "./grid";
 
 function getCellPosition(item: Locator): { row: number; col: number } {
@@ -20,12 +20,23 @@ function getCellPosition(item: Locator): { row: number; col: number } {
   return { row, col };
 }
 
-function press(item: Locator, key: string, modifiers: KeyboardEventInit = {}) {
-  item
-    .element()
-    .dispatchEvent(
-      new KeyboardEvent("keydown", { key, bubbles: true, ...modifiers }),
-    );
+async function press(
+  item: Locator,
+  key: string,
+  modifiers: { ctrlKey?: boolean; metaKey?: boolean; shiftKey?: boolean } = {},
+) {
+  item.element().focus();
+  let sequence = `{${key}}`;
+  if (modifiers.shiftKey) {
+    sequence = `{Shift>}${sequence}{/Shift}`;
+  }
+  if (modifiers.metaKey) {
+    sequence = `{Meta>}${sequence}{/Meta}`;
+  }
+  if (modifiers.ctrlKey) {
+    sequence = `{Control>}${sequence}{/Control}`;
+  }
+  await userEvent.keyboard(sequence);
 }
 
 function expectFocus(item: Locator) {
@@ -309,13 +320,7 @@ describe("Grid", () => {
       const item1 = screen.getByRole("button", { name: "Item 1", exact: true });
       const item2 = screen.getByRole("button", { name: "Item 2", exact: true });
 
-      item1.element().focus();
-      await expect.element(item1).toHaveFocus();
-
-      const item1El = item1.element();
-      item1El.dispatchEvent(
-        new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
-      );
+      await press(item1, "ArrowRight");
 
       await expect
         .poll(() => document.activeElement === item2.element())
@@ -346,14 +351,7 @@ describe("Grid", () => {
       const item1 = screen.getByRole("button", { name: "Item 1", exact: true });
       const item2 = screen.getByRole("button", { name: "Item 2", exact: true });
 
-      item1.element().focus();
-      await expect.element(item1).toHaveFocus();
-
-      item1
-        .element()
-        .dispatchEvent(
-          new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
-        );
+      await press(item1, "ArrowRight");
 
       await expect
         .poll(() => document.activeElement === item2.element())
@@ -385,14 +383,7 @@ describe("Grid", () => {
       const item1 = screen.getByRole("button", { name: "Item 1", exact: true });
       const item2 = screen.getByRole("button", { name: "Item 2", exact: true });
 
-      item1.element().focus();
-      await expect.element(item1).toHaveFocus();
-
-      item1
-        .element()
-        .dispatchEvent(
-          new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }),
-        );
+      await press(item1, "ArrowRight");
 
       await expect
         .poll(() => document.activeElement === item2.element())
@@ -413,14 +404,7 @@ describe("Grid", () => {
 
       const item1 = screen.getByRole("button", { name: "Item 1", exact: true });
 
-      item1.element().focus();
-      await expect.element(item1).toHaveFocus();
-
-      item1
-        .element()
-        .dispatchEvent(
-          new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
-        );
+      await press(item1, "ArrowDown");
 
       await expect
         .poll(() => document.activeElement === item1.element())
@@ -449,7 +433,7 @@ describe("Grid", () => {
       item3.element().focus();
       await expect.element(item3).toHaveFocus();
 
-      press(item3, "Home");
+      await press(item3, "Home");
 
       await expectFocus(item1);
     });
@@ -476,7 +460,7 @@ describe("Grid", () => {
       item1.element().focus();
       await expect.element(item1).toHaveFocus();
 
-      press(item1, "End");
+      await press(item1, "End");
 
       await expectFocus(item3);
     });
@@ -505,7 +489,7 @@ describe("Grid", () => {
       item3.element().focus();
       await expect.element(item3).toHaveFocus();
 
-      press(item3, "Home");
+      await press(item3, "Home");
 
       await expectFocus(item2);
     });
@@ -534,7 +518,7 @@ describe("Grid", () => {
       item1.element().focus();
       await expect.element(item1).toHaveFocus();
 
-      press(item1, "End");
+      await press(item1, "End");
 
       await expectFocus(item2);
     });
@@ -567,7 +551,7 @@ describe("Grid", () => {
       item4.element().focus();
       await expect.element(item4).toHaveFocus();
 
-      press(item4, "Home", { ctrlKey: true });
+      await press(item4, "Home", { ctrlKey: true });
 
       await expectFocus(item2);
     });
@@ -600,7 +584,7 @@ describe("Grid", () => {
       item1.element().focus();
       await expect.element(item1).toHaveFocus();
 
-      press(item1, "End", { ctrlKey: true });
+      await press(item1, "End", { ctrlKey: true });
 
       await expectFocus(item3);
     });
@@ -641,13 +625,13 @@ describe("Grid", () => {
         item1.element().focus();
         await expect.element(item1).toHaveFocus();
 
-        press(item1, "End", { [modifier]: true });
+        await press(item1, "End", { [modifier]: true });
         await expectFocus(item4);
 
         item4.element().focus();
         await expect.element(item4).toHaveFocus();
 
-        press(item4, "Home", { [modifier]: true });
+        await press(item4, "Home", { [modifier]: true });
         await expectFocus(item1);
       },
     );
@@ -673,7 +657,7 @@ describe("Grid", () => {
       item3.element().focus();
       await expect.element(item3).toHaveFocus();
 
-      press(item3, "Home", { shiftKey: true });
+      await press(item3, "Home", { shiftKey: true });
 
       await expectFocus(item3);
     });
@@ -700,7 +684,7 @@ describe("Grid", () => {
       item2.element().focus();
       await expect.element(item2).toHaveFocus();
 
-      press(item2, "ArrowRight");
+      await press(item2, "ArrowRight");
 
       await expectFocus(item1);
     });
@@ -727,7 +711,7 @@ describe("Grid", () => {
       item1.element().focus();
       await expect.element(item1).toHaveFocus();
 
-      press(item1, "ArrowLeft");
+      await press(item1, "ArrowLeft");
 
       await expectFocus(item2);
     });
@@ -760,7 +744,7 @@ describe("Grid", () => {
       item1.element().focus();
       await expect.element(item1).toHaveFocus();
 
-      press(item1, "ArrowDown");
+      await press(item1, "ArrowDown");
 
       await expectFocus(item2);
     });
@@ -791,7 +775,7 @@ describe("Grid", () => {
       item1.element().focus();
       await expect.element(item1).toHaveFocus();
 
-      press(item1, "Home");
+      await press(item1, "Home");
 
       await expectFocus(item3);
     });
@@ -821,7 +805,7 @@ describe("Grid", () => {
       item3.element().focus();
       await expect.element(item3).toHaveFocus();
 
-      press(item3, "End");
+      await press(item3, "End");
 
       await expectFocus(item1);
     });
@@ -853,7 +837,7 @@ describe("Grid", () => {
       // macOS Fn+Ctrl+ArrowLeft sends Ctrl+Home. Because ArrowLeft is the
       // forward/end direction in RTL, Ctrl+Home jumps to the last cell in
       // reading order — row max / col max — which is visually bottom-left.
-      press(item1, "Home", { ctrlKey: true });
+      await press(item1, "Home", { ctrlKey: true });
 
       await expectFocus(item4);
     });
@@ -885,7 +869,7 @@ describe("Grid", () => {
       // macOS Fn+Ctrl+ArrowRight sends Ctrl+End. ArrowRight is the
       // backward/start direction in RTL, so Ctrl+End jumps to the first
       // cell in reading order — row 0 / col 0 — which is visually top-right.
-      press(item4, "End", { ctrlKey: true });
+      await press(item4, "End", { ctrlKey: true });
 
       await expectFocus(item1);
     });

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -8,7 +8,11 @@ export type { BoardRouteParams } from "./navigation/use-board-navigation";
 export { boardPath, boardSetPath } from "./paths";
 export { getBoardSets, removeBoardSet } from "./storage/board-sets-store";
 export type { BoardSetRecord } from "./storage/db";
-export { BoardNotFoundError, getBoardSet, loadBoard } from "./storage/queries";
+export {
+  BoardNotFoundError,
+  getBoardSet,
+  hydrateBoard,
+} from "./storage/queries";
 export { useBoardSets } from "./storage/use-board-sets";
 export { useCustomInstructions } from "./suggestions/use-custom-instructions";
 export type { Board } from "./types";

--- a/src/features/board/message/message-bar.tsx
+++ b/src/features/board/message/message-bar.tsx
@@ -56,7 +56,7 @@ export function MessageBar({
             flexGrow: 2,
             gap: 2,
             paddingInlineEnd: 2,
-            borderRadius: 4, // 16px (4 * theme.shape.borderRadius)
+            borderRadius: 16,
             overflow: "hidden",
             bgcolor: "grey.200",
           },

--- a/src/features/board/message/message-bar.tsx
+++ b/src/features/board/message/message-bar.tsx
@@ -50,16 +50,18 @@ export function MessageBar({
     <Stack direction="row" sx={{ p: 2 }}>
       <Stack
         direction="row"
-        sx={(theme) => ({
-          height: 104,
-          flexGrow: 2,
-          gap: 2,
-          paddingInlineEnd: 2,
-          borderRadius: 18,
-          overflow: "hidden",
-          backgroundColor:
-            theme.palette.mode === "dark" ? "#383838" : "#ebebeb",
-        })}
+        sx={[
+          {
+            height: 104,
+            flexGrow: 2,
+            gap: 2,
+            paddingInlineEnd: 2,
+            borderRadius: 4, // 16px (4 * theme.shape.borderRadius)
+            overflow: "hidden",
+            bgcolor: "grey.200",
+          },
+          (theme) => theme.applyStyles("dark", { bgcolor: "grey.800" }),
+        ]}
       >
         <Stack
           ref={scrollContainerRef}

--- a/src/features/board/message/play-button.tsx
+++ b/src/features/board/message/play-button.tsx
@@ -32,10 +32,10 @@ export function PlayButton({
           sx={{
             width: 72,
             height: 72,
-            backgroundColor: (theme) => theme.palette.primary.main,
-            color: (theme) => theme.palette.primary.contrastText,
+            bgcolor: "primary.main",
+            color: "primary.contrastText",
             "&:hover": {
-              backgroundColor: (theme) => theme.palette.primary.dark,
+              bgcolor: "primary.dark",
             },
           }}
         >

--- a/src/features/board/message/play-button.tsx
+++ b/src/features/board/message/play-button.tsx
@@ -1,7 +1,7 @@
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import StopIcon from "@mui/icons-material/Stop";
 import Box from "@mui/material/Box";
-import IconButton from "@mui/material/IconButton";
+import Fab from "@mui/material/Fab";
 import Tooltip from "@mui/material/Tooltip";
 import { m } from "@paraglide/messages.js";
 import { flipForRtl } from "@shared/theme/rtl";
@@ -24,23 +24,18 @@ export function PlayButton({
   return (
     <Tooltip title={playButtonLabel}>
       <Box sx={{ alignSelf: "center" }}>
-        <IconButton
-          aria-label={playButtonLabel}
-          size="large"
+        <Fab
+          color="primary"
           disabled={disabled}
+          aria-label={playButtonLabel}
           onClick={isPlaying ? onStopClick : onPlayClick}
           sx={{
             width: 72,
             height: 72,
-            bgcolor: "primary.main",
-            color: "primary.contrastText",
-            "&:hover": {
-              bgcolor: "primary.dark",
-            },
           }}
         >
           {isPlaying ? <StopIcon /> : <PlayArrowIcon sx={flipForRtl} />}
-        </IconButton>
+        </Fab>
       </Box>
     </Tooltip>
   );

--- a/src/features/board/message/use-message-playback.test.tsx
+++ b/src/features/board/message/use-message-playback.test.tsx
@@ -1,5 +1,5 @@
 import { stubAudio, stubSpeech } from "@shared/testing/device-output";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 import { renderHook } from "vitest-browser-react";
 import type { MessagePart } from "./use-message";
 import { useMessagePlayback } from "./use-message-playback";
@@ -11,10 +11,6 @@ describe("useMessagePlayback", () => {
   beforeEach(() => {
     speech = stubSpeech();
     audio = stubAudio();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   test("speaks consecutive text parts as one merged utterance", async () => {

--- a/src/features/board/message/use-message.test.tsx
+++ b/src/features/board/message/use-message.test.tsx
@@ -1,12 +1,6 @@
-import { afterEach, describe, expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { renderHook } from "vitest-browser-react";
 import { useMessage } from "./use-message";
-
-const STORAGE_KEY = "message";
-
-afterEach(() => {
-  localStorage.removeItem(STORAGE_KEY);
-});
 
 describe("useMessage", () => {
   test("builds text from multiple parts joined by spaces", async () => {

--- a/src/features/board/obf/mapper.ts
+++ b/src/features/board/obf/mapper.ts
@@ -13,7 +13,7 @@ import type {
   BoardButton,
   BoardGrid,
   BoardLicense,
-  BoardLink,
+  LoadBoard,
 } from "../types";
 
 export function obfToBoard(obfBoard: OBFBoard): Board {
@@ -144,7 +144,7 @@ function parseAction(raw: string): BoardAction | null {
   }
 }
 
-function transformLoadBoard(obfLoadBoard: OBFLoadBoard): BoardLink {
+function transformLoadBoard(obfLoadBoard: OBFLoadBoard): LoadBoard {
   return {
     id: obfLoadBoard.id,
     name: obfLoadBoard.name,

--- a/src/features/board/storage/queries.test.ts
+++ b/src/features/board/storage/queries.test.ts
@@ -2,7 +2,7 @@ import type { OBFBoard } from "open-board-format";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { invalidateBoardSets } from "./board-sets-store";
 import { putAssets, putBoards, upsertBoardSet, withBoardsDB } from "./db";
-import { BoardNotFoundError, loadBoard } from "./queries";
+import { BoardNotFoundError, hydrateBoard } from "./queries";
 import { resetBoardsDB } from "./test-helpers";
 
 const SET_ID = "loader-test-set";
@@ -13,7 +13,7 @@ const REAL_PNG_URL = "/pwa-192x192.png";
 // Seed a minimal board with one path-based image, using a real PNG blob so
 // hydration produces an Image-loadable blob URL. Going direct to the storage
 // layer (vs. importBoardFiles) keeps the test independent of OBZ fixture
-// shape — the only thing under test here is loadBoard's behavior.
+// shape — the only thing under test here is hydrateBoard's behavior.
 async function seedTestBoard(): Promise<void> {
   const pngResponse = await fetch(REAL_PNG_URL);
   if (!pngResponse.ok) {
@@ -53,7 +53,7 @@ async function expectThrown(promise: Promise<unknown>): Promise<unknown> {
   } catch (error) {
     return error;
   }
-  throw new Error("Expected loadBoard to throw, but it resolved");
+  throw new Error("Expected hydrateBoard to throw, but it resolved");
 }
 
 // A blob URL is "alive" while its registry hasn't revoked it. Loading it as
@@ -73,7 +73,7 @@ function isObjectUrlAlive(url: string): Promise<boolean> {
   });
 }
 
-describe("loadBoard", () => {
+describe("hydrateBoard", () => {
   beforeEach(async () => {
     await resetBoardsDB();
     await invalidateBoardSets();
@@ -86,7 +86,7 @@ describe("loadBoard", () => {
   test("returns a hydrated board on the happy path", async () => {
     await seedTestBoard();
 
-    const board = await loadBoard(SET_ID, BOARD_ID);
+    const board = await hydrateBoard(SET_ID, BOARD_ID);
 
     expect(board.id).toBe(BOARD_ID);
 
@@ -99,20 +99,20 @@ describe("loadBoard", () => {
   test("throws BoardNotFoundError when the board is not in IDB", async () => {
     await seedTestBoard();
 
-    const error = await expectThrown(loadBoard(SET_ID, "missing-board"));
+    const error = await expectThrown(hydrateBoard(SET_ID, "missing-board"));
 
     expect(error).toBeInstanceOf(BoardNotFoundError);
   });
 
-  test("revokes the previous registry on the next loadBoard call", async () => {
+  test("revokes the previous registry on the next hydrateBoard call", async () => {
     await seedTestBoard();
 
-    const first = await loadBoard(SET_ID, BOARD_ID);
+    const first = await hydrateBoard(SET_ID, BOARD_ID);
     const firstUrl = first.buttons[0].imageSrc;
     expect(firstUrl).toBeDefined();
     expect(await isObjectUrlAlive(firstUrl!)).toBe(true);
 
-    const second = await loadBoard(SET_ID, BOARD_ID);
+    const second = await hydrateBoard(SET_ID, BOARD_ID);
     const secondUrl = second.buttons[0].imageSrc;
     expect(secondUrl).toBeDefined();
 
@@ -123,9 +123,9 @@ describe("loadBoard", () => {
   test("a missing-board error does not poison module state for a later success", async () => {
     await seedTestBoard();
 
-    await expectThrown(loadBoard(SET_ID, "missing-board"));
+    await expectThrown(hydrateBoard(SET_ID, "missing-board"));
 
-    const board = await loadBoard(SET_ID, BOARD_ID);
+    const board = await hydrateBoard(SET_ID, BOARD_ID);
     const url = board.buttons[0].imageSrc;
 
     expect(url).toBeDefined();

--- a/src/features/board/storage/queries.ts
+++ b/src/features/board/storage/queries.ts
@@ -32,7 +32,7 @@ export async function getBoardSet(
 // know when its URLs are safe to release; the next load defines that boundary.
 let previousRegistry: ObjectUrlRegistry | null = null;
 
-export async function loadBoard(
+export async function hydrateBoard(
   setId: string,
   boardId: string,
   signal?: AbortSignal,
@@ -41,7 +41,7 @@ export async function loadBoard(
   try {
     const board = await withBoardsDB(async (db) => {
       const obf = await fetchOBFBoard(db, setId, boardId);
-      const hydrated = await hydrateBoard(db, setId, obf, registry);
+      const hydrated = await hydrateOBFBoard(db, setId, obf, registry);
       return obfToBoard(hydrated);
     });
 
@@ -74,7 +74,7 @@ async function fetchOBFBoard(
   return record.obf;
 }
 
-async function hydrateBoard(
+async function hydrateOBFBoard(
   db: BoardsDB,
   setId: string,
   board: OBFBoard,

--- a/src/features/board/tile/tile.test.tsx
+++ b/src/features/board/tile/tile.test.tsx
@@ -51,7 +51,7 @@ describe("Tile", () => {
     const button = screen.getByRole("button", { name: "Colored" });
     const styles = getComputedStyle(button.element());
 
-    expect(styles.backgroundColor).toBe("rgb(0, 0, 0)");
+    expect(["rgb(0, 0, 0)", "oklab(0 0 0)"]).toContain(styles.backgroundColor);
     expect(styles.color).toBe("rgb(255, 255, 255)");
   });
 

--- a/src/features/board/tile/tile.tsx
+++ b/src/features/board/tile/tile.tsx
@@ -1,5 +1,4 @@
 import Button from "@mui/material/Button";
-import { darken } from "@mui/material/styles";
 import { getReadableTextColor } from "@shared/utils/colors";
 import { Pictogram } from "../pictogram/pictogram";
 
@@ -51,12 +50,12 @@ export function Tile({
         }),
         "&:hover": {
           backgroundColor: backgroundColor
-            ? darken(backgroundColor, 0.2)
+            ? `color-mix(in srgb, ${backgroundColor}, black 20%)`
             : undefined,
         },
         "&:active": {
           backgroundColor: backgroundColor
-            ? darken(backgroundColor, 0.3)
+            ? `color-mix(in srgb, ${backgroundColor}, black 30%)`
             : undefined,
         },
         "&:focus-visible": {

--- a/src/features/board/tile/tile.tsx
+++ b/src/features/board/tile/tile.tsx
@@ -59,7 +59,7 @@ export function Tile({
             : undefined,
         },
         "&:focus-visible": {
-          outline: `3px solid ${theme.palette.text.primary}`,
+          outline: `3px solid ${theme.vars?.palette.text.primary ?? theme.palette.text.primary}`,
           outlineOffset: 2,
         },
         "&::after": {

--- a/src/features/board/types.ts
+++ b/src/features/board/types.ts
@@ -24,7 +24,7 @@ export interface BoardButton {
   backgroundColor?: string;
   borderColor?: string;
   actions?: BoardAction[];
-  loadBoard?: BoardLink;
+  loadBoard?: LoadBoard;
 }
 
 export function getSpokenText(
@@ -44,7 +44,7 @@ export interface BoardLicense {
 
 export type BoardStrings = Record<string, Record<string, string>>;
 
-export interface BoardLink {
+export interface LoadBoard {
   id?: string;
   name?: string;
   url?: string;

--- a/src/features/board/use-board-translation.ts
+++ b/src/features/board/use-board-translation.ts
@@ -44,9 +44,9 @@ export function useBoardTranslation({
           signal,
         });
 
-        const phrases = collectSourcePhrases(board);
+        const translatableStrings = collectTranslatableStrings(board);
         const translations = await translatePhrases(
-          phrases,
+          translatableStrings,
           translator,
           signal,
         );
@@ -117,32 +117,32 @@ function applyTranslations(
   };
 }
 
-function collectSourcePhrases(board: Board): Set<string> {
-  const phrases = new Set<string>();
+function collectTranslatableStrings(board: Board): Set<string> {
+  const translatableStrings = new Set<string>();
 
   if (board.name) {
-    phrases.add(board.name);
+    translatableStrings.add(board.name);
   }
 
   for (const button of board.buttons) {
     if (button.label) {
-      phrases.add(button.label);
+      translatableStrings.add(button.label);
     }
     if (button.vocalization) {
-      phrases.add(button.vocalization);
+      translatableStrings.add(button.vocalization);
     }
   }
 
-  return phrases;
+  return translatableStrings;
 }
 
 async function translatePhrases(
-  phrases: Set<string>,
+  translatableStrings: Set<string>,
   translator: Translator,
   signal: AbortSignal,
 ): Promise<Record<string, string>> {
   const entries = await Promise.all(
-    Array.from(phrases).map(async (phrase) => {
+    Array.from(translatableStrings).map(async (phrase) => {
       const translated = await translator.translate(phrase, { signal });
       return [phrase, translated] as const;
     }),

--- a/src/features/board/use-button-activation.test.tsx
+++ b/src/features/board/use-button-activation.test.tsx
@@ -1,5 +1,5 @@
 import { stubAudio, stubSpeech } from "@shared/testing/device-output";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { renderHook } from "vitest-browser-react";
 import type { MessagePart, UseMessageReturn } from "./message/use-message";
 import type { UseMessagePlaybackReturn } from "./message/use-message-playback";
@@ -63,10 +63,6 @@ describe("useButtonActivation", () => {
   beforeEach(() => {
     speech = stubSpeech();
     audio = stubAudio();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   test("navigates to the linked board and skips message and audio when loadBoard.id is set", async () => {

--- a/src/features/board/use-button-activation.test.tsx
+++ b/src/features/board/use-button-activation.test.tsx
@@ -176,7 +176,7 @@ describe("useButtonActivation", () => {
     });
   });
 
-  test("treats a loadBoard without an id as not navigable and utters instead", async () => {
+  test("treats a loadBoard without an id as not navigable and speaks instead", async () => {
     const { result, message, navigation } = await setup();
 
     await result.current.activateButton({
@@ -189,7 +189,7 @@ describe("useButtonActivation", () => {
     expect(message.addPart).toHaveBeenCalledTimes(1);
   });
 
-  test("treats an empty actions array as no actions and utters instead", async () => {
+  test("treats an empty actions array as no actions and speaks instead", async () => {
     const { result, message } = await setup();
 
     await result.current.activateButton({

--- a/src/features/board/use-button-activation.ts
+++ b/src/features/board/use-button-activation.ts
@@ -37,7 +37,7 @@ export function useButtonActivation({
     }
 
     message.addPart(asMessagePart(button));
-    utter(button);
+    speakButton(button);
   }
 
   async function runAction(action: BoardAction) {
@@ -65,7 +65,7 @@ export function useButtonActivation({
     });
   }
 
-  function utter(button: BoardButton) {
+  function speakButton(button: BoardButton) {
     if (button.soundSrc) {
       void audio.play(button.soundSrc);
       return;

--- a/src/shared/built-in-ai/internal/lifecycle/create-instance.test.ts
+++ b/src/shared/built-in-ai/internal/lifecycle/create-instance.test.ts
@@ -31,7 +31,6 @@ function setUserActivation(isActive: boolean): void {
 }
 
 afterEach(() => {
-  vi.unstubAllGlobals();
   delete (navigator as unknown as { userActivation?: unknown }).userActivation;
 });
 

--- a/src/shared/built-in-ai/internal/lifecycle/use-lifecycle.test.tsx
+++ b/src/shared/built-in-ai/internal/lifecycle/use-lifecycle.test.tsx
@@ -49,7 +49,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  vi.unstubAllGlobals();
   delete (navigator as unknown as { userActivation?: unknown }).userActivation;
 });
 

--- a/src/shared/built-in-ai/is-supported.test.ts
+++ b/src/shared/built-in-ai/is-supported.test.ts
@@ -1,9 +1,5 @@
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { isSupported } from "./is-supported";
-
-afterEach(() => {
-  vi.unstubAllGlobals();
-});
 
 describe("isSupported", () => {
   test("returns true when the global namespace exists", () => {

--- a/src/shared/built-in-ai/proofreader/use-proofreader.test.tsx
+++ b/src/shared/built-in-ai/proofreader/use-proofreader.test.tsx
@@ -1,12 +1,8 @@
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { renderHook } from "vitest-browser-react";
 import { makeAIFake } from "../internal/testing/ai-namespace-fake";
 import { buildProofreaderInstance } from "../internal/testing/instance-fakes";
 import { useProofreader } from "./use-proofreader";
-
-afterEach(() => {
-  vi.unstubAllGlobals();
-});
 
 describe("useProofreader", () => {
   test("reaches ready", async () => {

--- a/src/shared/built-in-ai/rewriter/use-rewriter.test.tsx
+++ b/src/shared/built-in-ai/rewriter/use-rewriter.test.tsx
@@ -1,12 +1,8 @@
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { renderHook } from "vitest-browser-react";
 import { makeAIFake } from "../internal/testing/ai-namespace-fake";
 import { buildRewriterInstance } from "../internal/testing/instance-fakes";
 import { useRewriter } from "./use-rewriter";
-
-afterEach(() => {
-  vi.unstubAllGlobals();
-});
 
 describe("useRewriter", () => {
   test("reaches ready and exposes inputQuota from the instance", async () => {

--- a/src/shared/built-in-ai/translator/use-translator.test.tsx
+++ b/src/shared/built-in-ai/translator/use-translator.test.tsx
@@ -1,12 +1,8 @@
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { renderHook } from "vitest-browser-react";
 import { makeAIFake } from "../internal/testing/ai-namespace-fake";
 import { buildTranslatorInstance } from "../internal/testing/instance-fakes";
 import { useTranslator } from "./use-translator";
-
-afterEach(() => {
-  vi.unstubAllGlobals();
-});
 
 describe("useTranslator", () => {
   test("reaches ready and exposes inputQuota from the instance", async () => {

--- a/src/shared/hooks/use-persistent-state.test.tsx
+++ b/src/shared/hooks/use-persistent-state.test.tsx
@@ -1,12 +1,8 @@
-import { afterEach, describe, expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { renderHook } from "vitest-browser-react";
 import { usePersistentState } from "./use-persistent-state";
 
 const KEY = "test-persistent-state";
-
-afterEach(() => {
-  localStorage.removeItem(KEY);
-});
 
 describe("usePersistentState", () => {
   test("returns initial value when localStorage is empty", async () => {
@@ -92,8 +88,5 @@ describe("usePersistentState", () => {
 
     expect(hookA.result.current[0]).toBe("changed-a");
     expect(hookB.result.current[0]).toBe("b");
-
-    localStorage.removeItem(keyA);
-    localStorage.removeItem(keyB);
   });
 });

--- a/src/shared/snackbar/snackbar-provider.tsx
+++ b/src/shared/snackbar/snackbar-provider.tsx
@@ -122,6 +122,7 @@ export function SnackbarProvider({ children }: SnackbarProviderProps) {
       >
         <Alert
           severity={state.current?.severity ?? DEFAULT_SNACKBAR_SEVERITY}
+          onClose={handleClose}
           sx={{ width: "100%" }}
         >
           {state.current?.message}

--- a/src/shared/speech/speech-store.test.ts
+++ b/src/shared/speech/speech-store.test.ts
@@ -1,13 +1,9 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 describe("speech-store without Web Speech API", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.stubGlobal("speechSynthesis", undefined);
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
   });
 
   test("speak() resolves silently instead of throwing", async () => {

--- a/src/shared/testing/global-setup.ts
+++ b/src/shared/testing/global-setup.ts
@@ -1,0 +1,6 @@
+import { beforeEach } from "vitest";
+
+beforeEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+});

--- a/src/shared/theme/theme-provider.tsx
+++ b/src/shared/theme/theme-provider.tsx
@@ -21,7 +21,11 @@ const rtlCache = createCache({
 });
 
 const themeOptions = {
+  cssVariables: {
+    colorSchemeSelector: "class",
+  },
   colorSchemes: {
+    light: true,
     dark: true,
   },
   typography: {
@@ -40,7 +44,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
 
   return (
     <CacheProvider value={isRtl ? rtlCache : ltrCache}>
-      <MUIThemeProvider theme={isRtl ? rtlTheme : ltrTheme} noSsr>
+      <MUIThemeProvider theme={isRtl ? rtlTheme : ltrTheme}>
         <CssBaseline />
         {children}
       </MUIThemeProvider>

--- a/src/shared/theme/theme-provider.tsx
+++ b/src/shared/theme/theme-provider.tsx
@@ -28,10 +28,6 @@ const themeOptions = {
     button: {
       textTransform: "none",
     },
-    h4: {
-      fontWeight: 800,
-      letterSpacing: "-0.02em",
-    },
   },
 } as const;
 

--- a/src/shared/theme/theme-provider.tsx
+++ b/src/shared/theme/theme-provider.tsx
@@ -28,6 +28,10 @@ const themeOptions = {
     button: {
       textTransform: "none",
     },
+    h4: {
+      fontWeight: 800,
+      letterSpacing: "-0.02em",
+    },
   },
 } as const;
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -72,6 +72,10 @@ export default defineConfig({
     ],
   },
   test: {
+    setupFiles: ["./src/shared/testing/global-setup.ts"],
+    restoreMocks: true,
+    unstubGlobals: true,
+    unstubEnvs: true,
     browser: {
       enabled: true,
       provider: playwright(),


### PR DESCRIPTION
## Summary
- Align core domain vocabulary in `src/features/board` with canonical AAC specifications (OBF/OBZ); rename and adjust types, loader, queries, and hooks accordingly
- Adopt theme tokens and CSS variables: enable CSS variables/color schemes on `ThemeProvider`, replace legacy `mode === 'dark'` checks and hard-coded hex colors (MessageBar, Tile), use `color-mix` instead of JS `darken`, and switch `BoardViewer` to the array form of `applyStyles`
- Replace hand-rolled MUI primitives with built-ins: `PlayButton` now uses `Fab`, `Drawer` sizes its `Paper` slot directly, `OnboardingDialog` un-nests `DialogTitle` and consolidates typography/shape tokens
- Accessibility fixes: `SnackbarProvider` Alert gets an `onClose` dismiss callback (WCAG), and tile focus outline is restored by handling `overflow: hidden` with theme CSS variables
- Test infrastructure: centralize storage and mock cleanup via Vitest global setup; simplify per-test boilerplate across hooks, board, and built-in-AI suites

## Test plan
- [ ] `npm run lint`
- [ ] `npm test`
- [ ] Manual: open a board, send a message, verify Play button + MessageBar styling in light and dark mode
- [ ] Manual: open Settings and Menu drawers, confirm sizing and theming
- [ ] Manual: trigger a snackbar, confirm it can be dismissed via the close button (keyboard + click)
- [ ] Manual: tab through tiles, verify focus outline is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)