### PR TITLE
refactor: rename obf/mapper to obf-to-board and extract parse-action

### DIFF
--- a/src/features/board/import/board-import.ts
+++ b/src/features/board/import/board-import.ts
@@ -7,7 +7,7 @@ import {
   type OBFBoard,
   type OBFManifest,
 } from "open-board-format";
-import { resolveLoadBoardPaths } from "../obf/mapper";
+import { resolveLoadBoardPaths } from "../obf/obf-to-board";
 import { notifyBoardSetsChanged } from "../storage/board-sets-store";
 import type {
   BoardsDB,

--- a/src/features/board/obf/obf-to-board.test.ts
+++ b/src/features/board/obf/obf-to-board.test.ts
@@ -1,6 +1,6 @@
 import type { OBFBoard } from "open-board-format";
 import { describe, expect, test } from "vitest";
-import { obfToBoard, resolveLoadBoardPaths } from "./mapper";
+import { obfToBoard, resolveLoadBoardPaths } from "./obf-to-board";
 
 describe("obfToBoard", () => {
   test("maps a minimal board (id, buttons, grid)", () => {

--- a/src/features/board/obf/obf-to-board.ts
+++ b/src/features/board/obf/obf-to-board.ts
@@ -15,6 +15,7 @@ import type {
   BoardLicense,
   LoadBoard,
 } from "../types";
+import { parseAction } from "./parse-action";
 
 export function obfToBoard(obfBoard: OBFBoard): Board {
   const imageSourceById = buildMediaSourceMap(obfBoard.images);
@@ -122,26 +123,6 @@ function collectActions(obfButton: OBFButton): BoardAction[] {
     const action = value ? parseAction(value) : null;
     return action ? [action] : [];
   });
-}
-
-function parseAction(raw: string): BoardAction | null {
-  if (raw.startsWith("+")) {
-    return { kind: "spell", text: raw.slice(1).trim() };
-  }
-  switch (raw) {
-    case ":space":
-      return { kind: "space" };
-    case ":backspace":
-      return { kind: "backspace" };
-    case ":clear":
-      return { kind: "clear" };
-    case ":home":
-      return { kind: "home" };
-    case ":speak":
-      return { kind: "speak" };
-    default:
-      return null;
-  }
 }
 
 function transformLoadBoard(obfLoadBoard: OBFLoadBoard): LoadBoard {

--- a/src/features/board/obf/parse-action.test.ts
+++ b/src/features/board/obf/parse-action.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest";
+import { parseAction } from "./parse-action";
+
+describe("parseAction", () => {
+  test.each([
+    [":space", { kind: "space" }],
+    [":backspace", { kind: "backspace" }],
+    [":clear", { kind: "clear" }],
+    [":home", { kind: "home" }],
+    [":speak", { kind: "speak" }],
+  ] as const)("parses %s", (raw, expected) => {
+    expect(parseAction(raw)).toEqual(expected);
+  });
+
+  test("parses +text as a spell action", () => {
+    expect(parseAction("+ing")).toEqual({ kind: "spell", text: "ing" });
+  });
+
+  test("trims whitespace inside spell text", () => {
+    expect(parseAction("+  ing  ")).toEqual({ kind: "spell", text: "ing" });
+  });
+
+  test("allows empty spell text", () => {
+    expect(parseAction("+")).toEqual({ kind: "spell", text: "" });
+  });
+
+  test("returns null for unknown colon actions", () => {
+    expect(parseAction(":unknown")).toBeNull();
+  });
+
+  test("returns null for empty string", () => {
+    expect(parseAction("")).toBeNull();
+  });
+
+  test("returns null for arbitrary text", () => {
+    expect(parseAction("hello")).toBeNull();
+  });
+});

--- a/src/features/board/obf/parse-action.ts
+++ b/src/features/board/obf/parse-action.ts
@@ -1,0 +1,21 @@
+import type { BoardAction } from "../types";
+
+export function parseAction(raw: string): BoardAction | null {
+  if (raw.startsWith("+")) {
+    return { kind: "spell", text: raw.slice(1).trim() };
+  }
+  switch (raw) {
+    case ":space":
+      return { kind: "space" };
+    case ":backspace":
+      return { kind: "backspace" };
+    case ":clear":
+      return { kind: "clear" };
+    case ":home":
+      return { kind: "home" };
+    case ":speak":
+      return { kind: "speak" };
+    default:
+      return null;
+  }
+}

--- a/src/features/board/storage/queries.ts
+++ b/src/features/board/storage/queries.ts
@@ -3,7 +3,7 @@ import {
   type ObjectUrlRegistry,
 } from "@shared/utils/object-url";
 import type { OBFBoard, OBFMedia } from "open-board-format";
-import { obfToBoard } from "../obf/mapper";
+import { obfToBoard } from "../obf/obf-to-board";
 import type { Board } from "../types";
 import {
   getBoardSet as dbGetBoardSet,


### PR DESCRIPTION
## Summary
- Rename `src/features/board/obf/mapper.ts` → `obf-to-board.ts` to describe what the file actually does (a one-direction mapper from OBF to the internal Board shape).
- Extract the OBF action DSL parser (`:space`, `:backspace`, `:home`, `:speak`, `:clear`, `+<text>`) into its own `parse-action.ts` with dedicated tests.

Addresses §4 P2 from [docs/consolidated-action-plan.md](../blob/main/docs/consolidated-action-plan.md).

## Test plan
- [ ] OBF imports still produce the same Board output
- [ ] Action DSL parsing handles all six known tokens
- [ ] `npm run lint` and `npm test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)