### PR TITLE
fix: tighten raceAbort and drop redundant revoke on hydrateBoard abort

### DIFF
--- a/src/features/board/storage/queries.ts
+++ b/src/features/board/storage/queries.ts
@@ -47,7 +47,6 @@ export async function hydrateBoard(
 
     // Don't promote a superseded registry — it would orphan the live one.
     if (signal?.aborted) {
-      registry.revokeAll();
       throw new DOMException("Aborted", "AbortError");
     }
 

--- a/src/shared/built-in-ai/internal/signal.test.ts
+++ b/src/shared/built-in-ai/internal/signal.test.ts
@@ -83,10 +83,28 @@ describe("raceAbort", () => {
     );
   });
 
-  test("removes its abort listener once the promise resolves", async () => {
+  test("aborts its cleanup signal once the promise resolves", async () => {
     const { signal } = new AbortController();
-    const removeSpy = vi.spyOn(signal, "removeEventListener");
+    const addSpy = vi.spyOn(signal, "addEventListener");
+
     await raceAbort(Promise.resolve("ok"), signal);
-    expect(removeSpy).toHaveBeenCalledWith("abort", expect.any(Function));
+
+    const options = addSpy.mock.calls[0]?.[2] as
+      | AddEventListenerOptions
+      | undefined;
+    expect(options?.signal?.aborted).toBe(true);
+  });
+
+  test("aborts its cleanup signal once the promise rejects", async () => {
+    const { signal } = new AbortController();
+    const addSpy = vi.spyOn(signal, "addEventListener");
+    const inner = new Error("inner");
+
+    await expect(raceAbort(Promise.reject(inner), signal)).rejects.toBe(inner);
+
+    const options = addSpy.mock.calls[0]?.[2] as
+      | AddEventListenerOptions
+      | undefined;
+    expect(options?.signal?.aborted).toBe(true);
   });
 });

--- a/src/shared/built-in-ai/internal/signal.ts
+++ b/src/shared/built-in-ai/internal/signal.ts
@@ -25,18 +25,24 @@ export function raceAbort<T>(
   if (signal.aborted) {
     return Promise.reject(toError(signal.reason));
   }
-  return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(toError(signal.reason));
-    signal.addEventListener("abort", onAbort, { once: true });
-    promise.then(
-      (v) => {
-        signal.removeEventListener("abort", onAbort);
-        resolve(v);
-      },
-      (e: unknown) => {
-        signal.removeEventListener("abort", onAbort);
-        reject(toError(e));
-      },
-    );
+
+  const { promise: result, resolve, reject } = Promise.withResolvers<T>();
+  const cleanup = new AbortController();
+
+  signal.addEventListener("abort", () => reject(toError(signal.reason)), {
+    signal: cleanup.signal,
   });
+
+  promise.then(
+    (value) => {
+      cleanup.abort();
+      resolve(value);
+    },
+    (error: unknown) => {
+      cleanup.abort();
+      reject(toError(error));
+    },
+  );
+
+  return result;
 }


### PR DESCRIPTION
## Summary
- Rewrite `raceAbort` in `signal.ts` with `Promise.withResolvers` and signal-based abort-listener cleanup, matching the pattern already used in `speech-store.ts`. Flatter form, no manual `removeEventListener` calls.
- Drop the redundant `revokeAll()` on the abort path in `hydrateBoard` — the catch block already handles it.

Addresses §1 P0 `raceAbort` from [docs/consolidated-action-plan.md](../blob/main/docs/consolidated-action-plan.md). (The `ObjectUrlRegistry` `using`-friendly rewrite from the same section is still TODO.)

## Test plan
- [ ] `raceAbort` still rejects on signal abort with the right reason
- [ ] Abort listener is cleaned up on both success and rejection paths
- [ ] `hydrateBoard` abort path still revokes URLs exactly once
- [ ] `npm run lint` and `npm test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)