### PR TITLE
refactor: add persistBoardTranslations query, stop hook reaching into db.ts

### DIFF
--- a/src/features/board/storage/queries.ts
+++ b/src/features/board/storage/queries.ts
@@ -9,6 +9,7 @@ import {
   getBoardSet as dbGetBoardSet,
   getAssetBlob,
   getBoard,
+  updateBoardStrings,
   withBoardsDB,
   type BoardSetRecord,
   type BoardsDB,
@@ -25,6 +26,17 @@ export async function getBoardSet(
   setId: string,
 ): Promise<BoardSetRecord | undefined> {
   return withBoardsDB((db) => dbGetBoardSet(db, setId));
+}
+
+export async function persistBoardTranslations(
+  setId: string,
+  boardId: string,
+  locale: string,
+  translations: Record<string, string>,
+): Promise<void> {
+  await withBoardsDB((db) =>
+    updateBoardStrings(db, setId, boardId, locale, translations),
+  );
 }
 
 // Single concurrent caller assumed — the only consumer is boardLoader.

--- a/src/features/board/use-board-translation.ts
+++ b/src/features/board/use-board-translation.ts
@@ -2,7 +2,7 @@ import { createTranslator } from "@shared/built-in-ai";
 import { useLanguage } from "@shared/language/use-language";
 import { getLanguageCode } from "@shared/utils/locale";
 import { useEffect, useState } from "react";
-import { updateBoardStrings, withBoardsDB } from "./storage/db";
+import { persistBoardTranslations } from "./storage/queries";
 import type { Board } from "./types";
 
 const DEFAULT_BOARD_LANGUAGE = "en";
@@ -158,9 +158,7 @@ async function persistTranslations(
   translations: Record<string, string>,
 ): Promise<void> {
   try {
-    await withBoardsDB(async (db) => {
-      await updateBoardStrings(db, setId, boardId, locale, translations);
-    });
+    await persistBoardTranslations(setId, boardId, locale, translations);
   } catch {
     // Failure only costs a re-translation next load.
   }


### PR DESCRIPTION
## Summary
- Add `persistBoardTranslations(setId, boardId, locale, translations)` to `features/board/storage/queries.ts` — a thin wrapper around `withBoardsDB` + `updateBoardStrings`.
- Rewire `useBoardTranslation` to call it; drop the direct `withBoardsDB`/`updateBoardStrings` imports from the hook.

After this, `queries.ts` is the only file in `features/board/` that touches `withBoardsDB`. The level boundary inside the feature (React/hook layer → query layer → DB layer) holds.

Failure-swallow semantics intentionally stay in the hook — "AAC UX: failure costs a re-translation next load" is a caller-specific concern, not a property of the query itself.

Addresses §2 P1 from [docs/consolidated-action-plan.md](../blob/main/docs/consolidated-action-plan.md).

## Test plan
- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (333 tests)
- [ ] Translations still persist across reloads
- [ ] Persist failure still silently allows next-load re-translation

🤖 Generated with [Claude Code](https://claude.com/claude-code)