### PR TITLE
refactor: align built-in AI options and harden acquire against reset race

### DIFF
--- a/src/shared/built-in-ai/errors.ts
+++ b/src/shared/built-in-ai/errors.ts
@@ -1,7 +1,7 @@
 /**
- * Base class for every error thrown by this package's lifecycle. Use
- * `instanceof BuiltInAIError` to separate library errors from browser API
- * rejections (e.g. `AbortError`) that pass through unchanged.
+ * Base for the typed subclasses below, and the concrete wrapper for unmapped
+ * rejections (inspect `.cause`). `instanceof BuiltInAIError` separates library
+ * errors from pass-through browser rejections like `AbortError`.
  */
 export class BuiltInAIError extends Error {
   override name = "BuiltInAIError";

--- a/src/shared/built-in-ai/internal/lifecycle/store.ts
+++ b/src/shared/built-in-ai/internal/lifecycle/store.ts
@@ -267,7 +267,11 @@ export function createStore<
     if (merged.aborted) {
       throw merged.reason;
     }
-    return { instance: instance!, signal: merged };
+    // start()/stop() during the await nulls instance under a fresh (unaborted) controller.
+    if (!instance) {
+      throw new NotReadyError();
+    }
+    return { instance, signal: merged };
   };
 
   return {

--- a/src/shared/built-in-ai/proofreader/use-proofreader.ts
+++ b/src/shared/built-in-ai/proofreader/use-proofreader.ts
@@ -8,7 +8,10 @@ import type { BaseHookReturn } from "../types";
  *
  * @see https://developer.chrome.com/docs/ai/proofreader-api
  */
-export type ProofreaderOptions = ProofreaderCreateCoreOptions;
+export type ProofreaderOptions = Omit<
+  ProofreaderCreateOptions,
+  "signal" | "monitor"
+>;
 
 /** Per-call options for {@link useProofreader} action methods. */
 export type ProofreadCallOptions = ProofreaderProofreadOptions;

--- a/src/shared/built-in-ai/translator/use-translator.ts
+++ b/src/shared/built-in-ai/translator/use-translator.ts
@@ -9,7 +9,10 @@ import type { BaseHookReturn } from "../types";
  *
  * @see https://developer.chrome.com/docs/ai/translator-api
  */
-export type TranslatorOptions = TranslatorCreateCoreOptions;
+export type TranslatorOptions = Omit<
+  TranslatorCreateOptions,
+  "signal" | "monitor"
+>;
 
 /** Per-call options for {@link useTranslator} action methods. */
 export type TranslateCallOptions = TranslatorTranslateOptions;


### PR DESCRIPTION
## Summary
- Unify `TranslatorOptions` / `ProofreaderOptions` on `Omit<*CreateOptions, "signal" | "monitor">` so all three built-in AI hooks share one spelling (Rewriter already used it because it needs `sharedContext`, which `*CreateCoreOptions` strips).
- Replace `instance!` in `store.acquire` with an explicit `NotReadyError`: a concurrent `start()`/`stop()` during the `ensureReady` await rebuilds the abort controller, so `merged.aborted` alone can't catch the swap.
- Tighten `BuiltInAIError`'s doc to name its dual role (base class + concrete wrapper for unmapped rejections, inspect `.cause`).

## Test plan
- [x] `npm run -s lint -- <touched files>` clean
- [x] `npx vitest run src/shared/built-in-ai` — 82/82 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)