### PR TITLE
refactor: require rootBoardId on BoardSetRecord

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/da.json
+++ b/messages/da.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/el.json
+++ b/messages/el.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/he.json
+++ b/messages/he.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "המשך",
   "errorGenericTitle": "משהו השתבש",
   "errorGoHome": "חזרה לעמוד הבית",
-  "errorBoardSetNotFound": "ערכת הלוחות לא נמצאה",
-  "errorBoardSetIncomplete": "ערכת הלוחות אינה מלאה"
+  "errorBoardSetNotFound": "ערכת הלוחות לא נמצאה"
 }

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/id.json
+++ b/messages/id.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/te.json
+++ b/messages/te.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/th.json
+++ b/messages/th.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -77,6 +77,5 @@
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
-  "errorBoardSetNotFound": "Board set not found",
-  "errorBoardSetIncomplete": "Board set incomplete"
+  "errorBoardSetNotFound": "Board set not found"
 }

--- a/src/app/loaders/board-set-index-loader.test.ts
+++ b/src/app/loaders/board-set-index-loader.test.ts
@@ -59,12 +59,4 @@ describe("boardSetIndexLoader", () => {
 
     expectThrownStatus(error, 404);
   });
-
-  test("throws 422 when the board set has no root board", async () => {
-    await seedBoardSets([{ setId: "set-1" }]);
-
-    const error = await expectThrown(callLoader("set-1"));
-
-    expectThrownStatus(error, 422);
-  });
 });

--- a/src/app/loaders/board-set-index-loader.ts
+++ b/src/app/loaders/board-set-index-loader.ts
@@ -12,9 +12,6 @@ export async function boardSetIndexLoader({
   if (!set) {
     throw data(m.errorBoardSetNotFound(), { status: 404 });
   }
-  if (!set.rootBoardId) {
-    throw data(m.errorBoardSetIncomplete(), { status: 422 });
-  }
 
   return redirect(boardPath({ setId, boardId: set.rootBoardId }));
 }

--- a/src/app/loaders/root-index-loader.test.ts
+++ b/src/app/loaders/root-index-loader.test.ts
@@ -59,22 +59,6 @@ describe("rootIndexLoader", () => {
     expect(response.headers.get("Location")).toBe("/sets/set-2/boards/root-2");
   });
 
-  test("skips sets without a rootBoardId and falls through to the default board", async () => {
-    const probe = await fetch(DEFAULT_BOARD_PATH);
-    if (!probe.ok) {
-      throw new Error(`Default board fixture missing at ${DEFAULT_BOARD_PATH}`);
-    }
-
-    await seedBoardSets([{ setId: "set-broken" }]);
-
-    const response = await callLoader();
-
-    expect(response.status).toBe(302);
-    expect(response.headers.get("Location")).toMatch(
-      /^\/sets\/[^/]+\/boards\/[^/]+$/,
-    );
-  });
-
   test("imports the default board when no param is given and IDB is empty", async () => {
     const probe = await fetch(DEFAULT_BOARD_PATH);
     if (!probe.ok) {

--- a/src/app/loaders/root-index-loader.ts
+++ b/src/app/loaders/root-index-loader.ts
@@ -1,18 +1,8 @@
 import { boardPath } from "@app/route-patterns";
-import {
-  getBoardSets,
-  importBoardFromUrl,
-  type BoardSetRecord,
-} from "@features/board";
+import { getBoardSets, importBoardFromUrl } from "@features/board";
 import { redirect, type LoaderFunctionArgs } from "react-router";
 
 const DEFAULT_BOARD_URL = `${import.meta.env.BASE_URL}quick-core-24.obz`;
-
-function hasRootBoard(
-  set: BoardSetRecord,
-): set is BoardSetRecord & { rootBoardId: string } {
-  return Boolean(set.rootBoardId);
-}
 
 async function resolveInitialRedirectPath(
   boardUrl: string | null,
@@ -22,7 +12,7 @@ async function resolveInitialRedirectPath(
     return boardPath({ setId, boardId });
   }
 
-  const existing = (await getBoardSets()).find(hasRootBoard);
+  const [existing] = await getBoardSets();
   if (existing) {
     return boardPath({ setId: existing.setId, boardId: existing.rootBoardId });
   }

--- a/src/features/board/import/board-import.ts
+++ b/src/features/board/import/board-import.ts
@@ -96,7 +96,9 @@ function resolveRootBoardId(
   if (fromManifest) {
     return fromManifest;
   }
-  return manifest.root.split("/").at(-1)?.replace(".obf", "") ?? "";
+  throw new Error(
+    `Manifest root "${manifest.root}" does not match any board in manifest.paths.boards`,
+  );
 }
 
 function buildBoardRecords(

--- a/src/features/board/navigation/use-board-navigation.test.tsx
+++ b/src/features/board/navigation/use-board-navigation.test.tsx
@@ -80,14 +80,6 @@ describe("useBoardNavigation", () => {
       expect(result.current.nav.canGoHome).toBe(true);
     });
 
-    test("is false when the board set has no root board", async () => {
-      await seedBoardSets([{ setId: "set-1" }]);
-
-      const { result } = await setup();
-
-      expect(result.current.nav.canGoHome).toBe(false);
-    });
-
     test("is false when the board set is missing", async () => {
       await seedBoardSets([]);
 

--- a/src/features/board/navigation/use-board-navigation.ts
+++ b/src/features/board/navigation/use-board-navigation.ts
@@ -37,13 +37,12 @@ export function useBoardNavigation(): UseBoardNavigationReturn {
 
   const { setId, boardId } = useParams<BoardRouteParams>();
   const { boardSets } = useBoardSets();
-  const rootBoardId =
-    boardSets.find((set) => set.setId === setId)?.rootBoardId ?? "";
+  const rootBoardId = boardSets.find((set) => set.setId === setId)?.rootBoardId;
 
   const backStack = readBackStack(location.state);
 
   const canGoBack = backStack.length > 0;
-  const canGoHome = rootBoardId !== "";
+  const canGoHome = Boolean(rootBoardId);
 
   function goToBoard(id: string) {
     if (!setId || !id || id === boardId) {

--- a/src/features/board/storage/db.test.ts
+++ b/src/features/board/storage/db.test.ts
@@ -11,8 +11,15 @@ import {
   upsertBoardSet,
   withBoardsDB,
   type BoardsDB,
+  type UpsertBoardSetInput,
 } from "./db";
 import { openCleanBoardsDB } from "./test-helpers";
+
+function makeBoardSetInput(
+  overrides: Partial<UpsertBoardSetInput> = {},
+): UpsertBoardSetInput {
+  return { setId: "set-1", name: "Set", rootBoardId: "root-1", ...overrides };
+}
 
 function makeOBFBoard(overrides: Partial<OBFBoard> = {}): OBFBoard {
   return {
@@ -43,7 +50,7 @@ describe("upsertBoardSet", () => {
   test("inserts a new board set", async () => {
     const db = await openTestDB();
 
-    await upsertBoardSet(db, { setId: "set-1", name: "My Set" });
+    await upsertBoardSet(db, makeBoardSetInput({ name: "My Set" }));
 
     const sets = await listBoardSets(db);
     expect(sets).toHaveLength(1);
@@ -52,31 +59,14 @@ describe("upsertBoardSet", () => {
     expect(sets[0].boardCount).toBe(0);
   });
 
-  test("updates an existing board set preserving rootBoardId", async () => {
-    const db = await openTestDB();
-
-    await upsertBoardSet(db, {
-      setId: "set-1",
-      name: "Original",
-      rootBoardId: "root-1",
-    });
-
-    await upsertBoardSet(db, { setId: "set-1", name: "Updated" });
-
-    const sets = await listBoardSets(db);
-    expect(sets).toHaveLength(1);
-    expect(sets[0].name).toBe("Updated");
-    expect(sets[0].rootBoardId).toBe("root-1");
-  });
-
   test("preserves boardCount on upsert", async () => {
     const db = await openTestDB();
 
-    await upsertBoardSet(db, { setId: "set-1", name: "Set" });
+    await upsertBoardSet(db, makeBoardSetInput());
     const obf = makeOBFBoard({ id: "b1" });
     await putBoards(db, "set-1", [{ boardId: "b1", name: "B1", obf }]);
 
-    await upsertBoardSet(db, { setId: "set-1", name: "Set Renamed" });
+    await upsertBoardSet(db, makeBoardSetInput({ name: "Set Renamed" }));
 
     const sets = await listBoardSets(db);
     expect(sets[0].boardCount).toBe(1);
@@ -86,7 +76,7 @@ describe("upsertBoardSet", () => {
     const db = await openTestDB();
 
     await expect(
-      upsertBoardSet(db, { setId: "", name: "Bad" }),
+      upsertBoardSet(db, makeBoardSetInput({ setId: "", name: "Bad" })),
     ).rejects.toThrow("Invalid setId");
   });
 
@@ -94,7 +84,10 @@ describe("upsertBoardSet", () => {
     const db = await openTestDB();
 
     await expect(
-      upsertBoardSet(db, { setId: "x".repeat(256), name: "Bad" }),
+      upsertBoardSet(
+        db,
+        makeBoardSetInput({ setId: "x".repeat(256), name: "Bad" }),
+      ),
     ).rejects.toThrow("Invalid setId");
   });
 });
@@ -110,8 +103,8 @@ describe("listBoardSets", () => {
   test("returns sets sorted by updatedAt descending", async () => {
     const db = await openTestDB();
 
-    await upsertBoardSet(db, { setId: "old", name: "Old" });
-    await upsertBoardSet(db, { setId: "new", name: "New" });
+    await upsertBoardSet(db, makeBoardSetInput({ setId: "old", name: "Old" }));
+    await upsertBoardSet(db, makeBoardSetInput({ setId: "new", name: "New" }));
 
     // Force deterministic ordering via raw puts
     const tx = db.transaction("boardSets", "readwrite");
@@ -132,7 +125,7 @@ describe("listBoardSets", () => {
 describe("putBoards and getBoard", () => {
   test("stores and retrieves a board", async () => {
     const db = await openTestDB();
-    await upsertBoardSet(db, { setId: "set-1", name: "Set" });
+    await upsertBoardSet(db, makeBoardSetInput());
 
     const obf = makeOBFBoard({ id: "b1", name: "Board One" });
     await putBoards(db, "set-1", [{ boardId: "b1", name: "Board One", obf }]);
@@ -146,7 +139,7 @@ describe("putBoards and getBoard", () => {
 
   test("counts only unique boards", async () => {
     const db = await openTestDB();
-    await upsertBoardSet(db, { setId: "set-1", name: "Set" });
+    await upsertBoardSet(db, makeBoardSetInput());
 
     const obf = makeOBFBoard({ id: "b1" });
     await putBoards(db, "set-1", [{ boardId: "b1", name: "B1", obf }]);
@@ -162,7 +155,7 @@ describe("putBoards and getBoard", () => {
 
   test("counts multiple boards correctly", async () => {
     const db = await openTestDB();
-    await upsertBoardSet(db, { setId: "set-1", name: "Set" });
+    await upsertBoardSet(db, makeBoardSetInput());
 
     const boards = [
       { boardId: "b1", name: "B1", obf: makeOBFBoard({ id: "b1" }) },
@@ -178,7 +171,7 @@ describe("putBoards and getBoard", () => {
 
   test("returns undefined for nonexistent board", async () => {
     const db = await openTestDB();
-    await upsertBoardSet(db, { setId: "set-1", name: "Set" });
+    await upsertBoardSet(db, makeBoardSetInput());
 
     const board = await getBoard(db, "set-1", "nonexistent");
     expect(board).toBeUndefined();
@@ -207,7 +200,7 @@ describe("putBoards and getBoard", () => {
 describe("putAssets and getAssetBlob", () => {
   test("stores and retrieves an asset blob", async () => {
     const db = await openTestDB();
-    await upsertBoardSet(db, { setId: "set-1", name: "Set" });
+    await upsertBoardSet(db, makeBoardSetInput());
 
     const blob = new Blob(["hello"], { type: "text/plain" });
     await putAssets(db, "set-1", [
@@ -221,7 +214,7 @@ describe("putAssets and getAssetBlob", () => {
 
   test("normalizes paths with backslashes", async () => {
     const db = await openTestDB();
-    await upsertBoardSet(db, { setId: "set-1", name: "Set" });
+    await upsertBoardSet(db, makeBoardSetInput());
 
     const blob = new Blob(["data"]);
     await putAssets(db, "set-1", [{ path: "images\\photo.png", blob }]);
@@ -232,7 +225,7 @@ describe("putAssets and getAssetBlob", () => {
 
   test("normalizes paths with leading slashes", async () => {
     const db = await openTestDB();
-    await upsertBoardSet(db, { setId: "set-1", name: "Set" });
+    await upsertBoardSet(db, makeBoardSetInput());
 
     const blob = new Blob(["data"]);
     await putAssets(db, "set-1", [{ path: "/images/photo.png", blob }]);
@@ -243,7 +236,7 @@ describe("putAssets and getAssetBlob", () => {
 
   test("normalizes paths with double slashes", async () => {
     const db = await openTestDB();
-    await upsertBoardSet(db, { setId: "set-1", name: "Set" });
+    await upsertBoardSet(db, makeBoardSetInput());
 
     const blob = new Blob(["data"]);
     await putAssets(db, "set-1", [{ path: "images//photo.png", blob }]);
@@ -254,7 +247,7 @@ describe("putAssets and getAssetBlob", () => {
 
   test("returns undefined for nonexistent asset", async () => {
     const db = await openTestDB();
-    await upsertBoardSet(db, { setId: "set-1", name: "Set" });
+    await upsertBoardSet(db, makeBoardSetInput());
 
     const blob = await getAssetBlob(db, "set-1", "nope.png");
     expect(blob).toBeUndefined();
@@ -262,7 +255,7 @@ describe("putAssets and getAssetBlob", () => {
 
   test("stores asset size from blob when not explicitly provided", async () => {
     const db = await openTestDB();
-    await upsertBoardSet(db, { setId: "set-1", name: "Set" });
+    await upsertBoardSet(db, makeBoardSetInput());
 
     const blob = new Blob(["12345"]);
     await putAssets(db, "set-1", [{ path: "file.bin", blob }]);
@@ -276,7 +269,7 @@ describe("putAssets and getAssetBlob", () => {
 describe("updateBoardStrings", () => {
   test("adds localized strings to a board", async () => {
     const db = await openTestDB();
-    await upsertBoardSet(db, { setId: "set-1", name: "Set" });
+    await upsertBoardSet(db, makeBoardSetInput());
 
     const obf = makeOBFBoard({ id: "b1" });
     await putBoards(db, "set-1", [{ boardId: "b1", name: "B1", obf }]);
@@ -294,7 +287,7 @@ describe("updateBoardStrings", () => {
 
   test("preserves existing locale strings when adding a new locale", async () => {
     const db = await openTestDB();
-    await upsertBoardSet(db, { setId: "set-1", name: "Set" });
+    await upsertBoardSet(db, makeBoardSetInput());
 
     const obf = makeOBFBoard({
       id: "b1",
@@ -313,7 +306,7 @@ describe("updateBoardStrings", () => {
 
   test("replaces all strings when updating an existing locale", async () => {
     const db = await openTestDB();
-    await upsertBoardSet(db, { setId: "set-1", name: "Set" });
+    await upsertBoardSet(db, makeBoardSetInput());
 
     const obf = makeOBFBoard({ id: "b1" });
     await putBoards(db, "set-1", [{ boardId: "b1", name: "B1", obf }]);
@@ -330,7 +323,7 @@ describe("updateBoardStrings", () => {
 
   test("throws when board does not exist", async () => {
     const db = await openTestDB();
-    await upsertBoardSet(db, { setId: "set-1", name: "Set" });
+    await upsertBoardSet(db, makeBoardSetInput());
 
     await expect(
       updateBoardStrings(db, "set-1", "nonexistent", "es", {}),
@@ -341,7 +334,7 @@ describe("updateBoardStrings", () => {
 describe("deleteBoardSet", () => {
   test("removes the board set record", async () => {
     const db = await openTestDB();
-    await upsertBoardSet(db, { setId: "set-1", name: "Set" });
+    await upsertBoardSet(db, makeBoardSetInput());
 
     await deleteBoardSet(db, "set-1");
 
@@ -351,7 +344,7 @@ describe("deleteBoardSet", () => {
 
   test("cascade-deletes all boards in the set", async () => {
     const db = await openTestDB();
-    await upsertBoardSet(db, { setId: "set-1", name: "Set" });
+    await upsertBoardSet(db, makeBoardSetInput());
 
     await putBoards(db, "set-1", [
       { boardId: "b1", name: "B1", obf: makeOBFBoard({ id: "b1" }) },
@@ -366,7 +359,7 @@ describe("deleteBoardSet", () => {
 
   test("cascade-deletes all assets in the set", async () => {
     const db = await openTestDB();
-    await upsertBoardSet(db, { setId: "set-1", name: "Set" });
+    await upsertBoardSet(db, makeBoardSetInput());
 
     await putAssets(db, "set-1", [
       { path: "img1.png", blob: new Blob(["a"]) },
@@ -381,8 +374,11 @@ describe("deleteBoardSet", () => {
 
   test("does not affect other board sets", async () => {
     const db = await openTestDB();
-    await upsertBoardSet(db, { setId: "set-1", name: "Set 1" });
-    await upsertBoardSet(db, { setId: "set-2", name: "Set 2" });
+    await upsertBoardSet(db, makeBoardSetInput({ name: "Set 1" }));
+    await upsertBoardSet(
+      db,
+      makeBoardSetInput({ setId: "set-2", name: "Set 2" }),
+    );
 
     await putBoards(db, "set-1", [
       { boardId: "b1", name: "B1", obf: makeOBFBoard({ id: "b1" }) },
@@ -414,7 +410,10 @@ describe("withBoardsDB", () => {
 
     await withBoardsDB(async (db) => {
       capturedDb = db;
-      await upsertBoardSet(db, { setId: "temp", name: "Temp" });
+      await upsertBoardSet(
+        db,
+        makeBoardSetInput({ setId: "temp", name: "Temp" }),
+      );
     });
 
     expect(() => {

--- a/src/features/board/storage/db.ts
+++ b/src/features/board/storage/db.ts
@@ -5,7 +5,7 @@ import type { OBFBoard } from "open-board-format";
 export interface BoardSetRecord {
   setId: string;
   name: string;
-  rootBoardId?: string;
+  rootBoardId: string;
   updatedAt: number;
   boardCount: number;
   author?: string;
@@ -35,7 +35,7 @@ export interface AssetRecord {
 export interface UpsertBoardSetInput {
   setId: string;
   name: string;
-  rootBoardId?: string;
+  rootBoardId: string;
   author?: string;
   description?: string;
   license?: string;
@@ -144,7 +144,7 @@ export async function upsertBoardSet(
   const record: BoardSetRecord = {
     setId: input.setId,
     name: input.name,
-    rootBoardId: input.rootBoardId ?? existing?.rootBoardId,
+    rootBoardId: input.rootBoardId,
     updatedAt: Date.now(),
     boardCount: existing?.boardCount ?? 0,
     author: input.author ?? existing?.author,

--- a/src/features/board/storage/test-helpers.ts
+++ b/src/features/board/storage/test-helpers.ts
@@ -33,6 +33,7 @@ export async function openCleanBoardsDB(): Promise<BoardsDB> {
 
 export interface SeedBoardSet extends Partial<BoardSetRecord> {
   setId: string;
+  rootBoardId: string;
 }
 
 export async function seedBoardSets(records: SeedBoardSet[]): Promise<void> {

--- a/src/pages/library-page.tsx
+++ b/src/pages/library-page.tsx
@@ -1,6 +1,6 @@
 import { PageContainer } from "@app/layouts/page-container";
 import { PageTitle } from "@app/layouts/page-title";
-import { boardPath, boardSetPath } from "@app/route-patterns";
+import { boardPath } from "@app/route-patterns";
 import {
   BoardSetDeleteDialog,
   BoardSetInfoDialog,
@@ -31,16 +31,12 @@ export const Component = function LibraryPage() {
   const [infoTarget, setInfoTarget] = useState<BoardSetRecord | null>(null);
 
   function handleSelect(boardSet: BoardSetRecord) {
-    if (boardSet.rootBoardId) {
-      void navigate(
-        boardPath({
-          setId: boardSet.setId,
-          boardId: boardSet.rootBoardId,
-        }),
-      );
-    } else {
-      void navigate(boardSetPath({ setId: boardSet.setId }));
-    }
+    void navigate(
+      boardPath({
+        setId: boardSet.setId,
+        boardId: boardSet.rootBoardId,
+      }),
+    );
   }
 
   async function handleDelete() {


### PR DESCRIPTION
## Summary
- Make `rootBoardId` required on `BoardSetRecord` / `UpsertBoardSetInput` — every production import path already supplies one, and a set without it is unreachable from navigation.
- Delete dead defensive code: the 422 `errorBoardSetIncomplete` branch in the board-set index loader, the `hasRootBoard` type guard + filter in the root index loader, the `?? ""` / `!== ""` empty-string sentinel in `useBoardNavigation`, and the conditional `boardSetPath` fallback in `library-page`.
- Replace the silent `?? ""` fallback in `resolveRootBoardId` with a loud throw — malformed manifest now fails at import instead of producing a broken route later.
- Tighten `SeedBoardSet` to require `rootBoardId` so tests can't accidentally seed broken sets.
- Remove the now-unused `errorBoardSetIncomplete` translation key across all 35 locale files.
- Introduce a small `makeBoardSetInput` test helper in `db.test.ts` to keep upsert call sites one-liners.

Net change: 45 files, +96/-171.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean on changed files
- [x] `npx vitest run` — all 334 tests pass
- [ ] Manually verify: import an OBZ, navigate, hit Home, return to Library and pick a set