### PR TITLE
refactor: use `signal.throwIfAborted()` in `hydrateBoard`

### DIFF
--- a/src/features/board/storage/queries.ts
+++ b/src/features/board/storage/queries.ts
@@ -58,9 +58,7 @@ export async function hydrateBoard(
     });
 
     // Don't promote a superseded registry — it would orphan the live one.
-    if (signal?.aborted) {
-      throw new DOMException("Aborted", "AbortError");
-    }
+    signal?.throwIfAborted();
 
     const previous = previousRegistry;
     previousRegistry = registry;


### PR DESCRIPTION
## Summary
- Swap hand-rolled `new DOMException("Aborted", "AbortError")` for the spec-named `signal?.throwIfAborted()` in [`hydrateBoard`](src/features/board/storage/queries.ts#L61).
- Side benefit: propagates `signal.reason` instead of discarding it (forward-compatible with callers that `controller.abort(reason)`).
- Closes #369.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run src/features/board/storage/queries.test.ts` — 4/4 pass (no test asserted on `"Aborted"` text)
- [x] `npm run build` — typecheck + build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)