### PR TITLE
refactor(board): Extract pure translation logic into dedicated module

### DIFF
--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -14,4 +14,4 @@ export {
 } from "./storage/queries";
 export { useBoardSets } from "./storage/use-board-sets";
 export type { Board } from "./types";
-export { useBoardTranslation } from "./use-board-translation";
+export { useBoardTranslation } from "./translation/use-board-translation";

--- a/src/features/board/translation/board-translation-core.test.ts
+++ b/src/features/board/translation/board-translation-core.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "vitest";
+import {
+  applyTranslations,
+  collectTranslatableStrings,
+  findTranslations,
+  getBoardLanguage,
+  resolveSyncTranslation,
+} from "./board-translation-core";
+import type { Board } from "../types";
+
+const mockBoard: Board = {
+  id: "board-1",
+  name: "My Board",
+  grid: { columns: 2, rows: 1 },
+  buttons: [
+    {
+      id: "btn-1",
+      label: "Hello",
+      vocalization: "Hello there",
+    },
+    {
+      id: "btn-2",
+      label: undefined,
+      vocalization: undefined,
+    },
+  ],
+  locale: "en-US",
+  strings: {
+    "es-ES": {
+      "My Board": "Mi Tablero",
+      Hello: "Hola",
+      "Hello there": "Hola a todos",
+    },
+    "fr-CA": {
+      Hello: "Bonjour",
+    },
+  },
+};
+
+describe("board-translation-core", () => {
+  test("getBoardLanguage() extracts the base language code", () => {
+    expect(getBoardLanguage(mockBoard)).toBe("en");
+    expect(getBoardLanguage({ ...mockBoard, locale: undefined })).toBe("en");
+    expect(getBoardLanguage({ ...mockBoard, locale: "pt-BR" })).toBe("pt");
+  });
+
+  test("findTranslations() matches language codes correctly", () => {
+    expect(findTranslations(mockBoard.strings, "es")).toEqual(
+      mockBoard.strings!["es-ES"],
+    );
+    expect(findTranslations(mockBoard.strings, "fr")).toEqual(
+      mockBoard.strings!["fr-CA"],
+    );
+    expect(findTranslations(mockBoard.strings, "de")).toBeUndefined();
+    expect(findTranslations(undefined, "es")).toBeUndefined();
+  });
+
+  test("applyTranslations() maps string record onto board structure", () => {
+    const translations = {
+      "My Board": "Mi Tablero",
+      Hello: "Hola",
+    };
+    const translated = applyTranslations(mockBoard, translations);
+
+    expect(translated.name).toBe("Mi Tablero");
+    expect(translated.buttons[0].label).toBe("Hola");
+    expect(translated.buttons[0].vocalization).toBe("Hello there"); // Missing translation falls back to original
+    expect(translated.buttons[1].label).toBeUndefined(); // Undefined stays undefined
+  });
+
+  test("collectTranslatableStrings() extracts all unique UI text", () => {
+    const strings = collectTranslatableStrings(mockBoard);
+
+    expect(strings.size).toBe(3);
+    expect(strings.has("My Board")).toBe(true);
+    expect(strings.has("Hello")).toBe(true);
+    expect(strings.has("Hello there")).toBe(true);
+  });
+
+  test("resolveSyncTranslation() returns early if languages match", () => {
+    expect(resolveSyncTranslation(mockBoard, "en")).toBe(mockBoard);
+  });
+
+  test("resolveSyncTranslation() returns translated board if cached strings exist", () => {
+    const translated = resolveSyncTranslation(mockBoard, "es");
+    expect(translated).toBeDefined();
+    expect(translated?.name).toBe("Mi Tablero");
+    expect(translated?.buttons[0].label).toBe("Hola");
+  });
+
+  test("resolveSyncTranslation() returns undefined if translations are missing", () => {
+    expect(resolveSyncTranslation(mockBoard, "de")).toBeUndefined();
+  });
+});

--- a/src/features/board/translation/board-translation-core.ts
+++ b/src/features/board/translation/board-translation-core.ts
@@ -1,0 +1,70 @@
+import { getLanguageCode } from "@shared/utils/locale";
+import type { Board } from "../types";
+
+const DEFAULT_BOARD_LANGUAGE = "en";
+
+export function resolveSyncTranslation(
+  board: Board,
+  language: string,
+): Board | undefined {
+  if (getBoardLanguage(board) === language) {
+    return board;
+  }
+  const cached = findTranslations(board.strings, language);
+  return cached ? applyTranslations(board, cached) : undefined;
+}
+
+export function getBoardLanguage(board: Board): string {
+  return board.locale ? getLanguageCode(board.locale) : DEFAULT_BOARD_LANGUAGE;
+}
+
+export function findTranslations(
+  strings: Board["strings"],
+  language: string,
+): Record<string, string> | undefined {
+  if (!strings) {
+    return;
+  }
+
+  const match = Object.entries(strings).find(
+    ([locale]) => getLanguageCode(locale) === language,
+  );
+  return match?.[1];
+}
+
+export function applyTranslations(
+  board: Board,
+  translations: Record<string, string>,
+): Board {
+  const lookup = (phrase: string | undefined) =>
+    phrase ? (translations[phrase] ?? phrase) : phrase;
+
+  return {
+    ...board,
+    name: lookup(board.name),
+    buttons: board.buttons.map((button) => ({
+      ...button,
+      label: lookup(button.label),
+      vocalization: lookup(button.vocalization),
+    })),
+  };
+}
+
+export function collectTranslatableStrings(board: Board): Set<string> {
+  const translatableStrings = new Set<string>();
+
+  if (board.name) {
+    translatableStrings.add(board.name);
+  }
+
+  for (const button of board.buttons) {
+    if (button.label) {
+      translatableStrings.add(button.label);
+    }
+    if (button.vocalization) {
+      translatableStrings.add(button.vocalization);
+    }
+  }
+
+  return translatableStrings;
+}

--- a/src/features/board/translation/use-board-translation.ts
+++ b/src/features/board/translation/use-board-translation.ts
@@ -1,11 +1,14 @@
 import { createTranslator } from "@shared/built-in-ai";
 import { useLanguage } from "@shared/language/use-language";
-import { getLanguageCode } from "@shared/utils/locale";
 import { useEffect, useState } from "react";
-import { persistBoardTranslations } from "./storage/queries";
-import type { Board } from "./types";
-
-const DEFAULT_BOARD_LANGUAGE = "en";
+import { persistBoardTranslations } from "../storage/queries";
+import type { Board } from "../types";
+import {
+  applyTranslations,
+  collectTranslatableStrings,
+  getBoardLanguage,
+  resolveSyncTranslation,
+} from "./board-translation-core";
 
 export interface UseBoardTranslationOptions {
   setId: string;
@@ -68,72 +71,6 @@ export function useBoardTranslation({
   }, [setId, board, language]);
 
   return { translatedBoard };
-}
-
-function resolveSyncTranslation(
-  board: Board,
-  language: string,
-): Board | undefined {
-  if (getBoardLanguage(board) === language) {
-    return board;
-  }
-  const cached = findTranslations(board.strings, language);
-  return cached ? applyTranslations(board, cached) : undefined;
-}
-
-function getBoardLanguage(board: Board): string {
-  return board.locale ? getLanguageCode(board.locale) : DEFAULT_BOARD_LANGUAGE;
-}
-
-function findTranslations(
-  strings: Board["strings"],
-  language: string,
-): Record<string, string> | undefined {
-  if (!strings) {
-    return;
-  }
-
-  const match = Object.entries(strings).find(
-    ([locale]) => getLanguageCode(locale) === language,
-  );
-  return match?.[1];
-}
-
-function applyTranslations(
-  board: Board,
-  translations: Record<string, string>,
-): Board {
-  const lookup = (phrase: string | undefined) =>
-    phrase ? (translations[phrase] ?? phrase) : phrase;
-
-  return {
-    ...board,
-    name: lookup(board.name),
-    buttons: board.buttons.map((button) => ({
-      ...button,
-      label: lookup(button.label),
-      vocalization: lookup(button.vocalization),
-    })),
-  };
-}
-
-function collectTranslatableStrings(board: Board): Set<string> {
-  const translatableStrings = new Set<string>();
-
-  if (board.name) {
-    translatableStrings.add(board.name);
-  }
-
-  for (const button of board.buttons) {
-    if (button.label) {
-      translatableStrings.add(button.label);
-    }
-    if (button.vocalization) {
-      translatableStrings.add(button.vocalization);
-    }
-  }
-
-  return translatableStrings;
 }
 
 async function translatePhrases(


### PR DESCRIPTION
## What changed?

Extracted the pure synchronous translation functions (`applyTranslations`, `findTranslations`, `getBoardLanguage`, `resolveSyncTranslation`, and `collectTranslatableStrings`) out of the React hook and into their own pure module `src/features/board/translation/board-translation-core.ts`.

## Why?

This enforces a **Functional Core, Imperative Shell** architecture. 
The `use-board-translation.ts` hook was previously ~166 lines, mixing complex React lifecycle logic (effects, AbortControllers) and IndexedDB interactions with pure data transformations. By separating them:
1. **100% Mock-Free Unit Testing**: We can now test the complex translation applying and fallback logic deterministically in ~3ms without mounting a React rendering tree or mocking IndexedDB.
2. **Cognitive Load**: The React hook is now a lean ~90 lines, strictly focused on orchestration.
3. **Cohesion**: Created a new `translation` subfolder to keep the board feature root clean.

## Verification

- Added `board-translation-core.test.ts` with a full suite of mock-free tests.
- `npm test` passes locally (340 tests).
- `tsc -b` and `eslint .` pass.
