### PR TITLE
feat: handle iOS safe-area insets in landscape

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,23 +3,15 @@
   <head>
     <meta charset="UTF-8" />
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
 
     <title>AAC Board AI</title>
     <meta
       name="description"
       content="AAC Board AI helps people who can't speak communicate naturally with Built-in AI — proofreading, rephrasing, and translating safely on their device."
-    />
-
-    <meta
-      name="theme-color"
-      content="#1b75d2"
-      media="(prefers-color-scheme: light)"
-    />
-    <meta
-      name="theme-color"
-      content="#272727"
-      media="(prefers-color-scheme: dark)"
     />
 
     <link rel="icon" type="image/svg+xml" href="/board.svg" />

--- a/src/app/layouts/app-header.tsx
+++ b/src/app/layouts/app-header.tsx
@@ -18,7 +18,14 @@ export function AppHeader({ onMenuClick, onSettingsClick }: AppHeaderProps) {
 
   return (
     <AppBar position="static">
-      <Toolbar>
+      <Toolbar
+        sx={(theme) => ({
+          [theme.breakpoints.up("sm")]: {
+            pl: "env(safe-area-inset-left)",
+            pr: "env(safe-area-inset-right)",
+          },
+        })}
+      >
         <Tooltip title={m.menuOpen()}>
           <IconButton
             aria-label={m.menuLabel()}

--- a/src/app/menu/menu-drawer.tsx
+++ b/src/app/menu/menu-drawer.tsx
@@ -31,9 +31,19 @@ export function MenuDrawer({ open, onClose }: MenuDrawerProps) {
       anchor="left"
       open={open}
       onClose={onClose}
-      slotProps={{ paper: { sx: { width: 320 } } }}
+      slotProps={{
+        paper: {
+          sx: { width: "calc(320px + env(safe-area-inset-left))" },
+        },
+      }}
     >
-      <Toolbar>
+      <Toolbar
+        sx={(theme) => ({
+          [theme.breakpoints.up("sm")]: {
+            pl: "env(safe-area-inset-left)",
+          },
+        })}
+      >
         <Typography component="div" variant="h6" noWrap>
           {APP_NAME}
         </Typography>
@@ -41,7 +51,13 @@ export function MenuDrawer({ open, onClose }: MenuDrawerProps) {
 
       <Divider />
 
-      <List>
+      <List
+        sx={(theme) => ({
+          [theme.breakpoints.up("sm")]: {
+            pl: "env(safe-area-inset-left)",
+          },
+        })}
+      >
         {menuItems.map((item) => (
           <ListItem key={item.to} disablePadding>
             <ListItemButton

--- a/src/app/settings/settings-drawer.tsx
+++ b/src/app/settings/settings-drawer.tsx
@@ -23,9 +23,19 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
       anchor="right"
       open={open}
       onClose={onClose}
-      slotProps={{ paper: { sx: { width: 320 } } }}
+      slotProps={{
+        paper: {
+          sx: { width: "calc(320px + env(safe-area-inset-right))" },
+        },
+      }}
     >
-      <Toolbar>
+      <Toolbar
+        sx={(theme) => ({
+          [theme.breakpoints.up("sm")]: {
+            pr: "env(safe-area-inset-right)",
+          },
+        })}
+      >
         <Typography variant="h6" sx={{ flexGrow: 1 }}>
           {m.settingsTitle()}
         </Typography>
@@ -43,7 +53,16 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
         </Tooltip>
       </Toolbar>
 
-      <Stack sx={{ px: 3, pb: 3 }}>
+      <Stack
+        sx={[
+          { px: 3, pb: 3 },
+          (theme) => ({
+            [theme.breakpoints.up("sm")]: {
+              pr: "env(safe-area-inset-right)",
+            },
+          }),
+        ]}
+      >
         <AppearanceSettings />
 
         <Divider sx={{ my: 3 }} />

--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -54,6 +54,12 @@ export function BoardViewer({ board }: BoardViewerProps) {
             backgroundImage:
               "radial-gradient(80% 50% at 50% -20%, rgb(0, 41, 82), transparent)",
           }),
+        (theme) => ({
+          [theme.breakpoints.up("sm")]: {
+            pl: "env(safe-area-inset-left)",
+            pr: "env(safe-area-inset-right)",
+          },
+        }),
       ]}
     >
       <MessageBar


### PR DESCRIPTION
## Summary
- Add `viewport-fit=cover` so `env(safe-area-inset-*)` resolves on notched iPhones
- Pad AppBar Toolbar, board content, and both drawers against horizontal insets at `sm+` (where iPhone landscape lives)
- Grow drawer Paper widths by their edge inset so the usable content column stays at 320
- Remove `theme-color` metas — Safari 26+ ignores them; chrome tint is now sampled from page bg

## Test plan
- [ ] iPhone landscape: Toolbar icons, board edges, and drawer content sit clear of the notch
- [ ] iPhone portrait: no visual change (horizontal insets are 0)
- [ ] Tablet / desktop: no visual change
- [ ] Drawer width feels right at 320 + ~44px in iPhone landscape

🤖 Generated with [Claude Code](https://claude.com/claude-code)