### PR TITLE
fix: stop document-level rubber-band on iOS

### DIFF
--- a/src/shared/theme/theme-provider.tsx
+++ b/src/shared/theme/theme-provider.tsx
@@ -33,6 +33,15 @@ const themeOptions = {
       textTransform: "none",
     },
   },
+  components: {
+    MuiCssBaseline: {
+      styleOverrides: {
+        html: {
+          overscrollBehaviorY: "none",
+        },
+      },
+    },
+  },
 } as const;
 
 const ltrTheme = createTheme({ ...themeOptions, direction: "ltr" });


### PR DESCRIPTION
## Summary
- Add `overscroll-behavior-y: none` on `<html>` via the `MuiCssBaseline` override in the theme.
- Document doesn't scroll (AppShell is `100svh` flex column with the actual scroll inside `<main>`), so the iOS bounce was pure noise — feels like a browser page, not a native app.
- Axis-specific `-y` form preserves horizontal edge-swipe-back navigation for browser-tab users.

Closes #365

## Test plan
- [ ] Safari 26 (iOS Simulator, notched device): dragging at top/bottom edges no longer bounces the document.
- [ ] Scrolling within `<main>` still bounces when overshooting its own range.
- [ ] Browser tab (iOS Safari): horizontal edge-swipe-back navigation still works.
- [ ] No a11y regressions: VoiceOver gestures, status-bar tap-to-top, focus-scroll-into-view still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)