### PR TITLE
feat: hide AppBar on phones in landscape

### DIFF
--- a/src/app/layouts/app-header.tsx
+++ b/src/app/layouts/app-header.tsx
@@ -17,7 +17,16 @@ export function AppHeader({ onMenuClick, onSettingsClick }: AppHeaderProps) {
   const pageTitle = usePageTitle();
 
   return (
-    <AppBar position="static">
+    <AppBar
+      position="static"
+      sx={(theme) => ({
+        [theme.breakpoints.down("md")]: {
+          "@media (orientation: landscape)": {
+            display: "none",
+          },
+        },
+      })}
+    >
       <Toolbar
         sx={(theme) => ({
           [theme.breakpoints.up("sm")]: {


### PR DESCRIPTION
## Summary
- Hide the AppBar when viewport width is below `md` (900px) and orientation is landscape.
- Reclaims vertical space on phones in landscape (iPhone Pro Max landscape ≈ 430px tall) where the header was eating into the board.
- Portrait phones, tablets, and desktop keep the header.

## Test plan
- [ ] iPhone in landscape (Simulator): AppBar hidden, board fills the viewport.
- [ ] iPhone in portrait: AppBar visible.
- [ ] iPad landscape (>=900px wide): AppBar visible.
- [ ] Desktop: AppBar visible at all sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)