### PR TITLE
feat: enlarge play/stop icons in the 72px Fab

### DIFF
--- a/src/features/board/message/play-button.tsx
+++ b/src/features/board/message/play-button.tsx
@@ -34,7 +34,11 @@ export function PlayButton({
             height: 72,
           }}
         >
-          {isPlaying ? <StopIcon /> : <PlayArrowIcon sx={flipForRtl} />}
+          {isPlaying ? (
+            <StopIcon sx={{ fontSize: 36 }} />
+          ) : (
+            <PlayArrowIcon sx={[flipForRtl, { fontSize: 36 }]} />
+          )}
         </Fab>
       </Box>
     </Tooltip>


### PR DESCRIPTION
## Summary
- Bump play/stop icons from the default 24px to 36px via the `fontSize` sx prop.
- The Fab is 72×72; the default icon size felt undersized inside it.

## Test plan
- [ ] Play button shows a larger play icon at rest.
- [ ] Stop icon scales to match while speech is playing.
- [ ] RTL still flips the play icon correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)