### PR TITLE
tweak: dial play/stop icon size from 36 to 32

### DIFF
--- a/src/features/board/message/play-button.tsx
+++ b/src/features/board/message/play-button.tsx
@@ -35,9 +35,9 @@ export function PlayButton({
           }}
         >
           {isPlaying ? (
-            <StopIcon sx={{ fontSize: 36 }} />
+            <StopIcon sx={{ fontSize: 32 }} />
           ) : (
-            <PlayArrowIcon sx={[flipForRtl, { fontSize: 36 }]} />
+            <PlayArrowIcon sx={[flipForRtl, { fontSize: 32 }]} />
           )}
         </Fab>
       </Box>


### PR DESCRIPTION
## Summary
- Dial the play/stop icon size from 36 to 32 inside the 72px Fab.

## Test plan
- [ ] Visual check: icons feel proportionate inside the Fab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)