### PR TITLE
fix: align drawer safe-area gutters

### DIFF
--- a/src/app/menu/menu-drawer.tsx
+++ b/src/app/menu/menu-drawer.tsx
@@ -40,7 +40,7 @@ export function MenuDrawer({ open, onClose }: MenuDrawerProps) {
       <Toolbar
         sx={(theme) => ({
           [theme.breakpoints.up("sm")]: {
-            pl: "env(safe-area-inset-left)",
+            pl: 3,
           },
         })}
       >

--- a/src/app/settings/settings-drawer.tsx
+++ b/src/app/settings/settings-drawer.tsx
@@ -25,7 +25,16 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
       onClose={onClose}
       slotProps={{
         paper: {
-          sx: { width: "calc(320px + env(safe-area-inset-right))" },
+          sx: [
+            {
+              width: "calc(320px + env(safe-area-inset-right))",
+            },
+            (theme) => ({
+              [theme.breakpoints.up("sm")]: {
+                pr: 3,
+              },
+            }),
+          ],
         },
       }}
     >


### PR DESCRIPTION
## Summary
- Menu drawer Toolbar now uses a fixed 24px left gutter at `sm+` (was: `env(safe-area-inset-left)`).
- Settings drawer paper gets a matching 24px right gutter at `sm+`.
- Safe-area handling is still applied via the paper widening (`calc(320px + env(safe-area-inset-*))`); inner content gets a consistent 24px gutter on both sides.

## Test plan
- [ ] Both drawers open with a consistent 24px content gutter at `sm+`.
- [ ] Drawer paper still extends to the screen edge on notched landscape devices.
- [ ] List items in menu drawer still respect the safe-area inset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)