### PR TITLE
fix: respect safe-area-inset-left in menu drawer toolbar

### DIFF
--- a/src/app/menu/menu-drawer.tsx
+++ b/src/app/menu/menu-drawer.tsx
@@ -40,7 +40,7 @@ export function MenuDrawer({ open, onClose }: MenuDrawerProps) {
       <Toolbar
         sx={(theme) => ({
           [theme.breakpoints.up("sm")]: {
-            pl: 3,
+            pl: `calc(${theme.spacing(2)} + env(safe-area-inset-left))`,
           },
         })}
       >


### PR DESCRIPTION
## Summary
- Replace the fixed `pl: 3` on the menu drawer Toolbar (≥sm) with `calc(spacing(2) + env(safe-area-inset-left))` so content clears the notch/rounded corners in landscape.

## Test plan
- [ ] iPhone landscape: drawer toolbar content is not clipped by the notch
- [ ] Non-notched / portrait: spacing matches previous look (spacing(2) when inset is 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)