### PR TITLE
chore: bump version to 1.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aac-board-ai",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aac-board-ai",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aac-board-ai",
   "private": true,
-  "version": "1.6.1",
+  "version": "1.6.2",
   "license": "MIT",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Bump package version to 1.6.2.

**User-facing changes since v1.6.1:**

Features
- feat: hide AppBar on phones in landscape (#375, #376)
- feat: enlarge play/stop icons in the 72px Fab (#377)
- feat: handle iOS safe-area insets in landscape (#373)

Fixes
- fix: respect safe-area-inset-left in menu drawer toolbar (#381)
- fix: align drawer safe-area gutters (#379)
- fix: stop document-level rubber-band on iOS (#374)

Polish
- tweak: dial play/stop icon size from 36 to 32 (#378)
- chore: drop dedicated apple-touch-icon asset (#380)
- refactor: vocabulary alignment, theme tokens, and MUI primitives — CSS variables for dark mode, dismissible snackbar (a11y), tile focus outline restored (#345)

🤖 Generated with [Claude Code](https://claude.com/claude-code)