### PR TITLE
refactor: tighten ExternalLink and adopt it on About page

### DIFF
--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -3,7 +3,6 @@ import { PageContainer } from "@app/layouts/page-container";
 import { PageTitle } from "@app/layouts/page-title";
 import { ParaglideMessage } from "@inlang/paraglide-js-react";
 import GitHubIcon from "@mui/icons-material/GitHub";
-import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
@@ -13,7 +12,8 @@ export const Component = function AboutPage() {
   return (
     <PageContainer>
       <PageTitle>{m.aboutHeading()}</PageTitle>
-      <Stack spacing={{ xs: 3, sm: 4 }}>
+
+      <Stack spacing={{ xs: 3, sm: 4 }} sx={{ pt: 4 }}>
         <Typography component="p" variant="body1">
           {m.aboutAppDescription({ appName: APP_NAME })}
         </Typography>
@@ -49,16 +49,13 @@ export const Component = function AboutPage() {
           />
         </Typography>
 
-        <Button
-          variant="text"
-          startIcon={<GitHubIcon />}
+        <ExternalLink
           href="https://github.com/shayc/aac-board-ai"
-          target="_blank"
-          rel="noopener noreferrer"
-          sx={{ alignSelf: "flex-start" }}
+          sx={{ display: "inline-flex", gap: 1 }}
         >
+          <GitHubIcon />
           {m.aboutViewSource()}
-        </Button>
+        </ExternalLink>
       </Stack>
     </PageContainer>
   );

--- a/src/pages/library-page.tsx
+++ b/src/pages/library-page.tsx
@@ -74,6 +74,7 @@ export const Component = function LibraryPage() {
     return (
       <PageContainer>
         <PageTitle>{m.menuLibrary()}</PageTitle>
+
         <EmptyState
           icon={<FilterNoneOutlinedIcon />}
           title={m.libraryEmptyTitle()}
@@ -98,7 +99,7 @@ export const Component = function LibraryPage() {
 
       <Stack
         direction="row"
-        sx={{ alignItems: "center", justifyContent: "flex-end", mb: 2 }}
+        sx={{ alignItems: "center", justifyContent: "flex-end", pt: 4 }}
       >
         <Button
           variant="text"

--- a/src/shared/components/external-link.tsx
+++ b/src/shared/components/external-link.tsx
@@ -1,6 +1,6 @@
 import Link, { type LinkProps } from "@mui/material/Link";
 
-export function ExternalLink(props: LinkProps) {
+export function ExternalLink(props: Omit<LinkProps, "target" | "rel">) {
   return (
     <Link
       underline="hover"


### PR DESCRIPTION
## Summary
- `ExternalLink` hardcodes `target="_blank"` and `rel="noopener noreferrer"` after the props spread, so any caller-supplied `target`/`rel` was silently overridden — omit them from the accepted props type so the API matches the behavior
- About page: swap the hand-rolled GitHub `Button` (with manual `target`/`rel`) for `ExternalLink` with an inline `GitHubIcon` child
- About + Library pages: move the leading spacing from sibling margins to a top padding on the page content stack

## Test plan
- [x] `npm run -s lint`
- [ ] About page: GitHub link opens in a new tab with the icon + text aligned
- [ ] About + Library pages: top spacing looks right on phones and desktops

🤖 Generated with [Claude Code](https://claude.com/claude-code)