### PR TITLE
refactor: widen PageContainer and respect safe-area insets

### DIFF
--- a/src/app/layouts/page-container.tsx
+++ b/src/app/layouts/page-container.tsx
@@ -7,7 +7,18 @@ export interface PageContainerProps {
 
 export function PageContainer({ children }: PageContainerProps) {
   return (
-    <Container maxWidth="sm" sx={{ height: "100%" }}>
+    <Container
+      maxWidth="md"
+      sx={[
+        { height: "100%" },
+        (theme) => ({
+          [theme.breakpoints.up("sm")]: {
+            pl: `calc(${theme.spacing(2)} + env(safe-area-inset-left))`,
+            pr: `calc(${theme.spacing(2)} + env(safe-area-inset-right))`,
+          },
+        }),
+      ]}
+    >
       {children}
     </Container>
   );


### PR DESCRIPTION
## Summary
- Bump `PageContainer` max width from `sm` to `md`
- Add `safe-area-inset-left/right` padding at the `sm` breakpoint and up

## Test plan
- [ ] Verify standard page content layout on desktop and mobile
- [ ] Verify gutters respect notch/safe-area on iOS Safari (landscape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)