### PR TITLE
refactor: bold state title and refine page spacing

### DIFF
--- a/src/app/layouts/app-header.tsx
+++ b/src/app/layouts/app-header.tsx
@@ -43,7 +43,7 @@ export function AppHeader({ onMenuClick, onSettingsClick }: AppHeaderProps) {
           </IconButton>
         </Tooltip>
 
-        <Typography component="h1" variant="h6" noWrap sx={{ flexGrow: 1 }}>
+        <Typography noWrap component="h1" variant="h6" sx={{ flexGrow: 1 }}>
           {pageTitle}
         </Typography>
 

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -13,7 +13,7 @@ export const Component = function AboutPage() {
     <PageContainer>
       <PageTitle>{m.aboutHeading()}</PageTitle>
 
-      <Stack spacing={{ xs: 3, sm: 4 }} sx={{ pt: 4 }}>
+      <Stack spacing={{ xs: 3, sm: 4 }} sx={{ pt: 6 }}>
         <Typography component="p" variant="body1">
           {m.aboutAppDescription({ appName: APP_NAME })}
         </Typography>

--- a/src/pages/library-page.tsx
+++ b/src/pages/library-page.tsx
@@ -99,7 +99,7 @@ export const Component = function LibraryPage() {
 
       <Stack
         direction="row"
-        sx={{ alignItems: "center", justifyContent: "flex-end", pt: 4 }}
+        sx={{ alignItems: "center", justifyContent: "flex-end", pt: 3, pb: 2 }}
       >
         <Button
           variant="text"

--- a/src/shared/components/state-layout.tsx
+++ b/src/shared/components/state-layout.tsx
@@ -45,11 +45,13 @@ export function StateLayout({
       )}
 
       <Box sx={{ my: 1 }}>
-        <Typography variant="h5">{title}</Typography>
+        <Typography variant="h5" sx={{ fontWeight: "bold" }}>
+          {title}
+        </Typography>
 
         {description && (
           <Typography
-            variant="body1"
+            variant="subtitle1"
             sx={{ maxWidth: "sm", color: "text.secondary" }}
           >
             {description}


### PR DESCRIPTION
## Summary
- Bold the title in empty/error `StateLayout` and switch its description to `subtitle1` for stronger hierarchy
- Bump `AboutPage` top padding (`pt: 4` → `pt: 6`) and split `LibraryPage` action toolbar padding into `pt: 3, pb: 2`
- Reorder `noWrap` prop on the `AppHeader` title (no visual change)

## Test plan
- [ ] Library page: import bar spacing looks right above the board list
- [ ] About page: top padding feels balanced under the AppBar
- [ ] Empty library state: title reads as bold; description sits under it cleanly
- [ ] Error states (network/import failure): same visual treatment as empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)