### PR TITLE
chore: exclude paraglide compiled output from coverage

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest/config" />
 import { paraglideVitePlugin } from "@inlang/paraglide-js";
 import babel from "@rolldown/plugin-babel";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
@@ -6,6 +5,7 @@ import { playwright } from "@vitest/browser-playwright";
 import path from "path";
 import { defineConfig } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
+import { coverageConfigDefaults } from "vitest/config";
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -81,6 +81,9 @@ export default defineConfig({
       provider: playwright(),
       // https://vitest.dev/guide/browser/playwright
       instances: [{ browser: "chromium" }],
+    },
+    coverage: {
+      exclude: [...coverageConfigDefaults.exclude, "src/paraglide/**"],
     },
   },
 });


### PR DESCRIPTION
## Summary
- Paraglide's compiled output (`src/paraglide/`) is already gitignored and eslint-ignored; exclude it from coverage so generated code isn't measured against test thresholds.
- Spread `coverageConfigDefaults.exclude` to keep Vitest's standard exclusions (node_modules, dist, configs, test files).

## Test plan
- [x] `npm run -s lint -- vite.config.ts` clean
- [ ] `npm run coverage` — verify `coverage/code/aac-board-ai/src/paraglide/` no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)