### PR TITLE
test: drop redundant afterEach resets

### DIFF
--- a/src/app/loaders/root-index-loader.test.ts
+++ b/src/app/loaders/root-index-loader.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 import type { LoaderFunctionArgs } from "react-router";
 import { invalidateBoardSets } from "@features/board/storage/board-sets-store";
 import { listBoardSets, withBoardsDB } from "@features/board/storage/db";
@@ -26,10 +26,6 @@ describe("rootIndexLoader", () => {
     // snapshot from prior tests — explicitly invalidate so getBoardSets()
     // reads fresh from the now-empty DB.
     await invalidateBoardSets();
-  });
-
-  afterEach(async () => {
-    await resetBoardsDB();
   });
 
   test("imports the URL from ?board and redirects to its board route", async () => {

--- a/src/features/board/import/board-import.test.ts
+++ b/src/features/board/import/board-import.test.ts
@@ -1,5 +1,5 @@
 import { loadOBF, loadOBZ } from "open-board-format";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 import {
   getAssetBlob,
   getBoard,
@@ -34,10 +34,6 @@ async function loadFixtureFile(name: string): Promise<File> {
 
 describe("writeBoardSetFiles", () => {
   beforeEach(async () => {
-    await resetBoardsDB();
-  });
-
-  afterEach(async () => {
     await resetBoardsDB();
   });
 

--- a/src/features/board/storage/queries.test.ts
+++ b/src/features/board/storage/queries.test.ts
@@ -1,5 +1,5 @@
 import type { OBFBoard } from "open-board-format";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 import { invalidateBoardSets } from "./board-sets-store";
 import { putAssets, putBoards, upsertBoardSet, withBoardsDB } from "./db";
 import { BoardNotFoundError, hydrateBoard } from "./queries";
@@ -77,10 +77,6 @@ describe("hydrateBoard", () => {
   beforeEach(async () => {
     await resetBoardsDB();
     await invalidateBoardSets();
-  });
-
-  afterEach(async () => {
-    await resetBoardsDB();
   });
 
   test("returns a hydrated board on the happy path", async () => {


### PR DESCRIPTION
## Summary
- Each affected suite already calls `resetBoardsDB()` in `beforeEach`, so the trailing `afterEach(resetBoardsDB)` is a no-op — the next test resets again, and the cleanup vanishes with the suite.
- Removes the redundant hook (and unused `afterEach` import) from three files.

## Test plan
- [ ] `npm test` still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)