### PR TITLE
refactor: regroup Board types and strengthen db.test.ts

### DIFF
--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -13,5 +13,5 @@ export {
   hydrateBoard,
 } from "./storage/queries";
 export { useBoardSets } from "./storage/use-board-sets";
-export type { Board } from "./types";
 export { useBoardTranslation } from "./translation/use-board-translation";
+export type { Board } from "./types";

--- a/src/features/board/storage/db.test.ts
+++ b/src/features/board/storage/db.test.ts
@@ -1,5 +1,5 @@
 import type { OBFBoard } from "open-board-format";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   deleteBoardSet,
   getAssetBlob,
@@ -101,19 +101,16 @@ describe("listBoardSets", () => {
   });
 
   test("returns sets sorted by updatedAt descending", async () => {
+    // Each Date.now() call advances by 1000ms, so every upsertBoardSet gets
+    // a strictly increasing timestamp regardless of how many times the source
+    // reads Date.now() internally.
+    let now = 1000;
+    vi.spyOn(Date, "now").mockImplementation(() => (now += 1000));
+
     const db = await openTestDB();
 
     await upsertBoardSet(db, makeBoardSetInput({ setId: "old", name: "Old" }));
     await upsertBoardSet(db, makeBoardSetInput({ setId: "new", name: "New" }));
-
-    // Force deterministic ordering via raw puts
-    const tx = db.transaction("boardSets", "readwrite");
-    const store = tx.objectStore("boardSets");
-    const oldRec = (await store.get("old"))!;
-    const newRec = (await store.get("new"))!;
-    await store.put({ ...oldRec, updatedAt: 1000 });
-    await store.put({ ...newRec, updatedAt: 2000 });
-    await tx.done;
 
     const sets = await listBoardSets(db);
     expect(sets).toHaveLength(2);
@@ -212,38 +209,24 @@ describe("putAssets and getAssetBlob", () => {
     expect(await retrieved!.text()).toBe("hello");
   });
 
-  test("normalizes paths with backslashes", async () => {
-    const db = await openTestDB();
-    await upsertBoardSet(db, makeBoardSetInput());
+  test.each([
+    { rawPath: "images\\photo.png", description: "backslashes" },
+    { rawPath: "/images/photo.png", description: "leading slashes" },
+    { rawPath: "images//photo.png", description: "double slashes" },
+  ])(
+    "normalizes $description so the asset is retrievable by canonical path",
+    async ({ rawPath }) => {
+      const db = await openTestDB();
+      await upsertBoardSet(db, makeBoardSetInput());
 
-    const blob = new Blob(["data"]);
-    await putAssets(db, "set-1", [{ path: "images\\photo.png", blob }]);
+      const blob = new Blob(["data"]);
+      await putAssets(db, "set-1", [{ path: rawPath, blob }]);
 
-    const retrieved = await getAssetBlob(db, "set-1", "images/photo.png");
-    expect(retrieved).not.toBeNull();
-  });
-
-  test("normalizes paths with leading slashes", async () => {
-    const db = await openTestDB();
-    await upsertBoardSet(db, makeBoardSetInput());
-
-    const blob = new Blob(["data"]);
-    await putAssets(db, "set-1", [{ path: "/images/photo.png", blob }]);
-
-    const retrieved = await getAssetBlob(db, "set-1", "images/photo.png");
-    expect(retrieved).not.toBeNull();
-  });
-
-  test("normalizes paths with double slashes", async () => {
-    const db = await openTestDB();
-    await upsertBoardSet(db, makeBoardSetInput());
-
-    const blob = new Blob(["data"]);
-    await putAssets(db, "set-1", [{ path: "images//photo.png", blob }]);
-
-    const retrieved = await getAssetBlob(db, "set-1", "images/photo.png");
-    expect(retrieved).not.toBeNull();
-  });
+      const retrieved = await getAssetBlob(db, "set-1", "images/photo.png");
+      expect(retrieved).toBeInstanceOf(Blob);
+      expect(await retrieved!.text()).toBe("data");
+    },
+  );
 
   test("returns undefined for nonexistent asset", async () => {
     const db = await openTestDB();
@@ -260,9 +243,9 @@ describe("putAssets and getAssetBlob", () => {
     const blob = new Blob(["12345"]);
     await putAssets(db, "set-1", [{ path: "file.bin", blob }]);
 
-    const retrieved = await getAssetBlob(db, "set-1", "file.bin");
-    expect(retrieved).not.toBeNull();
-    expect(retrieved!.size).toBe(5);
+    const record = await db.get("assets", ["set-1", "file.bin"]);
+    expect(record).toBeDefined();
+    expect(record!.size).toBe(5);
   });
 });
 

--- a/src/features/board/types.ts
+++ b/src/features/board/types.ts
@@ -27,6 +27,22 @@ export interface BoardButton {
   loadBoard?: LoadBoard;
 }
 
+export interface LoadBoard {
+  id?: string;
+  name?: string;
+  url?: string;
+  path?: string;
+  dataUrl?: string;
+}
+
+export type BoardAction =
+  | { kind: "space" }
+  | { kind: "backspace" }
+  | { kind: "clear" }
+  | { kind: "home" }
+  | { kind: "speak" }
+  | { kind: "spell"; text: string };
+
 export function getSpokenText(
   button: Pick<BoardButton, "vocalization" | "label">,
 ): string | undefined {
@@ -43,19 +59,3 @@ export interface BoardLicense {
 }
 
 export type BoardStrings = Record<string, Record<string, string>>;
-
-export interface LoadBoard {
-  id?: string;
-  name?: string;
-  url?: string;
-  path?: string;
-  dataUrl?: string;
-}
-
-export type BoardAction =
-  | { kind: "space" }
-  | { kind: "backspace" }
-  | { kind: "clear" }
-  | { kind: "home" }
-  | { kind: "speak" }
-  | { kind: "spell"; text: string };


### PR DESCRIPTION
## Summary
Two cleanups grouped under one branch.

**types.ts reorder**
- `LoadBoard` and `BoardAction` are `BoardButton` fields but were declared after `BoardLicense`/`BoardStrings`. Moves them to sit immediately after `BoardButton` so the file reads as a top-down cascade of `Board` → its fields → their nested types.
- `getSpokenText` stays adjacent to `BoardButton` since it operates on one.

**db.test.ts assertions**
- *Sort test:* spy `Date.now()` with a monotonic counter instead of bypassing the public API with raw `store.put` — `upsertBoardSet` is now exercised end-to-end while ordering stays deterministic.
- *Path normalization:* three near-identical tests → one `test.each`. Replaced the broken `expect(retrieved).not.toBeNull()` (the function returns `undefined`, not `null`, so the assertion never failed) with `toBeInstanceOf(Blob)` + a `text()` round-trip.
- *Asset size test:* read the asset record directly via `db.get(...)` so the assertion checks the **stored** `size` field. The prior version asserted `Blob.size`, which the library reports correctly even if the code wrote `size: 0`.

Also sorts sibling exports in `features/board/index.ts`.

## Test plan
- [ ] `npm test -- db.test` passes
- [ ] Full suite green
- [ ] Grep for `Board`/`BoardButton`/`BoardAction`/`LoadBoard` consumers to confirm no behavioral change from the types reorder

🤖 Generated with [Claude Code](https://claude.com/claude-code)