### PR TITLE
refactor: file ordering, route centralization, and small extractions

### DIFF
--- a/src/app/app-router.tsx
+++ b/src/app/app-router.tsx
@@ -54,8 +54,14 @@ const router = createBrowserRouter([
               },
             ],
           },
-          { path: "library", lazy: async () => import("@pages/library-page") },
-          { path: "about", lazy: async () => import("@pages/about-page") },
+          {
+            path: ROUTE_PATTERNS.LIBRARY,
+            lazy: async () => import("@pages/library-page"),
+          },
+          {
+            path: ROUTE_PATTERNS.ABOUT,
+            lazy: async () => import("@pages/about-page"),
+          },
         ],
       },
     ],

--- a/src/app/menu/menu-drawer.tsx
+++ b/src/app/menu/menu-drawer.tsx
@@ -1,4 +1,5 @@
 import { APP_NAME } from "@app/app-info";
+import { ABOUT_PATH, LIBRARY_PATH } from "@app/route-patterns";
 import FilterNoneOutlinedIcon from "@mui/icons-material/FilterNoneOutlined";
 import HomeOutlinedIcon from "@mui/icons-material/HomeOutlined";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
@@ -22,8 +23,8 @@ export interface MenuDrawerProps {
 export function MenuDrawer({ open, onClose }: MenuDrawerProps) {
   const menuItems = [
     { icon: HomeOutlinedIcon, label: m.menuHome(), to: "/" },
-    { icon: FilterNoneOutlinedIcon, label: m.menuLibrary(), to: "/library" },
-    { icon: InfoOutlinedIcon, label: m.menuAbout(), to: "/about" },
+    { icon: FilterNoneOutlinedIcon, label: m.menuLibrary(), to: LIBRARY_PATH },
+    { icon: InfoOutlinedIcon, label: m.menuAbout(), to: ABOUT_PATH },
   ];
 
   return (

--- a/src/app/route-patterns.ts
+++ b/src/app/route-patterns.ts
@@ -2,8 +2,10 @@ import { generatePath } from "react-router";
 
 const BOARD_SET = "sets/:setId";
 const BOARDS = "boards/:boardId";
+const LIBRARY = "library";
+const ABOUT = "about";
 
-export const ROUTE_PATTERNS = { BOARD_SET, BOARDS } as const;
+export const ROUTE_PATTERNS = { BOARD_SET, BOARDS, LIBRARY, ABOUT } as const;
 
 export function boardSetPath({ setId }: { setId: string }): string {
   return generatePath(`/${BOARD_SET}`, { setId });
@@ -18,3 +20,6 @@ export function boardPath({
 }): string {
   return generatePath(`/${BOARD_SET}/${BOARDS}`, { setId, boardId });
 }
+
+export const LIBRARY_PATH = `/${LIBRARY}` as const;
+export const ABOUT_PATH = `/${ABOUT}` as const;

--- a/src/app/settings/speech-settings.tsx
+++ b/src/app/settings/speech-settings.tsx
@@ -42,6 +42,20 @@ export function SpeechSettings() {
     type: "language",
   });
 
+  function renderLocaleOptions(voiceLocale: string) {
+    const header = hasMultipleLocales && (
+      <ListSubheader key={`header-${voiceLocale}`}>
+        {languageNames.of(voiceLocale) ?? voiceLocale}
+      </ListSubheader>
+    );
+    const items = (voicesByLocale[voiceLocale] ?? []).map((voice) => (
+      <MenuItem key={voice.voiceURI} value={voice.voiceURI}>
+        {voice.name}
+      </MenuItem>
+    ));
+    return [header, ...items];
+  }
+
   const speechControls = [
     {
       id: "rate",
@@ -81,18 +95,7 @@ export function SpeechSettings() {
           value={voiceURI ?? ""}
           onChange={(event) => setVoiceURI(event.target.value || null)}
         >
-          {locales.map((voiceLocale) => [
-            hasMultipleLocales && (
-              <ListSubheader key={`header-${voiceLocale}`}>
-                {languageNames.of(voiceLocale) ?? voiceLocale}
-              </ListSubheader>
-            ),
-            ...(voicesByLocale[voiceLocale] ?? []).map((voice) => (
-              <MenuItem key={voice.voiceURI} value={voice.voiceURI}>
-                {voice.name}
-              </MenuItem>
-            )),
-          ])}
+          {locales.map(renderLocaleOptions)}
         </Select>
       </FormControl>
 

--- a/src/features/board/board-set/info-dialog.tsx
+++ b/src/features/board/board-set/info-dialog.tsx
@@ -15,33 +15,33 @@ export interface BoardSetInfoDialogProps {
   onClose: () => void;
 }
 
+function buildChipLabels(boardSet: BoardSetRecord): string[] {
+  const labels: string[] = [];
+
+  if (boardSet.gridRows && boardSet.gridColumns) {
+    labels.push(
+      m.libraryGridDimensions({
+        rows: boardSet.gridRows,
+        columns: boardSet.gridColumns,
+      }),
+    );
+  }
+
+  if (boardSet.locale) {
+    labels.push(getEnglishLocaleName(boardSet.locale));
+  }
+
+  if (boardSet.license) {
+    labels.push(boardSet.license);
+  }
+
+  return labels;
+}
+
 export function BoardSetInfoDialog({
   boardSet,
   onClose,
 }: BoardSetInfoDialogProps) {
-  function buildChipLabels(boardSet: BoardSetRecord): string[] {
-    const labels: string[] = [];
-
-    if (boardSet.gridRows && boardSet.gridColumns) {
-      labels.push(
-        m.libraryGridDimensions({
-          rows: boardSet.gridRows,
-          columns: boardSet.gridColumns,
-        }),
-      );
-    }
-
-    if (boardSet.locale) {
-      labels.push(getEnglishLocaleName(boardSet.locale));
-    }
-
-    if (boardSet.license) {
-      labels.push(boardSet.license);
-    }
-
-    return labels;
-  }
-
   const chipLabels = boardSet ? buildChipLabels(boardSet) : [];
 
   return (

--- a/src/features/board/board-set/list.tsx
+++ b/src/features/board/board-set/list.tsx
@@ -17,8 +17,8 @@ import type { BoardSetRecord } from "../storage/db";
 export interface BoardSetListProps {
   boardSets: BoardSetRecord[];
   onSelect: (boardSet: BoardSetRecord) => void;
-  onDelete: (boardSet: BoardSetRecord) => void;
   onInfo: (boardSet: BoardSetRecord) => void;
+  onDelete: (boardSet: BoardSetRecord) => void;
 }
 
 function formatSecondary(boardSet: BoardSetRecord): string {
@@ -40,8 +40,8 @@ function formatSecondary(boardSet: BoardSetRecord): string {
 export function BoardSetList({
   boardSets,
   onSelect,
-  onDelete,
   onInfo,
+  onDelete,
 }: BoardSetListProps) {
   const [menuAnchor, setMenuAnchor] = useState<{
     element: HTMLElement;

--- a/src/features/board/board-set/list.tsx
+++ b/src/features/board/board-set/list.tsx
@@ -21,6 +21,22 @@ export interface BoardSetListProps {
   onInfo: (boardSet: BoardSetRecord) => void;
 }
 
+function formatSecondary(boardSet: BoardSetRecord): string {
+  const parts: string[] = [];
+
+  const { gridRows, gridColumns, author } = boardSet;
+
+  if (gridRows && gridColumns) {
+    parts.push(`${gridRows}×${gridColumns}`);
+  }
+
+  if (author) {
+    parts.push(m.libraryByAuthor({ author }));
+  }
+
+  return parts.join(" · ");
+}
+
 export function BoardSetList({
   boardSets,
   onSelect,
@@ -33,22 +49,6 @@ export function BoardSetList({
   } | null>(null);
 
   const menuOpen = Boolean(menuAnchor);
-
-  function formatSecondary(boardSet: BoardSetRecord): string {
-    const parts: string[] = [];
-
-    const { gridRows, gridColumns, author } = boardSet;
-
-    if (gridRows && gridColumns) {
-      parts.push(`${gridRows}×${gridColumns}`);
-    }
-
-    if (author) {
-      parts.push(m.libraryByAuthor({ author }));
-    }
-
-    return parts.join(" · ");
-  }
 
   function handleMenuOpen(
     event: React.MouseEvent<HTMLElement>,

--- a/src/features/board/grid/use-grid-keyboard-navigation.ts
+++ b/src/features/board/grid/use-grid-keyboard-navigation.ts
@@ -21,6 +21,24 @@ export interface UseGridKeyboardNavigationReturn {
   activeCell: Cell;
 }
 
+interface Step {
+  row: -1 | 0 | 1;
+  col: -1 | 0 | 1;
+}
+
+interface FocusTarget {
+  element: HTMLElement;
+  position: Cell;
+}
+
+interface KeyboardKey {
+  key: string;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+}
+
 export function useGridKeyboardNavigation({
   grid,
   dir = "ltr",
@@ -114,24 +132,6 @@ function findFirstNonEmptyCell(grid: readonly (readonly unknown[])[]): Cell {
     }
   }
   return { row: 0, col: 0 };
-}
-
-interface Step {
-  row: -1 | 0 | 1;
-  col: -1 | 0 | 1;
-}
-
-interface FocusTarget {
-  element: HTMLElement;
-  position: Cell;
-}
-
-interface KeyboardKey {
-  key: string;
-  ctrlKey: boolean;
-  metaKey: boolean;
-  shiftKey: boolean;
-  altKey: boolean;
 }
 
 function nextFocus(

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -4,9 +4,7 @@ export { BoardSetList } from "./board-set/list";
 export { BoardViewer } from "./board-viewer";
 export { importBoardFromUrl } from "./import/from-url";
 export { useImportBoardFiles } from "./import/use-import-board-files";
-export type { BoardRouteParams } from "./navigation/use-board-navigation";
 export { getBoardSets, removeBoardSet } from "./storage/board-sets-store";
-export type { BoardSetRecord } from "./storage/db";
 export {
   BoardNotFoundError,
   getBoardSet,
@@ -14,4 +12,7 @@ export {
 } from "./storage/queries";
 export { useBoardSets } from "./storage/use-board-sets";
 export { useBoardTranslation } from "./translation/use-board-translation";
+
+export type { BoardRouteParams } from "./navigation/use-board-navigation";
+export type { BoardSetRecord } from "./storage/db";
 export type { Board } from "./types";

--- a/src/features/board/message/use-message.ts
+++ b/src/features/board/message/use-message.ts
@@ -11,9 +11,9 @@ export interface UseMessageReturn {
   text: string;
   addPart: (part: MessagePart) => void;
   addSpace: () => void;
+  updateLastPart: (part: MessagePart) => void;
   setFromText: (input: string) => void;
   removeLastPart: () => void;
-  updateLastPart: (part: MessagePart) => void;
   clear: () => void;
 }
 
@@ -25,8 +25,11 @@ export function useMessage(): UseMessageReturn {
     setParts((prev) => [...prev, part]);
   }
 
-  function removeLastPart() {
-    setParts((prev) => prev.slice(0, -1));
+  function addSpace() {
+    addPart({
+      id: crypto.randomUUID(),
+      label: "",
+    });
   }
 
   function updateLastPart(part: MessagePart) {
@@ -40,17 +43,6 @@ export function useMessage(): UseMessageReturn {
     });
   }
 
-  function clear() {
-    setParts([]);
-  }
-
-  function addSpace() {
-    addPart({
-      id: crypto.randomUUID(),
-      label: "",
-    });
-  }
-
   function setFromText(input: string) {
     const segmenter = new Intl.Segmenter(undefined, { granularity: "word" });
     const words = Array.from(segmenter.segment(input))
@@ -60,14 +52,22 @@ export function useMessage(): UseMessageReturn {
     setParts(words.map((word) => ({ id: crypto.randomUUID(), label: word })));
   }
 
+  function removeLastPart() {
+    setParts((prev) => prev.slice(0, -1));
+  }
+
+  function clear() {
+    setParts([]);
+  }
+
   return {
     parts,
     text,
     addPart,
     addSpace,
+    updateLastPart,
     setFromText,
     removeLastPart,
-    updateLastPart,
     clear,
   };
 }

--- a/src/features/board/navigation/use-board-navigation.test.tsx
+++ b/src/features/board/navigation/use-board-navigation.test.tsx
@@ -16,6 +16,8 @@ import {
   type UseBoardNavigationReturn,
 } from "./use-board-navigation";
 
+const DEFAULT_PATH = "/sets/set-1/boards/board-1";
+
 interface NavState {
   backStack: string[];
 }
@@ -27,7 +29,7 @@ interface NavTestHook {
 }
 
 function setup(
-  pathname = "/sets/set-1/boards/board-1",
+  pathname = DEFAULT_PATH,
   state?: NavState,
 ): Promise<RenderHookResult<NavTestHook, unknown>> {
   return renderHook(
@@ -121,9 +123,7 @@ describe("useBoardNavigation", () => {
 
       await act(() => result.current.nav.goToBoard(""));
 
-      expect(result.current.location.pathname).toBe(
-        "/sets/set-1/boards/board-1",
-      );
+      expect(result.current.location.pathname).toBe(DEFAULT_PATH);
       expect(result.current.location.state).toBeNull();
     });
 
@@ -155,9 +155,7 @@ describe("useBoardNavigation", () => {
 
       await act(() => result.current.nav.goBack());
 
-      expect(result.current.location.pathname).toBe(
-        "/sets/set-1/boards/board-1",
-      );
+      expect(result.current.location.pathname).toBe(DEFAULT_PATH);
     });
 
     test("does nothing when backStack is empty", async () => {
@@ -165,9 +163,7 @@ describe("useBoardNavigation", () => {
 
       await act(() => result.current.nav.goBack());
 
-      expect(result.current.location.pathname).toBe(
-        "/sets/set-1/boards/board-1",
-      );
+      expect(result.current.location.pathname).toBe(DEFAULT_PATH);
     });
 
     test("does nothing when setId is missing from the route", async () => {
@@ -224,9 +220,7 @@ describe("useBoardNavigation", () => {
 
       await act(() => result.current.nav.goHome());
 
-      expect(result.current.location.pathname).toBe(
-        "/sets/set-1/boards/board-1",
-      );
+      expect(result.current.location.pathname).toBe(DEFAULT_PATH);
     });
 
     test("does nothing when setId is missing from the route", async () => {

--- a/src/features/board/obf/parse-action.ts
+++ b/src/features/board/obf/parse-action.ts
@@ -4,6 +4,7 @@ export function parseAction(raw: string): BoardAction | null {
   if (raw.startsWith("+")) {
     return { kind: "spell", text: raw.slice(1).trim() };
   }
+
   switch (raw) {
     case ":space":
       return { kind: "space" };

--- a/src/features/board/storage/board-sets-store.ts
+++ b/src/features/board/storage/board-sets-store.ts
@@ -13,6 +13,9 @@ export interface BoardSetsSnapshot {
 }
 
 const boardSetsSyncChannel = new BroadcastChannel("board-sets-sync");
+boardSetsSyncChannel.addEventListener("message", () => {
+  void invalidateBoardSets();
+});
 
 const store = createExternalStore<BoardSetsSnapshot>({
   boardSets: [],
@@ -45,6 +48,11 @@ function ensureLoaded(): void {
   }
 }
 
+export async function invalidateBoardSets(): Promise<void> {
+  pendingLoad = loadBoardSets();
+  await pendingLoad;
+}
+
 export async function notifyBoardSetsChanged(): Promise<void> {
   await invalidateBoardSets();
   boardSetsSyncChannel.postMessage("invalidate");
@@ -71,16 +79,7 @@ export async function getBoardSets(): Promise<BoardSetRecord[]> {
   return store.getSnapshot().boardSets;
 }
 
-export async function invalidateBoardSets(): Promise<void> {
-  pendingLoad = loadBoardSets();
-  await pendingLoad;
-}
-
 export async function removeBoardSet(setId: string): Promise<void> {
   await withBoardsDB((db) => deleteBoardSet(db, setId));
   await notifyBoardSetsChanged();
 }
-
-boardSetsSyncChannel.addEventListener("message", () => {
-  void invalidateBoardSets();
-});

--- a/src/features/board/storage/db.ts
+++ b/src/features/board/storage/db.ts
@@ -2,6 +2,8 @@ import type { DBSchema, IDBPDatabase } from "idb";
 import { openDB } from "idb";
 import type { OBFBoard } from "open-board-format";
 
+// Stored records
+
 export interface BoardSetRecord {
   setId: string;
   name: string;
@@ -32,6 +34,8 @@ export interface AssetRecord {
   size?: number;
 }
 
+// Input shapes
+
 export interface UpsertBoardSetInput {
   setId: string;
   name: string;
@@ -58,6 +62,8 @@ export interface UpsertAssetInput {
   mediaId?: string;
 }
 
+// Schema
+
 export interface BoardsDBSchema extends DBSchema {
   boardSets: {
     key: string;
@@ -81,6 +87,8 @@ export type BoardsDB = IDBPDatabase<BoardsDBSchema>;
 const DB_NAME = "aac-boards-db";
 const DB_VERSION = 1;
 
+// Helpers
+
 function normalizePath(rawPath: string): string {
   if (!rawPath) {
     throw new Error("Path cannot be empty");
@@ -99,6 +107,8 @@ function validateId(id: string, fieldName: string): void {
     throw new Error(`Invalid ${fieldName}: must be 1-255 characters`);
   }
 }
+
+// Connection
 
 export async function openBoardsDB(): Promise<BoardsDB> {
   const db = await openDB<BoardsDBSchema>(DB_NAME, DB_VERSION, {
@@ -132,6 +142,8 @@ export async function withBoardsDB<T>(
     db.close();
   }
 }
+
+// Board sets — upsert / get / list / delete
 
 export async function upsertBoardSet(
   db: BoardsDB,
@@ -203,6 +215,8 @@ export async function deleteBoardSet(
   await tx.done;
 }
 
+// Boards — put / get / updateStrings
+
 export async function putBoards(
   db: BoardsDB,
   setId: string,
@@ -242,6 +256,33 @@ export async function getBoard(
   validateId(boardId, "boardId");
   return db.get("boards", [setId, boardId]);
 }
+
+export async function updateBoardStrings(
+  db: BoardsDB,
+  setId: string,
+  boardId: string,
+  locale: string,
+  translations: Record<string, string>,
+): Promise<void> {
+  validateId(setId, "setId");
+  validateId(boardId, "boardId");
+  const tx = db.transaction("boards", "readwrite");
+  const record = await tx.store.get([setId, boardId]);
+
+  if (!record) {
+    throw new Error(`Board not found: ${setId}/${boardId}`);
+  }
+
+  const updatedObf = {
+    ...record.obf,
+    strings: { ...record.obf.strings, [locale]: translations },
+  };
+
+  await tx.store.put({ ...record, obf: updatedObf });
+  await tx.done;
+}
+
+// Assets — put / get
 
 export async function putAssets(
   db: BoardsDB,
@@ -285,29 +326,4 @@ export async function getAssetBlob(
   const asset = await db.get("assets", [setId, cleanPath]);
 
   return asset?.blob;
-}
-
-export async function updateBoardStrings(
-  db: BoardsDB,
-  setId: string,
-  boardId: string,
-  locale: string,
-  translations: Record<string, string>,
-): Promise<void> {
-  validateId(setId, "setId");
-  validateId(boardId, "boardId");
-  const tx = db.transaction("boards", "readwrite");
-  const record = await tx.store.get([setId, boardId]);
-
-  if (!record) {
-    throw new Error(`Board not found: ${setId}/${boardId}`);
-  }
-
-  const updatedObf = {
-    ...record.obf,
-    strings: { ...record.obf.strings, [locale]: translations },
-  };
-
-  await tx.store.put({ ...record, obf: updatedObf });
-  await tx.done;
 }

--- a/src/features/board/storage/queries.ts
+++ b/src/features/board/storage/queries.ts
@@ -22,6 +22,11 @@ export class BoardNotFoundError extends Error {
   }
 }
 
+// Single concurrent caller assumed — the only consumer is boardLoader.
+// Revoke on the next call rather than from the caller: the consumer can't
+// know when its URLs are safe to release; the next load defines that boundary.
+let previousRegistry: ObjectUrlRegistry | null = null;
+
 export async function getBoardSet(
   setId: string,
 ): Promise<BoardSetRecord | undefined> {
@@ -38,11 +43,6 @@ export async function persistBoardTranslations(
     updateBoardStrings(db, setId, boardId, locale, translations),
   );
 }
-
-// Single concurrent caller assumed — the only consumer is boardLoader.
-// Revoke on the next call rather than from the caller: the consumer can't
-// know when its URLs are safe to release; the next load defines that boundary.
-let previousRegistry: ObjectUrlRegistry | null = null;
 
 export async function hydrateBoard(
   setId: string,

--- a/src/features/board/storage/test-helpers.ts
+++ b/src/features/board/storage/test-helpers.ts
@@ -8,6 +8,11 @@ import {
 
 const STORE_NAMES = ["boardSets", "boards", "assets"] as const;
 
+export interface SeedBoardSet extends Partial<BoardSetRecord> {
+  setId: string;
+  rootBoardId: string;
+}
+
 async function clearAllStores(db: BoardsDB): Promise<void> {
   const tx = db.transaction(STORE_NAMES, "readwrite");
   for (const name of STORE_NAMES) {
@@ -29,11 +34,6 @@ export async function openCleanBoardsDB(): Promise<BoardsDB> {
   const db = await openBoardsDB();
   await clearAllStores(db);
   return db;
-}
-
-export interface SeedBoardSet extends Partial<BoardSetRecord> {
-  setId: string;
-  rootBoardId: string;
 }
 
 export async function seedBoardSets(records: SeedBoardSet[]): Promise<void> {

--- a/src/features/board/suggestions/tone-selector.tsx
+++ b/src/features/board/suggestions/tone-selector.tsx
@@ -15,10 +15,10 @@ export interface ToneSelectorProps {
 export function ToneSelector({ tone, onChange }: ToneSelectorProps) {
   const handleChange = (
     _event: React.MouseEvent<HTMLElement>,
-    tone: SuggestionTone | null,
+    nextTone: SuggestionTone | null,
   ) => {
-    if (tone) {
-      onChange(tone);
+    if (nextTone) {
+      onChange(nextTone);
     }
   };
 

--- a/src/features/board/types.ts
+++ b/src/features/board/types.ts
@@ -43,12 +43,6 @@ export type BoardAction =
   | { kind: "speak" }
   | { kind: "spell"; text: string };
 
-export function getSpokenText(
-  button: Pick<BoardButton, "vocalization" | "label">,
-): string | undefined {
-  return button.vocalization ?? button.label;
-}
-
 export interface BoardLicense {
   type: string;
   authorName?: string;
@@ -59,3 +53,9 @@ export interface BoardLicense {
 }
 
 export type BoardStrings = Record<string, Record<string, string>>;
+
+export function getSpokenText(
+  button: Pick<BoardButton, "vocalization" | "label">,
+): string | undefined {
+  return button.vocalization ?? button.label;
+}

--- a/src/shared/built-in-ai/internal/lifecycle/store.ts
+++ b/src/shared/built-in-ai/internal/lifecycle/store.ts
@@ -24,6 +24,10 @@ export interface Acquired<Model> {
   signal: AbortSignal;
 }
 
+interface ProvisionOptions {
+  showDownloadUI: boolean;
+}
+
 const INITIAL_SNAPSHOT: Snapshot = {
   status: "idle",
   progress: 0,
@@ -118,10 +122,6 @@ export function createStore<
    * matters; the silent path keeps an "available" model on "idle" until it
    * lands as "ready".
    */
-  interface ProvisionOptions {
-    showDownloadUI: boolean;
-  }
-
   async function provision(
     signal: AbortSignal,
     { showDownloadUI }: ProvisionOptions,

--- a/src/shared/built-in-ai/internal/progress-store.ts
+++ b/src/shared/built-in-ai/internal/progress-store.ts
@@ -1,17 +1,17 @@
 const progressByKey = new Map<string, number>();
 const listeners = new Set<() => void>();
 
+function notify(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
 export function subscribeProgress(listener: () => void): () => void {
   listeners.add(listener);
   return () => {
     listeners.delete(listener);
   };
-}
-
-function notify(): void {
-  for (const listener of listeners) {
-    listener();
-  }
 }
 
 export function setDownloadProgress(key: string, progress: number): void {

--- a/src/shared/built-in-ai/internal/signal.ts
+++ b/src/shared/built-in-ai/internal/signal.ts
@@ -7,10 +7,6 @@ export function abortError(reason?: unknown): DOMException {
       );
 }
 
-function toError(reason: unknown): Error {
-  return reason instanceof Error ? reason : abortError(reason);
-}
-
 export function mergeSignals(
   ...signals: readonly (AbortSignal | undefined)[]
 ): AbortSignal {
@@ -45,4 +41,8 @@ export function raceAbort<T>(
   );
 
   return result;
+}
+
+function toError(reason: unknown): Error {
+  return reason instanceof Error ? reason : abortError(reason);
 }

--- a/src/shared/built-in-ai/internal/testing/ai-namespace-fake.ts
+++ b/src/shared/built-in-ai/internal/testing/ai-namespace-fake.ts
@@ -39,17 +39,3 @@ export function makeAIFake<I>({
     instances,
   };
 }
-
-/** `ReadableStream<string>` that emits `chunks` in order then closes. */
-export function makeChunkStream(
-  chunks: readonly string[],
-): ReadableStream<string> {
-  return new ReadableStream<string>({
-    start(controller) {
-      for (const c of chunks) {
-        controller.enqueue(c);
-      }
-      controller.close();
-    },
-  });
-}

--- a/src/shared/built-in-ai/internal/testing/instance-fakes.ts
+++ b/src/shared/built-in-ai/internal/testing/instance-fakes.ts
@@ -1,27 +1,5 @@
 import { vi } from "vitest";
-import { makeChunkStream } from "./ai-namespace-fake";
-
-export function buildTranslatorInstance() {
-  return {
-    translate: vi.fn((input: string) => Promise.resolve(`T:${input}`)),
-    translateStreaming: vi.fn(() => makeChunkStream(["T:", "hello"])),
-    measureInputUsage: vi.fn(() => Promise.resolve(7)),
-    inputQuota: 1024,
-    destroy: vi.fn<() => void>(),
-  };
-}
-
-export function buildRewriterInstance() {
-  return {
-    rewrite: vi.fn((input: string, opts?: RewriterRewriteOptions) =>
-      Promise.resolve(`R(${opts?.context ?? ""}):${input}`),
-    ),
-    rewriteStreaming: vi.fn(() => makeChunkStream(["R:", "alt"])),
-    measureInputUsage: vi.fn(() => Promise.resolve(4)),
-    inputQuota: 768,
-    destroy: vi.fn<() => void>(),
-  };
-}
+import { makeChunkStream } from "./stream-fake";
 
 export function buildProofreaderInstance() {
   return {
@@ -38,6 +16,28 @@ export function buildProofreaderInstance() {
         ],
       }),
     ),
+    destroy: vi.fn<() => void>(),
+  };
+}
+
+export function buildRewriterInstance() {
+  return {
+    rewrite: vi.fn((input: string, opts?: RewriterRewriteOptions) =>
+      Promise.resolve(`R(${opts?.context ?? ""}):${input}`),
+    ),
+    rewriteStreaming: vi.fn(() => makeChunkStream(["R:", "alt"])),
+    measureInputUsage: vi.fn(() => Promise.resolve(4)),
+    inputQuota: 768,
+    destroy: vi.fn<() => void>(),
+  };
+}
+
+export function buildTranslatorInstance() {
+  return {
+    translate: vi.fn((input: string) => Promise.resolve(`T:${input}`)),
+    translateStreaming: vi.fn(() => makeChunkStream(["T:", "hello"])),
+    measureInputUsage: vi.fn(() => Promise.resolve(7)),
+    inputQuota: 1024,
     destroy: vi.fn<() => void>(),
   };
 }

--- a/src/shared/built-in-ai/internal/testing/stream-fake.ts
+++ b/src/shared/built-in-ai/internal/testing/stream-fake.ts
@@ -1,0 +1,13 @@
+/** `ReadableStream<string>` that emits `chunks` in order then closes. */
+export function makeChunkStream(
+  chunks: readonly string[],
+): ReadableStream<string> {
+  return new ReadableStream<string>({
+    start(controller) {
+      for (const c of chunks) {
+        controller.enqueue(c);
+      }
+      controller.close();
+    },
+  });
+}

--- a/src/shared/hooks/use-audio.ts
+++ b/src/shared/hooks/use-audio.ts
@@ -34,10 +34,6 @@ export function useAudio(): UseAudioReturn {
     audioRef.current = null;
   }
 
-  useEffect(() => {
-    return () => cleanup();
-  }, []);
-
   function play(url: string) {
     cleanup();
 
@@ -84,6 +80,10 @@ export function useAudio(): UseAudioReturn {
     setIsPlaying(false);
     setIsPaused(false);
   }
+
+  useEffect(() => {
+    return () => cleanup();
+  }, []);
 
   return { play, stop, isPlaying, isPaused };
 }

--- a/src/shared/language/language-context.ts
+++ b/src/shared/language/language-context.ts
@@ -1,9 +1,9 @@
 import { createContext } from "react";
 
 export interface LanguageContextValue {
-  languages: { language: string; name: string }[];
   language: string;
   setLanguage: (language: string) => void;
+  languages: { language: string; name: string }[];
   direction: "ltr" | "rtl";
 }
 

--- a/src/shared/language/language-provider.tsx
+++ b/src/shared/language/language-provider.tsx
@@ -26,9 +26,9 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
   useVoiceLanguageSync({ language });
 
   const contextValue: LanguageContextValue = {
-    languages,
     language,
     setLanguage,
+    languages,
     direction,
   };
 

--- a/src/shared/snackbar/snackbar-provider.tsx
+++ b/src/shared/snackbar/snackbar-provider.tsx
@@ -11,10 +11,6 @@ import {
 
 const DEFAULT_SNACKBAR_SEVERITY: SnackbarSeverity = "info";
 
-export interface SnackbarProviderProps {
-  children: ReactNode;
-}
-
 interface SnackbarMessage extends SnackbarOptions {
   key: number;
 }
@@ -68,6 +64,10 @@ function snackbarReducer(
       return { ...state, current: undefined };
     }
   }
+}
+
+export interface SnackbarProviderProps {
+  children: ReactNode;
 }
 
 export function SnackbarProvider({ children }: SnackbarProviderProps) {

--- a/src/shared/speech/speech-store.ts
+++ b/src/shared/speech/speech-store.ts
@@ -8,18 +8,18 @@ export interface SpeechRange {
   fallback: number;
 }
 
-type VoicesByLanguage = Partial<Record<string, SpeechSynthesisVoice[]>>;
-
-interface VoiceCatalogState {
-  voices: SpeechSynthesisVoice[];
-  voicesByLanguage: VoicesByLanguage;
-}
-
 export interface SpeechConfig {
   voiceURI: string | null;
   rate: number;
   pitch: number;
   volume: number;
+}
+
+type VoicesByLanguage = Partial<Record<string, SpeechSynthesisVoice[]>>;
+
+interface VoiceCatalogState {
+  voices: SpeechSynthesisVoice[];
+  voicesByLanguage: VoicesByLanguage;
 }
 
 export const SPEECH_RATE: SpeechRange = { min: 0.1, max: 2, fallback: 1 };
@@ -68,11 +68,17 @@ function buildVoiceCatalog(voices: SpeechSynthesisVoice[]): VoiceCatalogState {
   };
 }
 
+// Module init
+
 const synthesis: SpeechSynthesis | undefined = globalThis.speechSynthesis;
 
 const voiceCatalogStore = createExternalStore<VoiceCatalogState>(
   buildVoiceCatalog(synthesis?.getVoices() ?? []),
 );
+
+synthesis?.addEventListener("voiceschanged", () => {
+  voiceCatalogStore.setState(buildVoiceCatalog(synthesis.getVoices()));
+});
 
 const speechConfigStore = createExternalStore<SpeechConfig>(
   loadPersistedConfig(),
@@ -92,10 +98,6 @@ speechConfigStore.subscribe(() => {
 function updateConfig(patch: Partial<SpeechConfig>): void {
   speechConfigStore.setState({ ...speechConfigStore.getSnapshot(), ...patch });
 }
-
-synthesis?.addEventListener("voiceschanged", () => {
-  voiceCatalogStore.setState(buildVoiceCatalog(synthesis.getVoices()));
-});
 
 export function getSpeechConfig(): SpeechConfig {
   return speechConfigStore.getSnapshot();

--- a/src/shared/speech/speech-store.ts
+++ b/src/shared/speech/speech-store.ts
@@ -127,12 +127,12 @@ export function speak(text: string): Promise<void> {
   const { promise, resolve, reject } = Promise.withResolvers<void>();
 
   const { voices } = voiceCatalogStore.getSnapshot();
-  const { voiceURI, pitch, rate, volume } = speechConfigStore.getSnapshot();
+  const { voiceURI, rate, pitch, volume } = speechConfigStore.getSnapshot();
 
   const utterance = new SpeechSynthesisUtterance(text);
   utterance.voice = voices.find((voice) => voice.voiceURI === voiceURI) ?? null;
-  utterance.pitch = pitch;
   utterance.rate = rate;
+  utterance.pitch = pitch;
   utterance.volume = volume;
 
   utterance.onend = () => resolve();

--- a/src/shared/testing/device-output.ts
+++ b/src/shared/testing/device-output.ts
@@ -1,10 +1,12 @@
-import { vi } from "vitest";
+import { type MockInstance, vi } from "vitest";
 
 // Stubs fire onend/ended via microtask so awaited callers can settle in tests.
 // cancel/pause are also stubbed: real device output calls them during lifecycle, causing spurious AbortErrors.
 
-export function stubSpeech() {
-  const cancel = vi.spyOn(speechSynthesis, "cancel").mockReturnValue(undefined);
+export function stubSpeech(): {
+  speak: MockInstance<SpeechSynthesis["speak"]>;
+  cancel: MockInstance<SpeechSynthesis["cancel"]>;
+} {
   const speak = vi
     .spyOn(speechSynthesis, "speak")
     .mockImplementation((utterance) => {
@@ -12,14 +14,14 @@ export function stubSpeech() {
         utterance.onend?.({ utterance } as unknown as SpeechSynthesisEvent);
       });
     });
+  const cancel = vi.spyOn(speechSynthesis, "cancel").mockReturnValue(undefined);
   return { speak, cancel };
 }
 
-export function stubAudio() {
-  const pause = vi
-    .spyOn(HTMLAudioElement.prototype, "pause")
-    .mockReturnValue(undefined);
-
+export function stubAudio(): {
+  play: MockInstance<HTMLAudioElement["play"]>;
+  pause: MockInstance<HTMLAudioElement["pause"]>;
+} {
   const play = vi
     .spyOn(HTMLAudioElement.prototype, "play")
     .mockImplementation(function (this: HTMLAudioElement) {
@@ -29,5 +31,8 @@ export function stubAudio() {
       });
       return Promise.resolve();
     });
+  const pause = vi
+    .spyOn(HTMLAudioElement.prototype, "pause")
+    .mockReturnValue(undefined);
   return { play, pause };
 }

--- a/src/shared/utils/locale.ts
+++ b/src/shared/utils/locale.ts
@@ -28,6 +28,19 @@ export function getLanguageCode(locale: string): string {
 }
 
 /**
+ * Returns the writing direction for a BCP-47 locale code.
+ * Falls back to "ltr" for structurally invalid input; unknown
+ * but well-formed codes default to "ltr" via Intl.
+ */
+export function getTextDirection(locale: string): "ltr" | "rtl" {
+  try {
+    return parseLocale(locale).getTextInfo().direction ?? "ltr";
+  } catch {
+    return "ltr";
+  }
+}
+
+/**
  * Returns the display name of a locale code in English.
  * Falls back to the original code if the locale is not recognized.
  */
@@ -52,18 +65,5 @@ export function getNativeLanguageName(locale: string): string {
     );
   } catch {
     return language;
-  }
-}
-
-/**
- * Returns the writing direction for a BCP-47 locale code.
- * Falls back to "ltr" for structurally invalid input; unknown
- * but well-formed codes default to "ltr" via Intl.
- */
-export function getTextDirection(locale: string): "ltr" | "rtl" {
-  try {
-    return parseLocale(locale).getTextInfo().direction ?? "ltr";
-  } catch {
-    return "ltr";
   }
 }

--- a/src/shared/utils/locale.ts
+++ b/src/shared/utils/locale.ts
@@ -1,3 +1,8 @@
+const englishLanguageNames = new Intl.DisplayNames(["en"], {
+  type: "language",
+  languageDisplay: "dialect",
+});
+
 function parseLocale(locale: string): Intl.Locale {
   return new Intl.Locale(locale.replace(/_/g, "-"));
 }
@@ -21,11 +26,6 @@ export function normalizeLocale(locale: string): string {
 export function getLanguageCode(locale: string): string {
   return locale.split(/[_-]/)[0].toLowerCase();
 }
-
-const englishLanguageNames = new Intl.DisplayNames(["en"], {
-  type: "language",
-  languageDisplay: "dialect",
-});
 
 /**
  * Returns the display name of a locale code in English.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,7 @@ import { paraglideVitePlugin } from "@inlang/paraglide-js";
 import babel from "@rolldown/plugin-babel";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import { playwright } from "@vitest/browser-playwright";
-import path from "path";
+import path from "node:path";
 import { defineConfig } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
 import { coverageConfigDefaults } from "vitest/config";
@@ -54,17 +54,17 @@ export default defineConfig({
     alias: {
       "@app": path.resolve(__dirname, "./src/app"),
       "@features": path.resolve(__dirname, "./src/features"),
-      "@shared": path.resolve(__dirname, "./src/shared"),
       "@pages": path.resolve(__dirname, "./src/pages"),
       "@paraglide": path.resolve(__dirname, "./src/paraglide"),
+      "@shared": path.resolve(__dirname, "./src/shared"),
     },
   },
   optimizeDeps: {
     include: [
-      "@mui/material/*",
-      "@mui/icons-material/*",
       "@emotion/cache",
       "@emotion/react",
+      "@mui/icons-material/*",
+      "@mui/material/*",
       "@mui/stylis-plugin-rtl",
       "react-dom/client",
       "react-router/dom",


### PR DESCRIPTION
## Summary
A pass over the codebase tightening intra-file structure, centralizing static route strings, and pulling a few inline expressions into named helpers. Behavior unchanged across the board.

**Ordering and grouping**
- Helpers and types hoisted above their consumers; exported interfaces placed before implementations.
- Module-init side effects (BroadcastChannel listener, `voiceschanged` listener) live next to the stores they wire up.
- Hook lifecycle cleanups land at the bottom.
- `db.ts` gains section dividers grouping records / inputs / schema / connection / boardSets / boards / assets.
- Extract `makeChunkStream` from `ai-namespace-fake.ts` into a dedicated `stream-fake.ts` so neither side carries a misleading import.
- Reorder props/state tuples and method signatures so related operations cluster (`language`/`setLanguage` adjacent; `rate, pitch, volume` matching the `SPEECH_*` constants; `info` before `delete`; single-part mutations before bulk).

**Centralized routes**
- Extend `ROUTE_PATTERNS` with `LIBRARY` / `ABOUT` so `app-router` consumes the same table as the rest.
- Add `LIBRARY_PATH` / `ABOUT_PATH` as `as const` template-string constants for static (no-param) routes; `menu-drawer` references them directly instead of duplicating `/library` / `/about`.

**Small extractions / latent-bug prevention**
- `speech-settings`: hoist the inline locale-options renderer into a named function so the `.map` call site reads as one verb.
- `use-board-navigation.test`: `DEFAULT_PATH` constant for a literal that appeared 5×.
- `tone-selector`: rename the inner `tone` handler param to `nextTone` so it no longer shadows the outer prop.

**Misc**
- `vite.config.ts`: `node:path` prefix; alphabetize aliases and `optimizeDeps`.
- `features/board/index.ts`: split value exports from `export type` block to make `verbatimModuleSyntax` intent visible.

## Test plan
- [ ] `npm test` passes
- [ ] `npm run lint` clean
- [ ] `npm run dev` — spot-check `/library`, `/about`, voice picker grouping, and the tone selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)