### PR TITLE
refactor(board): add message.appendText for spell action

### DIFF
--- a/src/features/board/activation/use-button-activation.test.tsx
+++ b/src/features/board/activation/use-button-activation.test.tsx
@@ -13,6 +13,7 @@ function createMessageStub(parts: MessagePart[] = []): UseMessageReturn {
     text: parts.map((p) => p.label ?? "").join(" "),
     addPart: vi.fn(),
     addSpace: vi.fn(),
+    appendText: vi.fn(),
     setFromText: vi.fn(),
     removeLastPart: vi.fn(),
     updateLastPart: vi.fn(),
@@ -157,7 +158,7 @@ describe("useButtonActivation", () => {
     expect(navigation.goHome).toHaveBeenCalledTimes(1);
   });
 
-  test("appends a spell action's text to the last message part's label", async () => {
+  test("delegates a spell action's text to the message's appendText", async () => {
     const message = createMessageStub([{ id: "ca", label: "ca" }]);
     const { result } = await setup({ message });
 
@@ -166,10 +167,7 @@ describe("useButtonActivation", () => {
       actions: [{ kind: "spell", text: "t" }],
     });
 
-    expect(message.updateLastPart).toHaveBeenCalledWith({
-      id: "t",
-      label: "cat",
-    });
+    expect(message.appendText).toHaveBeenCalledWith("t");
   });
 
   test("treats a loadBoard without an id as not navigable and speaks instead", async () => {

--- a/src/features/board/activation/use-button-activation.ts
+++ b/src/features/board/activation/use-button-activation.ts
@@ -56,6 +56,8 @@ export function useButtonActivation({
 
   async function runAction(action: BoardAction) {
     switch (action.kind) {
+      case "spell":
+        return message.appendText(action.text);
       case "space":
         return message.addSpace();
       case "backspace":
@@ -66,8 +68,6 @@ export function useButtonActivation({
         return navigation.goHome();
       case "speak":
         return playback.play();
-      case "spell":
-        return appendToLastPart(action.text);
 
       default: {
         const _exhaustiveCheck: never = action;
@@ -76,14 +76,6 @@ export function useButtonActivation({
         );
       }
     }
-  }
-
-  function appendToLastPart(text: string) {
-    const lastPart = message.parts.at(-1);
-    message.updateLastPart({
-      id: text,
-      label: `${lastPart?.label ?? ""}${text}`,
-    });
   }
 
   return { activateButton };

--- a/src/features/board/message/use-message.test.tsx
+++ b/src/features/board/message/use-message.test.tsx
@@ -48,6 +48,48 @@ describe("useMessage", () => {
     expect(result.current.parts[0]).toEqual({ id: "1", label: "first" });
   });
 
+  test("appends text to the last part without mangling its id", async () => {
+    const { result, rerender } = await renderHook(() => useMessage());
+
+    result.current.addPart({ id: "abc-123", label: "ca", imageSrc: "img.png" });
+    await rerender();
+
+    result.current.appendText("t");
+    await rerender();
+
+    expect(result.current.parts).toHaveLength(1);
+    expect(result.current.parts[0]).toEqual({
+      id: "abc-123",
+      label: "cat",
+      imageSrc: "img.png",
+    });
+  });
+
+  test("appends text as a new part when the message is empty", async () => {
+    const { result, rerender } = await renderHook(() => useMessage());
+
+    result.current.appendText("h");
+    await rerender();
+
+    expect(result.current.parts).toHaveLength(1);
+    expect(result.current.parts[0].label).toBe("h");
+    expect(result.current.parts[0].id).toBeTruthy();
+  });
+
+  test("accumulates rapid appends into a single part", async () => {
+    const { result, rerender } = await renderHook(() => useMessage());
+
+    result.current.addPart({ id: "p1", label: "" });
+    await rerender();
+
+    result.current.appendText("h");
+    result.current.appendText("i");
+    await rerender();
+
+    expect(result.current.parts).toHaveLength(1);
+    expect(result.current.parts[0]).toEqual({ id: "p1", label: "hi" });
+  });
+
   test("removes the last-added part", async () => {
     const { result, rerender } = await renderHook(() => useMessage());
 

--- a/src/features/board/message/use-message.ts
+++ b/src/features/board/message/use-message.ts
@@ -11,6 +11,7 @@ export interface UseMessageReturn {
   text: string;
   addPart: (part: MessagePart) => void;
   addSpace: () => void;
+  appendText: (text: string) => void;
   updateLastPart: (part: MessagePart) => void;
   setFromText: (input: string) => void;
   removeLastPart: () => void;
@@ -29,6 +30,20 @@ export function useMessage(): UseMessageReturn {
     addPart({
       id: crypto.randomUUID(),
       label: "",
+    });
+  }
+
+  function appendText(text: string) {
+    setParts((prev) => {
+      const lastPart = prev.at(-1);
+      if (!lastPart) {
+        return [{ id: crypto.randomUUID(), label: text }];
+      }
+
+      return prev.with(-1, {
+        ...lastPart,
+        label: `${lastPart.label ?? ""}${text}`,
+      });
     });
   }
 
@@ -65,6 +80,7 @@ export function useMessage(): UseMessageReturn {
     text,
     addPart,
     addSpace,
+    appendText,
     updateLastPart,
     setFromText,
     removeLastPart,


### PR DESCRIPTION
## Summary
- Extract spell-action append into `message.appendText`, preserving the part's `id` and other fields (`imageSrc`, `vocalization`, `soundSrc`) instead of overwriting `id` with the appended letter.
- Functional setState lets successive `appendText` calls in the same tick accumulate correctly.
- Update `useButtonActivation` to delegate `spell` to `message.appendText`.

## Test plan
- [x] `useMessage` tests cover preserve-id, empty fallback, rapid-append accumulation
- [x] `useButtonActivation` test asserts `spell` delegates to `appendText`

🤖 Generated with [Claude Code](https://claude.com/claude-code)