### PR TITLE
chore(deps): bump @shayc/open-board-format ^0.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mui/icons-material": "^9.0.1",
         "@mui/material": "^9.0.1",
         "@mui/stylis-plugin-rtl": "^9.0.1",
-        "@shayc/open-board-format": "^0.1.2",
+        "@shayc/open-board-format": "^0.1.3",
         "@shayc/react-built-in-ai": "^0.2.1",
         "idb": "^8.0.3",
         "mrmime": "^2.0.1",
@@ -3454,9 +3454,9 @@
       ]
     },
     "node_modules/@shayc/open-board-format": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@shayc/open-board-format/-/open-board-format-0.1.2.tgz",
-      "integrity": "sha512-SrwnbMkja1vIqQ+Wz/j2lY0MepzjQ0FLEFDZ+BS8xVmaNAwVAV4xc+bxQEWAkvmhm+uxGU9Asj5BHOrdQP1qTw==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@shayc/open-board-format/-/open-board-format-0.1.3.tgz",
+      "integrity": "sha512-LlJf/yIiysueBumVg6jrtkW+vF68Br4ZKzJkR/MR5y1M4OHcC5dJbmJfdS9Uz3k8TjwA9NrvxrQIJIc093GoBw==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@mui/icons-material": "^9.0.1",
     "@mui/material": "^9.0.1",
     "@mui/stylis-plugin-rtl": "^9.0.1",
-    "@shayc/open-board-format": "^0.1.2",
+    "@shayc/open-board-format": "^0.1.3",
     "@shayc/react-built-in-ai": "^0.2.1",
     "idb": "^8.0.3",
     "mrmime": "^2.0.1",


### PR DESCRIPTION
## Summary
- Bump `@shayc/open-board-format` from `^0.1.2` to `^0.1.3` (patch release).

## Test plan
- [x] lint
- [x] typecheck + production build
- [x] tests (249/249)
- [x] API-compatible: `loadOBF`/`loadOBZ` and `OBF*` types still typecheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)