### PR TITLE
style(about-page): use body1 variant for app description

### DIFF
--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -14,7 +14,7 @@ export const Component = function AboutPage() {
       <PageTitle>{m.aboutHeading()}</PageTitle>
 
       <Stack spacing={{ xs: 3, sm: 4 }}>
-        <Typography component="p" variant="h6" sx={{ pt: 6 }}>
+        <Typography component="p" variant="body1" sx={{ pt: 6 }}>
           {m.aboutAppDescription({ appName: APP_NAME })}
         </Typography>
 


### PR DESCRIPTION
## Summary
- Change the About page app-description `Typography` from the `h6` variant to `body1`, so the intro paragraph reads as body copy rather than an oversized subheading.

## Test plan
- `npm run lint` passes
- Visual: About page description now renders at body-text size (top padding unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)