### PR TITLE
Mobile-responsive onboarding dialog & about page, dev:host script

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Open [http://localhost:5173](http://localhost:5173)
 ```bash
 npx playwright install  # One-time: install Chromium for tests
 npm run dev             # Start dev server
+npm run dev:host        # Dev server, accessible from other devices on your network
 npm run lint            # Lint
 npm test                # Run tests
 npm run build           # Typecheck + production build

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "dev": "vite",
+    "dev:host": "vite --host",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "format": "prettier --write .",

--- a/src/app/onboarding/onboarding-dialog.tsx
+++ b/src/app/onboarding/onboarding-dialog.tsx
@@ -12,6 +12,7 @@ import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import { m } from "@paraglide/messages.js";
 import type { ReactNode } from "react";
 
@@ -21,6 +22,8 @@ export interface OnboardingDialogProps {
 }
 
 export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
+  const fullScreen = useMediaQuery((theme) => theme.breakpoints.down("sm"));
+
   const highlights: { icon: ReactNode; primary: string; secondary: string }[] =
     [
       {
@@ -44,6 +47,7 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
     <Dialog
       open={open}
       onClose={onClose}
+      fullScreen={fullScreen}
       fullWidth
       maxWidth="xs"
       aria-labelledby="welcome-dialog-title"
@@ -51,7 +55,7 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
       slotProps={{
         paper: {
           sx: {
-            borderRadius: 6,
+            borderRadius: fullScreen ? 0 : 6,
             p: 1,
           },
         },

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -14,7 +14,7 @@ export const Component = function AboutPage() {
       <PageTitle>{m.aboutHeading()}</PageTitle>
 
       <Stack spacing={{ xs: 3, sm: 4 }}>
-        <Typography component="p" variant="body1" sx={{ pt: 6 }}>
+        <Typography component="p" variant="body1" sx={{ pt: { xs: 4, sm: 6 } }}>
           {m.aboutAppDescription({ appName: APP_NAME })}
         </Typography>
 


### PR DESCRIPTION
## Summary
- Onboarding dialog now goes full screen on mobile (`breakpoints.down("sm")`), dropping rounded corners when it fills the viewport
- About page app-description top padding is now responsive (`pt` 4 on mobile, 6 from `sm` up)
- Adds a `dev:host` npm script for local network access

## Test plan
- [ ] Onboarding dialog fills the screen on a narrow viewport, stays an `xs` card on desktop
- [ ] About page top spacing is tighter on mobile
- [ ] `npm run dev:host` serves on the local network

🤖 Generated with [Claude Code](https://claude.com/claude-code)