### PR TITLE
refactor(board): rename useGridKeyboardNavigation to useGridKeyboard

### DIFF
--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -1,5 +1,5 @@
 import Stack from "@mui/material/Stack";
-import { useGridKeyboardNavigation } from "./use-grid-keyboard-navigation";
+import { useGridKeyboard } from "./use-grid-keyboard";
 
 export interface GridItemProps {
   tabIndex: number;
@@ -25,7 +25,7 @@ export function Grid<TItem extends { id: string }>({
   gap = 2,
 }: GridProps<TItem>) {
   const grid = buildGrid(items, rows, columns, order);
-  const { rootRef, rootProps, activeCell } = useGridKeyboardNavigation({
+  const { rootRef, rootProps, activeCell } = useGridKeyboard({
     grid,
     dir,
   });

--- a/src/features/board/grid/use-grid-keyboard.ts
+++ b/src/features/board/grid/use-grid-keyboard.ts
@@ -10,12 +10,12 @@ export interface Cell {
   col: number;
 }
 
-export interface UseGridKeyboardNavigationOptions {
+export interface UseGridKeyboardOptions {
   grid: readonly (readonly unknown[])[];
   dir?: "ltr" | "rtl";
 }
 
-export interface UseGridKeyboardNavigationReturn {
+export interface UseGridKeyboardReturn {
   rootRef: RefObject<HTMLDivElement | null>;
   rootProps: DOMAttributes<HTMLElement>;
   activeCell: Cell;
@@ -39,10 +39,10 @@ interface KeyboardKey {
   altKey: boolean;
 }
 
-export function useGridKeyboardNavigation({
+export function useGridKeyboard({
   grid,
   dir = "ltr",
-}: UseGridKeyboardNavigationOptions): UseGridKeyboardNavigationReturn {
+}: UseGridKeyboardOptions): UseGridKeyboardReturn {
   const rootRef = useRef<HTMLDivElement>(null);
   const [activeCell, setActiveCell] = useState<Cell>(() =>
     findFirstNonEmptyCell(grid),


### PR DESCRIPTION
The `-Navigation` suffix was redundant — `useGridKeyboard` is just as high-signal and shorter at every call site.

- Renames the hook `useGridKeyboardNavigation` → `useGridKeyboard`
- Renames its `UseGridKeyboard{Options,Return}` interfaces
- Renames the file `use-grid-keyboard-navigation.ts` → `use-grid-keyboard.ts` (git mv, history preserved)
- Updates the only consumer, `grid.tsx`

Pure rename, no behavior change. Also unblocks the filename referenced by #409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)