### PR TITLE
test(board): cover translation abort when UI language changes mid-flight

### DIFF
--- a/src/features/board/translation/use-board-translation.test.tsx
+++ b/src/features/board/translation/use-board-translation.test.tsx
@@ -148,4 +148,43 @@ describe("useBoardTranslation", () => {
       targetLanguage: "de",
     });
   });
+
+  test("ignores a stale translation when the UI language changes mid-flight", async () => {
+    const board = makeBoard();
+    // Each translate call hangs until resolved by hand, so the test controls
+    // which language's batch settles first.
+    const calls: { input: string; resolve: (value: string) => void }[] = [];
+    stubTranslator(
+      (input) =>
+        new Promise<string>((resolve) => {
+          calls.push({ input, resolve });
+        }),
+    );
+
+    const { result } = await setup(board, "es");
+
+    // The "es" batch is in flight: one pending translate per unique string.
+    await vi.waitFor(() => {
+      expect(calls).toHaveLength(3);
+    });
+
+    // Switching language aborts the "es" run and starts a fresh "de" one.
+    result.current.setLanguage("de");
+    await vi.waitFor(() => {
+      expect(calls).toHaveLength(6);
+    });
+
+    // Settle the fresh "de" batch first, then let the aborted "es" batch resolve.
+    for (const { input, resolve } of calls.slice(3)) {
+      resolve(`de:${input}`);
+    }
+    for (const { input, resolve } of calls.slice(0, 3)) {
+      resolve(`es:${input}`);
+    }
+
+    // The stale "es" resolution must not clobber the "de" board.
+    await vi.waitFor(() => {
+      expect(result.current.translation.translatedBoard.name).toBe("de:Food");
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Adds the one meaningful gap left after #411: the abort path in `useBoardTranslation`.

The merged suggestions suite tests its stale-in-flight race thoroughly; the translation hook has the same `signal.aborted` guard ([use-board-translation.ts](src/features/board/translation/use-board-translation.ts)) on the cache-miss path but no coverage. This test drives the **real `LanguageProvider`**, starts an `"es"` translation, switches to `"de"` mid-flight, then resolves the fresh `"de"` batch before the aborted `"es"` batch — asserting the stale result never clobbers the board.

## Why it's meaningful (not testing the mock)
Mutation-checked: with the `if (signal.aborted) return` guard removed, **only this test fails** (`expected 'es:Food' to be 'de:Food'`) while the other 8 stay green. It isolates the guard's behavior precisely.

Deliberately scoped to the abort path only — the persistence call is left to [queries.test.ts](src/features/board/storage/queries.test.ts); asserting it at the hook level would mean stubbing `../storage/queries`, i.e. testing the mock.

## Test plan
- `npx vitest run` on the file: **9/9 pass**
- `tsc -b`, `eslint`, `prettier` clean
- Mutation check: guard removed → this test (and only this test) fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)