### PR TITLE
test(board): drop title-restating comment in stale-translation test

### DIFF
--- a/src/features/board/translation/use-board-translation.test.tsx
+++ b/src/features/board/translation/use-board-translation.test.tsx
@@ -182,7 +182,6 @@ describe("useBoardTranslation", () => {
       resolve(`es:${input}`);
     }
 
-    // The stale "es" resolution must not clobber the "de" board.
     await vi.waitFor(() => {
       expect(result.current.translation.translatedBoard.name).toBe("de:Food");
     });


### PR DESCRIPTION
## Summary
Removes a single comment in `use-board-translation.test.tsx` that just restated the test name (`// The stale "es" resolution must not clobber the "de" board.` above a test titled *"ignores a stale translation when the UI language changes mid-flight"*).

This matches the identical cleanup already applied to the sibling suggestions stale-flight test — keeping the two parallel tests consistent. The remaining comment (resolve-ordering rationale) is retained, as it explains *why* the de batch is settled before the es batch, which the code alone doesn't convey.

## Test plan
- `npx vitest run` on the file: **7/7 pass**
- `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)