### PR TITLE
feat(board): physical-keyboard shortcuts

### DIFF
--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -3,6 +3,7 @@ import Stack from "@mui/material/Stack";
 import { useLanguage } from "@shared/language/use-language";
 import { useButtonActivation } from "./activation/use-button-activation";
 import { Grid, type GridItemProps } from "./grid/grid";
+import { useBoardKeyboard } from "./keyboard/use-board-keyboard";
 import { MessageBar } from "./message/message-bar";
 import { useMessage } from "./message/use-message";
 import { useMessagePlayback } from "./message/use-message-playback";
@@ -30,6 +31,8 @@ export function BoardViewer({ board }: BoardViewerProps) {
     navigation,
   });
 
+  const keyboard = useBoardKeyboard({ message, playback });
+
   const renderTile = (button: BoardButton, props: GridItemProps) => (
     <Tile
       key={button.id}
@@ -45,6 +48,7 @@ export function BoardViewer({ board }: BoardViewerProps) {
 
   return (
     <Stack
+      {...keyboard.rootProps}
       direction="column"
       sx={[
         { height: "100%" },

--- a/src/features/board/grid/use-grid-keyboard.ts
+++ b/src/features/board/grid/use-grid-keyboard.ts
@@ -59,17 +59,21 @@ export function useGridKeyboard({
     onKeyDown: (event) => {
       const root = rootRef.current;
       if (!root) {
+        event.continuePropagation();
         return;
       }
 
       const from = cellOf(event.target as Element | null);
       if (!from) {
+        event.continuePropagation();
         return;
       }
 
       const next = nextFocus(event, root, from, dir);
-      // Don't preventDefault when we didn't move — let the key fall through (e.g. Home/End at row boundary).
+      // react-aria stops propagation by default; only an arrow/Home/End move is
+      // ours, so let every other key bubble up to the board-root handler.
       if (!next || sameCell(next.position, from)) {
+        event.continuePropagation();
         return;
       }
 

--- a/src/features/board/keyboard/board-key-resolver.test.ts
+++ b/src/features/board/keyboard/board-key-resolver.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "vitest";
+import { resolveBoardKey, type KeyEventLike } from "./board-key-resolver";
+
+function key(overrides: Partial<KeyEventLike>): KeyEventLike {
+  return { key: "", metaKey: false, ctrlKey: false, ...overrides };
+}
+
+describe("resolveBoardKey", () => {
+  test("Backspace removes the last part", () => {
+    expect(resolveBoardKey(key({ key: "Backspace" }), false)).toEqual({
+      kind: "backspace",
+    });
+  });
+
+  test("⌘/Ctrl+Backspace clears the message", () => {
+    expect(
+      resolveBoardKey(key({ key: "Backspace", metaKey: true }), false),
+    ).toEqual({
+      kind: "clear",
+    });
+    expect(
+      resolveBoardKey(key({ key: "Backspace", ctrlKey: true }), false),
+    ).toEqual({
+      kind: "clear",
+    });
+  });
+
+  test("⌘/Ctrl+Enter speaks, but is inert while already speaking", () => {
+    expect(
+      resolveBoardKey(key({ key: "Enter", metaKey: true }), false),
+    ).toEqual({
+      kind: "speak",
+    });
+    expect(
+      resolveBoardKey(key({ key: "Enter", ctrlKey: true }), false),
+    ).toEqual({
+      kind: "speak",
+    });
+    expect(
+      resolveBoardKey(key({ key: "Enter", metaKey: true }), true),
+    ).toBeNull();
+  });
+
+  test("Escape cancels only while speaking", () => {
+    expect(resolveBoardKey(key({ key: "Escape" }), true)).toEqual({
+      kind: "cancel",
+    });
+    expect(resolveBoardKey(key({ key: "Escape" }), false)).toBeNull();
+  });
+
+  test("Enter without a modifier is left for the focused control", () => {
+    expect(resolveBoardKey(key({ key: "Enter" }), false)).toBeNull();
+  });
+
+  test("typing keys are not yet claimed — spelling comes later", () => {
+    for (const typed of ["h", "5", "!", " "]) {
+      expect(resolveBoardKey(key({ key: typed }), false)).toBeNull();
+    }
+  });
+
+  test("⌘/Ctrl combos the board doesn't use pass through to the browser", () => {
+    expect(resolveBoardKey(key({ key: "c", metaKey: true }), false)).toBeNull();
+    expect(resolveBoardKey(key({ key: "r", ctrlKey: true }), false)).toBeNull();
+  });
+
+  test("navigation and other named keys are ignored", () => {
+    for (const named of ["ArrowUp", "ArrowDown", "Home", "End", "Tab", "F1"]) {
+      expect(resolveBoardKey(key({ key: named }), false)).toBeNull();
+    }
+  });
+});

--- a/src/features/board/keyboard/board-key-resolver.ts
+++ b/src/features/board/keyboard/board-key-resolver.ts
@@ -1,0 +1,41 @@
+export type BoardKeyAction =
+  | { kind: "backspace" }
+  | { kind: "clear" }
+  | { kind: "speak" }
+  | { kind: "cancel" };
+
+export interface KeyEventLike {
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+}
+
+/**
+ * Resolves a keystroke to a board action, or `null` when the board doesn't
+ * claim the key — so the caller leaves it be: Enter and Space keep activating
+ * the focused control, and ⌘/Ctrl combos reach the browser.
+ */
+export function resolveBoardKey(
+  event: KeyEventLike,
+  isSpeaking: boolean,
+): BoardKeyAction | null {
+  if (event.metaKey || event.ctrlKey) {
+    if (event.key === "Enter") {
+      // While speaking, ⌘+Enter is inert — don't stack a second playback.
+      return isSpeaking ? null : { kind: "speak" };
+    }
+    if (event.key === "Backspace") {
+      return { kind: "clear" };
+    }
+    return null;
+  }
+
+  if (event.key === "Escape") {
+    return isSpeaking ? { kind: "cancel" } : null;
+  }
+  if (event.key === "Backspace") {
+    return { kind: "backspace" };
+  }
+
+  return null;
+}

--- a/src/features/board/keyboard/use-board-keyboard.test.tsx
+++ b/src/features/board/keyboard/use-board-keyboard.test.tsx
@@ -1,0 +1,91 @@
+import { AppProviders } from "@app/app-providers";
+import { stubAudio, stubSpeech } from "@shared/testing/device-output";
+import type { OBFBoard } from "@shayc/open-board-format";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { userEvent } from "vitest/browser";
+import { BoardViewer } from "../board-viewer";
+import { obfToBoard } from "../obf/obf-to-board";
+
+const TWO_TILE_BOARD: OBFBoard = {
+  format: "open-board-0.1",
+  id: "test-board",
+  locale: "en",
+  buttons: [
+    { id: "btn-1", label: "hello" },
+    { id: "btn-2", label: "world" },
+  ],
+  grid: { rows: 1, columns: 2, order: [["btn-1", "btn-2"]] },
+};
+
+async function renderBoard() {
+  return render(
+    <MemoryRouter>
+      <AppProviders>
+        <div style={{ height: "100vh" }}>
+          <BoardViewer board={obfToBoard(TWO_TILE_BOARD)} />
+        </div>
+      </AppProviders>
+    </MemoryRouter>,
+  );
+}
+
+describe("board keyboard shortcuts", () => {
+  let speech: ReturnType<typeof stubSpeech>;
+
+  beforeEach(() => {
+    speech = stubSpeech();
+    stubAudio();
+  });
+
+  test("Backspace from a focused tile removes the last message part", async () => {
+    const screen = await renderBoard();
+    await screen.getByRole("button", { name: "hello" }).click();
+    await screen.getByRole("button", { name: "world" }).click();
+
+    // The key must bubble past the grid's handler (which stops propagation by
+    // default) to the board root.
+    screen.getByRole("button", { name: "world" }).element().focus();
+    await userEvent.keyboard("{Backspace}");
+
+    speech.speak.mockClear();
+    await screen.getByRole("button", { name: "Play message" }).click();
+
+    await vi.waitFor(() => {
+      expect(speech.speak.mock.calls).toHaveLength(1);
+      expect(speech.speak.mock.calls[0][0].text).toBe("hello");
+    });
+  });
+
+  test("Backspace works board-wide — even from a non-grid button", async () => {
+    const screen = await renderBoard();
+    await screen.getByRole("button", { name: "hello" }).click();
+    await screen.getByRole("button", { name: "world" }).click();
+
+    screen.getByRole("button", { name: "Play message" }).element().focus();
+    await userEvent.keyboard("{Backspace}");
+
+    speech.speak.mockClear();
+    await screen.getByRole("button", { name: "Play message" }).click();
+
+    await vi.waitFor(() => {
+      expect(speech.speak.mock.calls[0][0].text).toBe("hello");
+    });
+  });
+
+  test("⌘+Enter speaks the message", async () => {
+    const screen = await renderBoard();
+    await screen.getByRole("button", { name: "hello" }).click();
+    await screen.getByRole("button", { name: "world" }).click();
+
+    speech.speak.mockClear();
+    screen.getByRole("button", { name: "world" }).element().focus();
+    await userEvent.keyboard("{Meta>}{Enter}{/Meta}");
+
+    await vi.waitFor(() => {
+      expect(speech.speak.mock.calls).toHaveLength(1);
+      expect(speech.speak.mock.calls[0][0].text).toBe("hello world");
+    });
+  });
+});

--- a/src/features/board/keyboard/use-board-keyboard.ts
+++ b/src/features/board/keyboard/use-board-keyboard.ts
@@ -1,0 +1,58 @@
+import type { DOMAttributes } from "react";
+import { useKeyboard } from "react-aria";
+import type { UseMessageReturn } from "../message/use-message";
+import type { UseMessagePlaybackReturn } from "../message/use-message-playback";
+import { resolveBoardKey } from "./board-key-resolver";
+
+export interface UseBoardKeyboardOptions {
+  message: Pick<UseMessageReturn, "removeLastPart" | "clear">;
+  playback: Pick<UseMessagePlaybackReturn, "play" | "stop" | "isPlaying">;
+}
+
+export interface UseBoardKeyboardReturn {
+  rootProps: DOMAttributes<HTMLElement>;
+}
+
+export function useBoardKeyboard({
+  message,
+  playback,
+}: UseBoardKeyboardOptions): UseBoardKeyboardReturn {
+  const { keyboardProps } = useKeyboard({
+    onKeyDown: (event) => {
+      const action = resolveBoardKey(
+        { key: event.key, metaKey: event.metaKey, ctrlKey: event.ctrlKey },
+        playback.isPlaying,
+      );
+
+      // react-aria stops propagation by default; let keys we don't claim bubble.
+      if (!action) {
+        event.continuePropagation();
+        return;
+      }
+
+      event.preventDefault();
+      switch (action.kind) {
+        case "backspace":
+          message.removeLastPart();
+          break;
+        case "clear":
+          message.clear();
+          break;
+        case "speak":
+          void playback.play();
+          break;
+        case "cancel":
+          playback.stop();
+          break;
+        default: {
+          const _exhaustiveCheck: never = action;
+          throw new Error(
+            `Unhandled board key action: ${JSON.stringify(_exhaustiveCheck)}`,
+          );
+        }
+      }
+    },
+  });
+
+  return { rootProps: keyboardProps };
+}


### PR DESCRIPTION
## What
Adds physical-keyboard shortcuts to the board, active while **any** board element is focused (grid tile, nav, message-bar, suggestion chip):

| Keys | Action |
|---|---|
| **Backspace** | remove last message part |
| **⌘/Ctrl + Backspace** | clear the message |
| **⌘/Ctrl + Enter** | speak (inert while already speaking) |
| **Esc** *(while speaking)* | cancel |

Enter and Space are untouched — they still activate the focused control — and every other ⌘/Ctrl combo passes through to the browser.

## How
- `resolveBoardKey()` — a pure, DOM-free mapper from keystroke → board action (`board-key-resolver.ts`), mirroring the `intent-resolver` pattern. All playback-state policy lives here.
- `useBoardKeyboard()` — a thin shell hook (react-aria `useKeyboard`) that dispatches the action and returns `rootProps` for `BoardViewer`'s root, mirroring `useGridKeyboard`.
- **Grid propagation fix:** react-aria's `useKeyboard` stops propagation for *every* key by default, so shortcuts from a focused tile never reached the board root. `useGridKeyboard` now `continuePropagation()`s the keys it doesn't consume — it stops only the arrow/Home/End moves it owns.

## Tests
- `board-key-resolver.test.ts` — pure unit coverage of every binding, incl. ⌘+Enter inert while speaking, Enter/Space left for the focused control, and ⌘/Ctrl combos passing through.
- `use-board-keyboard.test.tsx` — integration proving the key bubbles past the grid (from a focused tile) **and** works board-wide (from a non-grid button), plus ⌘+Enter speaking.

## Deliberately deferred
- **Spelling** (printable keys + Space → `appendText`/`addSpace`) — slots into the resolver as two more branches; this is where IME/AltGr handling will return.
- **Focus-on-mount** — until it lands, shortcuts are reliable once keyboard focus enters the board (Tab); note Safari/Firefox-mac don't focus buttons on click, so that follow-up matters there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)