### PR TITLE
Mr. Prose review: audio isPaused fix, vocabulary unification & prose polish

### DIFF
--- a/src/app/settings/language-settings.tsx
+++ b/src/app/settings/language-settings.tsx
@@ -31,8 +31,8 @@ export function LanguageSettings() {
           disabled={!isSupported("Translator")}
           onChange={(event) => setLanguage(event.target.value)}
         >
-          {languages.map(({ language, name }) => (
-            <MenuItem key={language} value={language}>
+          {languages.map(({ code, name }) => (
+            <MenuItem key={code} value={code}>
               {name}
             </MenuItem>
           ))}

--- a/src/features/board/board-set/info-dialog.tsx
+++ b/src/features/board/board-set/info-dialog.tsx
@@ -7,7 +7,7 @@ import DialogTitle from "@mui/material/DialogTitle";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
-import { getEnglishLocaleName } from "@shared/utils/locale";
+import { getEnglishLanguageName } from "@shared/utils/locale";
 import type { BoardSetRecord } from "../storage/db";
 
 export interface BoardSetInfoDialogProps {
@@ -28,7 +28,7 @@ function buildChipLabels(boardSet: BoardSetRecord): string[] {
   }
 
   if (boardSet.locale) {
-    labels.push(getEnglishLocaleName(boardSet.locale));
+    labels.push(getEnglishLanguageName(boardSet.locale));
   }
 
   if (boardSet.license) {

--- a/src/features/board/grid/use-grid-keyboard.ts
+++ b/src/features/board/grid/use-grid-keyboard.ts
@@ -140,7 +140,7 @@ function findFirstNonEmptyCell(grid: readonly (readonly unknown[])[]): Cell {
 
 function nextFocus(
   event: KeyboardKey,
-  grid: HTMLElement,
+  root: HTMLElement,
   from: Cell,
   dir: "ltr" | "rtl",
 ): FocusTarget | null {
@@ -150,7 +150,7 @@ function nextFocus(
     }
     const wholeGrid = event.ctrlKey || event.metaKey;
     const scope = wholeGrid ? CELL : `${CELL}[aria-rowindex='${from.row + 1}']`;
-    const candidates = grid.querySelectorAll<HTMLElement>(
+    const candidates = root.querySelectorAll<HTMLElement>(
       `${scope} ${FOCUSABLE}`,
     );
 
@@ -176,7 +176,7 @@ function nextFocus(
   }
 
   const step = arrowStep(event.key, dir);
-  return step ? nearestInDirection(grid, from, step) : null;
+  return step ? nearestInDirection(root, from, step) : null;
 }
 
 function arrowStep(key: string, dir: "ltr" | "rtl"): Step | null {
@@ -198,14 +198,14 @@ function arrowStep(key: string, dir: "ltr" | "rtl"): Step | null {
 // Among cells in the step's half-plane, prefer the most in-line tile
 // (smallest cross-axis distance), then the closest along the primary axis.
 function nearestInDirection(
-  grid: HTMLElement,
+  root: HTMLElement,
   from: Cell,
   step: Step,
 ): FocusTarget | null {
   let best: { target: FocusTarget; primary: number; cross: number } | null =
     null;
 
-  for (const cell of grid.querySelectorAll<HTMLElement>(CELL)) {
+  for (const cell of root.querySelectorAll<HTMLElement>(CELL)) {
     const position = positionOf(cell);
     const element = cell.querySelector<HTMLElement>(FOCUSABLE);
     if (!position || !element) {

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -4,7 +4,7 @@ export { BoardSetList } from "./board-set/list";
 export { BoardViewer } from "./board-viewer";
 export { importBoardFromUrl } from "./import/from-url";
 export { useImportBoardFiles } from "./import/use-import-board-files";
-export { getBoardSets, removeBoardSet } from "./storage/board-sets-store";
+export { getBoardSets, deleteBoardSet } from "./storage/board-sets-store";
 export {
   BoardNotFoundError,
   getBoardSet,

--- a/src/features/board/keyboard/board-key-resolver.test.ts
+++ b/src/features/board/keyboard/board-key-resolver.test.ts
@@ -29,12 +29,12 @@ describe("resolveBoardKey", () => {
     expect(
       resolveBoardKey(key({ key: "Enter", metaKey: true }), false),
     ).toEqual({
-      kind: "speak",
+      kind: "play",
     });
     expect(
       resolveBoardKey(key({ key: "Enter", ctrlKey: true }), false),
     ).toEqual({
-      kind: "speak",
+      kind: "play",
     });
     expect(
       resolveBoardKey(key({ key: "Enter", metaKey: true }), true),
@@ -43,7 +43,7 @@ describe("resolveBoardKey", () => {
 
   test("Escape cancels only while speaking", () => {
     expect(resolveBoardKey(key({ key: "Escape" }), true)).toEqual({
-      kind: "cancel",
+      kind: "stop",
     });
     expect(resolveBoardKey(key({ key: "Escape" }), false)).toBeNull();
   });

--- a/src/features/board/keyboard/board-key-resolver.ts
+++ b/src/features/board/keyboard/board-key-resolver.ts
@@ -1,8 +1,8 @@
 export type BoardKeyAction =
   | { kind: "backspace" }
   | { kind: "clear" }
-  | { kind: "speak" }
-  | { kind: "cancel" };
+  | { kind: "play" }
+  | { kind: "stop" };
 
 export interface KeyEventLike {
   key: string;
@@ -17,12 +17,12 @@ export interface KeyEventLike {
  */
 export function resolveBoardKey(
   event: KeyEventLike,
-  isSpeaking: boolean,
+  isPlaying: boolean,
 ): BoardKeyAction | null {
   if (event.metaKey || event.ctrlKey) {
     if (event.key === "Enter") {
-      // While speaking, ⌘+Enter is inert — don't stack a second playback.
-      return isSpeaking ? null : { kind: "speak" };
+      // While playing, ⌘+Enter is inert — don't stack a second playback.
+      return isPlaying ? null : { kind: "play" };
     }
     if (event.key === "Backspace") {
       return { kind: "clear" };
@@ -31,7 +31,7 @@ export function resolveBoardKey(
   }
 
   if (event.key === "Escape") {
-    return isSpeaking ? { kind: "cancel" } : null;
+    return isPlaying ? { kind: "stop" } : null;
   }
   if (event.key === "Backspace") {
     return { kind: "backspace" };

--- a/src/features/board/keyboard/use-board-keyboard.ts
+++ b/src/features/board/keyboard/use-board-keyboard.ts
@@ -38,10 +38,10 @@ export function useBoardKeyboard({
         case "clear":
           message.clear();
           break;
-        case "speak":
+        case "play":
           void playback.play();
           break;
-        case "cancel":
+        case "stop":
           playback.stop();
           break;
         default: {

--- a/src/features/board/message/use-message-playback.ts
+++ b/src/features/board/message/use-message-playback.ts
@@ -4,10 +4,9 @@ import { useState } from "react";
 import { getSpokenText } from "../types";
 import type { MessagePart } from "./use-message";
 
-interface PlaybackSegment {
-  type: "text" | "sound";
-  data: string;
-}
+type PlaybackSegment =
+  | { kind: "sound"; src: string }
+  | { kind: "text"; text: string };
 
 export interface UseMessagePlaybackReturn {
   isPlaying: boolean;
@@ -27,12 +26,12 @@ export function useMessagePlayback(
       const segments = convertPartsToSegments(parts);
 
       for (const segment of segments) {
-        if (segment.type === "sound") {
-          await audio.play(segment.data);
+        if (segment.kind === "sound") {
+          await audio.play(segment.src);
         }
 
-        if (segment.type === "text") {
-          await speak(segment.data);
+        if (segment.kind === "text") {
+          await speak(segment.text);
         }
       }
     } catch {
@@ -59,12 +58,12 @@ export function useMessagePlayback(
 function convertPartsToSegments(parts: MessagePart[]): PlaybackSegment[] {
   const segments = parts.flatMap((part) => {
     if (part.soundSrc) {
-      return { type: "sound" as const, data: part.soundSrc };
+      return { kind: "sound" as const, src: part.soundSrc };
     }
 
     const text = getSpokenText(part);
     if (text) {
-      return { type: "text" as const, data: text };
+      return { kind: "text" as const, text };
     }
 
     return [];
@@ -78,10 +77,10 @@ function mergeTextSegments(segments: PlaybackSegment[]): PlaybackSegment[] {
 
   for (const segment of segments) {
     const previous = result.at(-1);
-    const canMerge = previous?.type === "text" && segment.type === "text";
+    const canMerge = previous?.kind === "text" && segment.kind === "text";
 
     if (canMerge) {
-      previous.data = `${previous.data} ${segment.data}`.replace(/\s+/g, " ");
+      previous.text = `${previous.text} ${segment.text}`.replace(/\s+/g, " ");
     } else {
       result.push({ ...segment });
     }

--- a/src/features/board/storage/board-sets-store.ts
+++ b/src/features/board/storage/board-sets-store.ts
@@ -1,6 +1,6 @@
 import { createExternalStore } from "@shared/utils/external-store";
 import {
-  deleteBoardSet,
+  deleteBoardSet as deleteBoardSetRecord,
   listBoardSets,
   withBoardsDB,
   type BoardSetRecord,
@@ -79,7 +79,7 @@ export async function getBoardSets(): Promise<BoardSetRecord[]> {
   return store.getSnapshot().boardSets;
 }
 
-export async function removeBoardSet(setId: string): Promise<void> {
-  await withBoardsDB((db) => deleteBoardSet(db, setId));
+export async function deleteBoardSet(setId: string): Promise<void> {
+  await withBoardsDB((db) => deleteBoardSetRecord(db, setId));
   await notifyBoardSetsChanged();
 }

--- a/src/features/board/suggestions/suggestion-bar.tsx
+++ b/src/features/board/suggestions/suggestion-bar.tsx
@@ -30,9 +30,9 @@ export function SuggestionBar({
           overflowX: "auto",
         }}
       >
-        {suggestions.map((suggestion, index) => (
+        {suggestions.map((suggestion) => (
           <Chip
-            key={index}
+            key={suggestion}
             label={suggestion}
             onClick={() => onSuggestionClick(suggestion)}
           />

--- a/src/pages/library-page.tsx
+++ b/src/pages/library-page.tsx
@@ -5,7 +5,7 @@ import {
   BoardSetDeleteDialog,
   BoardSetInfoDialog,
   BoardSetList,
-  removeBoardSet,
+  deleteBoardSet,
   useBoardSets,
   useImportBoardFiles,
   type BoardSetRecord,
@@ -48,7 +48,7 @@ export const Component = function LibraryPage() {
     setDeleteTarget(null);
 
     try {
-      await removeBoardSet(setId);
+      await deleteBoardSet(setId);
       showSnackbar({
         message: m.libraryDeleted({ name }),
         severity: "success",

--- a/src/shared/hooks/use-audio.test.ts
+++ b/src/shared/hooks/use-audio.test.ts
@@ -1,0 +1,41 @@
+import { stubAudio } from "@shared/testing/device-output";
+import { beforeEach, describe, expect, test } from "vitest";
+import { renderHook } from "vitest-browser-react";
+import { useAudio } from "./use-audio";
+
+describe("useAudio", () => {
+  let audio: ReturnType<typeof stubAudio>;
+
+  beforeEach(() => {
+    audio = stubAudio();
+  });
+
+  test("plays a url and resolves when the clip ends", async () => {
+    const { result } = await renderHook(() => useAudio());
+
+    await expect(result.current.play("bell.mp3")).resolves.toBeUndefined();
+    expect(audio.play).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns to a fully idle state when an error interrupts a paused clip", async () => {
+    // Drive the sequence the bug needed: a pause (isPaused -> true) immediately
+    // followed by an error. The error exit must clear isPaused too, or the hook
+    // reports "paused" with nothing loaded.
+    audio.play.mockImplementation(function (this: HTMLAudioElement) {
+      queueMicrotask(() => {
+        this.dispatchEvent(new Event("play"));
+        this.dispatchEvent(new Event("pause"));
+        this.dispatchEvent(new Event("error"));
+      });
+      return Promise.resolve();
+    });
+
+    const { result, rerender } = await renderHook(() => useAudio());
+
+    await expect(result.current.play("boom.mp3")).rejects.toThrow();
+    await rerender();
+
+    expect(result.current.isPlaying).toBe(false);
+    expect(result.current.isPaused).toBe(false);
+  });
+});

--- a/src/shared/hooks/use-audio.ts
+++ b/src/shared/hooks/use-audio.ts
@@ -62,12 +62,14 @@ export function useAudio(): UseAudioReturn {
 
     audio.onerror = (error) => {
       setIsPlaying(false);
+      setIsPaused(false);
       rejectRef.current = null;
       reject(new Error(`Audio error: ${(error as Event).type}`));
     };
 
     audio.play().catch((error: unknown) => {
       setIsPlaying(false);
+      setIsPaused(false);
       rejectRef.current = null;
       reject(error instanceof Error ? error : new Error(String(error)));
     });

--- a/src/shared/language/language-context.ts
+++ b/src/shared/language/language-context.ts
@@ -3,7 +3,7 @@ import { createContext } from "react";
 export interface LanguageContextValue {
   language: string;
   setLanguage: (language: string) => void;
-  languages: { language: string; name: string }[];
+  languages: { code: string; name: string }[];
   direction: "ltr" | "rtl";
 }
 

--- a/src/shared/language/use-available-languages.ts
+++ b/src/shared/language/use-available-languages.ts
@@ -11,7 +11,7 @@ export function useAvailableLanguages() {
     .filter((code) => !UNTRANSLATABLE_LANGUAGES.has(code))
     .sort((a, b) => a.localeCompare(b))
     .map((code) => ({
-      language: code,
+      code,
       name: getNativeLanguageName(code),
     }));
 }

--- a/src/shared/speech/speech-store.ts
+++ b/src/shared/speech/speech-store.ts
@@ -137,6 +137,8 @@ export function speak(text: string): Promise<void> {
 
   utterance.onend = () => resolve();
   utterance.onerror = (event) => {
+    // Each speak() and stop() calls synthesis.cancel(), so "interrupted" is the
+    // expected end of a superseded utterance — resolve it rather than reject.
     if (event.error === "interrupted") {
       resolve();
     } else {

--- a/src/shared/utils/locale.test.ts
+++ b/src/shared/utils/locale.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
-  getEnglishLocaleName,
+  getEnglishLanguageName,
   getLanguageCode,
   getNativeLanguageName,
   getTextDirection,
@@ -59,13 +59,13 @@ describe("getTextDirection", () => {
   });
 });
 
-describe("getEnglishLocaleName", () => {
+describe("getEnglishLanguageName", () => {
   test("uses dialect form for region-qualified locales", () => {
-    expect(getEnglishLocaleName("en-US")).toBe("American English");
+    expect(getEnglishLanguageName("en-US")).toBe("American English");
   });
 
   test("returns plain language name when no region is given", () => {
-    expect(getEnglishLocaleName("es")).toBe("Spanish");
+    expect(getEnglishLanguageName("es")).toBe("Spanish");
   });
 });
 

--- a/src/shared/utils/locale.ts
+++ b/src/shared/utils/locale.ts
@@ -41,10 +41,11 @@ export function getTextDirection(locale: string): "ltr" | "rtl" {
 }
 
 /**
- * Returns the display name of a locale code in English.
+ * Returns the language name of a locale code in English
+ * (e.g. "he-IL" → "Hebrew").
  * Falls back to the original code if the locale is not recognized.
  */
-export function getEnglishLocaleName(locale: string): string {
+export function getEnglishLanguageName(locale: string): string {
   try {
     return englishLanguageNames.of(normalizeLocale(locale)) ?? locale;
   } catch {


### PR DESCRIPTION
## Mr. Prose review — applied findings

Four focused commits from a multi-agent editorial review. Every edit was fact-checked against the source for behavior preservation before landing.

## What's here

- **`fix(audio): reset isPaused on the error paths`** — the error exits reset `isPlaying` but left `isPaused` set, so an error after a pause left the hook reporting "paused" with nothing loaded. Now mirrors `onended`/`stop()`. Ships with a regression test that fails without the fix.
- **`refactor(message): realign PlaybackSegment`** — reshape the lone `type`/`data` union to the domain's `kind` + named-payload form (`{ kind: "sound"; src } | { kind: "text"; text }`), updating the four read sites. The highest-risk change — worth the closest read.
- **`refactor: unify vocabulary across seams`** — one term per concept: `removeBoardSet`→`deleteBoardSet`, keyboard `speak`/`cancel`→`play`/`stop` (+ `isSpeaking`→`isPlaying`), `languages.language`→`languages.code`, grid helper `grid`→`root`, `getEnglishLocaleName`→`getEnglishLanguageName`.
- **`refactor: tighten two local rough edges`** — chip keys by value (robustness on a wholesale-replaced list) and a why-comment on the speech `interrupted` case.

## Verification

`npm run lint` clean · `tsc -b` + `vite build` green · `npm test` **279/279** (including the new `use-audio` regression test).

## Out of scope

The catalog-wide `m.errorBoardSetNotFound()` → `m.boardSetNotFound()` rename (touches every locale under `messages/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
