### PR TITLE
chore: bump version to 1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aac-board-ai",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aac-board-ai",
-      "version": "1.6.2",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aac-board-ai",
   "private": true,
-  "version": "1.6.2",
+  "version": "1.7.0",
   "license": "MIT",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release v1.7.0 — changes since v1.6.2.

## New feature
- **Physical-keyboard shortcuts on the board** (#415)

## Fixes & UX
- Audio `isPaused` fix, vocabulary unification & prose polish (#418)
- Mobile-responsive onboarding dialog & about page, `dev:host` script (#408)
- About-page copy/layout refresh, page spacing, safe-area insets, `ExternalLink` adoption (#383–#386)

## Dependencies / plumbing
- Migrate to scoped packages `@shayc/open-board-format` and `@shayc/react-built-in-ai`; remove vendored module (#395, #396)
- Bump `@shayc/react-built-in-ai` 0.2 → 0.4, plus react-aria / react-router (#400, #401, #405, #407, #417)
- Bump `@shayc/open-board-format` through 0.1.7 (#401, #403, #404, #405)
- Large test & refactor cleanup (149 files, +2742/−4552)

Minor bump: backward-compatible feature addition (physical-keyboard shortcuts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)