### PR TITLE
chore(eslint): require blank lines before returns and after blocks

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,6 +33,14 @@ export default defineConfig([
       globals: globals.browser,
     },
     rules: {
+      "padding-line-between-statements": [
+        "error",
+        // Always require a blank line before returns
+        { blankLine: "always", prev: "*", next: "return" },
+
+        // Always require a blank line after block-like statements (if, for, switch, etc.)
+        { blankLine: "always", prev: ["block", "block-like"], next: "*" },
+      ],
       "react-x/no-array-index-key": "off",
       "no-restricted-imports": [
         "error",

--- a/src/app/layouts/page-title.tsx
+++ b/src/app/layouts/page-title.tsx
@@ -10,5 +10,6 @@ export function PageTitle({ children }: PageTitleProps) {
   if (!children) {
     return null;
   }
+
   return <title>{`${children} | ${APP_NAME}`}</title>;
 }

--- a/src/app/loaders/board-loader.ts
+++ b/src/app/loaders/board-loader.ts
@@ -15,6 +15,7 @@ export async function boardLoader({
     if (error instanceof BoardNotFoundError) {
       throw data(m.boardNotFound(), { status: 404 });
     }
+
     throw error;
   }
 }

--- a/src/app/loaders/board-set-index-loader.test.ts
+++ b/src/app/loaders/board-set-index-loader.test.ts
@@ -11,6 +11,7 @@ function callLoader(setId: string): Promise<Response> {
     request: new Request("http://localhost/"),
     params: { setId },
   } as unknown as LoaderFunctionArgs;
+
   return boardSetIndexLoader(args);
 }
 

--- a/src/app/loaders/root-index-loader.test.ts
+++ b/src/app/loaders/root-index-loader.test.ts
@@ -16,6 +16,7 @@ function callLoader(searchParams = ""): Promise<Response> {
     request: new Request(`http://localhost/${searchParams}`),
     params: {},
   } as unknown as LoaderFunctionArgs;
+
   return rootIndexLoader(args);
 }
 

--- a/src/app/loaders/root-index-loader.ts
+++ b/src/app/loaders/root-index-loader.ts
@@ -9,6 +9,7 @@ async function resolveInitialRedirectPath(
 ): Promise<string> {
   if (boardUrl) {
     const { setId, boardId } = await importBoardFromUrl(boardUrl);
+
     return boardPath({ setId, boardId });
   }
 
@@ -18,6 +19,7 @@ async function resolveInitialRedirectPath(
   }
 
   const { setId, boardId } = await importBoardFromUrl(DEFAULT_BOARD_URL);
+
   return boardPath({ setId, boardId });
 }
 
@@ -26,5 +28,6 @@ export async function rootIndexLoader({
 }: LoaderFunctionArgs): Promise<Response> {
   const boardUrl = new URL(request.url).searchParams.get("board");
   const path = await resolveInitialRedirectPath(boardUrl);
+
   return redirect(path);
 }

--- a/src/app/settings/speech-settings.tsx
+++ b/src/app/settings/speech-settings.tsx
@@ -53,6 +53,7 @@ export function SpeechSettings() {
         {voice.name}
       </MenuItem>
     ));
+
     return [header, ...items];
   }
 

--- a/src/features/board/activation/intent-resolver.ts
+++ b/src/features/board/activation/intent-resolver.ts
@@ -14,6 +14,7 @@ export function resolveButtonIntent(button: BoardButton): ButtonIntent[] {
   const targetBoardId = button.loadBoard?.id;
   if (targetBoardId) {
     intents.push({ kind: "navigate", targetBoardId });
+
     return intents;
   }
 
@@ -21,6 +22,7 @@ export function resolveButtonIntent(button: BoardButton): ButtonIntent[] {
     for (const action of button.actions) {
       intents.push({ kind: "runAction", action });
     }
+
     return intents;
   }
 

--- a/src/features/board/activation/use-button-activation.test.ts
+++ b/src/features/board/activation/use-button-activation.test.ts
@@ -111,6 +111,7 @@ describe("useButtonActivation", () => {
     const playback = createPlaybackStub();
     playback.play = vi.fn(() => {
       callOrder.push("play");
+
       return Promise.resolve();
     });
 

--- a/src/features/board/grid/grid.test.tsx
+++ b/src/features/board/grid/grid.test.tsx
@@ -30,12 +30,15 @@ async function press(
   if (modifiers.shiftKey) {
     sequence = `{Shift>}${sequence}{/Shift}`;
   }
+
   if (modifiers.metaKey) {
     sequence = `{Meta>}${sequence}{/Meta}`;
   }
+
   if (modifiers.ctrlKey) {
     sequence = `{Control>}${sequence}{/Control}`;
   }
+
   await userEvent.keyboard(sequence);
 }
 

--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -87,6 +87,7 @@ function buildGrid<T extends { id: string }>(
 
       return Array.from({ length: columns }, (_, c) => {
         const id = orderRow[c] ?? undefined;
+
         return id ? itemsById.get(id) : undefined;
       });
     });
@@ -95,6 +96,7 @@ function buildGrid<T extends { id: string }>(
   return Array.from({ length: rows }, (_, r) =>
     Array.from({ length: columns }, (_, c) => {
       const index = r * columns + c;
+
       return items[index];
     }),
   );

--- a/src/features/board/grid/use-grid-keyboard.ts
+++ b/src/features/board/grid/use-grid-keyboard.ts
@@ -60,12 +60,14 @@ export function useGridKeyboard({
       const root = rootRef.current;
       if (!root) {
         event.continuePropagation();
+
         return;
       }
 
       const from = cellOf(event.target as Element | null);
       if (!from) {
         event.continuePropagation();
+
         return;
       }
 
@@ -74,6 +76,7 @@ export function useGridKeyboard({
       // ours, so let every other key bubble up to the board-root handler.
       if (!next || sameCell(next.position, from)) {
         event.continuePropagation();
+
         return;
       }
 
@@ -97,6 +100,7 @@ export function useGridKeyboard({
     if (previousGridRef.current === grid) {
       return;
     }
+
     previousGridRef.current = grid;
 
     if (document.activeElement !== document.body) {
@@ -115,6 +119,7 @@ export function useGridKeyboard({
 
     if (sameCellElement) {
       sameCellElement.focus();
+
       return;
     }
 
@@ -135,6 +140,7 @@ function findFirstNonEmptyCell(grid: readonly (readonly unknown[])[]): Cell {
       }
     }
   }
+
   return { row: 0, col: 0 };
 }
 
@@ -148,6 +154,7 @@ function nextFocus(
     if (event.shiftKey || event.altKey) {
       return null;
     }
+
     const wholeGrid = event.ctrlKey || event.metaKey;
     const scope = wholeGrid ? CELL : `${CELL}[aria-rowindex='${from.row + 1}']`;
     const candidates = root.querySelectorAll<HTMLElement>(
@@ -168,6 +175,7 @@ function nextFocus(
     }
 
     const position = cellOf(element);
+
     return position ? { element, position } : null;
   }
 
@@ -176,6 +184,7 @@ function nextFocus(
   }
 
   const step = arrowStep(event.key, dir);
+
   return step ? nearestInDirection(root, from, step) : null;
 }
 
@@ -245,11 +254,13 @@ function positionOf(cell: Element | null): Cell | null {
   if (!cell) {
     return null;
   }
+
   const row = Number.parseInt(cell.getAttribute("aria-rowindex") ?? "", 10) - 1;
   const col = Number.parseInt(cell.getAttribute("aria-colindex") ?? "", 10) - 1;
   if (Number.isNaN(row) || Number.isNaN(col)) {
     return null;
   }
+
   return { row, col };
 }
 

--- a/src/features/board/import/board-import.ts
+++ b/src/features/board/import/board-import.ts
@@ -32,6 +32,7 @@ export async function importBoardFiles(
 ): Promise<ImportResult[]> {
   const results = await writeBoardSetFiles(files);
   await notifyBoardSetsChanged();
+
   return results;
 }
 
@@ -96,6 +97,7 @@ function resolveRootBoardId(
   if (fromManifest) {
     return fromManifest;
   }
+
   throw new Error(
     `Manifest root "${manifest.root}" does not match any board in manifest.paths.boards`,
   );

--- a/src/features/board/import/from-url.ts
+++ b/src/features/board/import/from-url.ts
@@ -16,5 +16,6 @@ export async function importBoardFromUrl(url: string): Promise<ImportResult> {
   });
 
   const [result] = await importBoardFiles(file);
+
   return result;
 }

--- a/src/features/board/keyboard/board-key-resolver.ts
+++ b/src/features/board/keyboard/board-key-resolver.ts
@@ -24,15 +24,18 @@ export function resolveBoardKey(
       // While playing, ⌘+Enter is inert — don't stack a second playback.
       return isPlaying ? null : { kind: "play" };
     }
+
     if (event.key === "Backspace") {
       return { kind: "clear" };
     }
+
     return null;
   }
 
   if (event.key === "Escape") {
     return isPlaying ? { kind: "stop" } : null;
   }
+
   if (event.key === "Backspace") {
     return { kind: "backspace" };
   }

--- a/src/features/board/keyboard/use-board-keyboard.ts
+++ b/src/features/board/keyboard/use-board-keyboard.ts
@@ -27,6 +27,7 @@ export function useBoardKeyboard({
       // react-aria stops propagation by default; let keys we don't claim bubble.
       if (!action) {
         event.continuePropagation();
+
         return;
       }
 

--- a/src/features/board/message/use-message-playback.test.ts
+++ b/src/features/board/message/use-message-playback.test.ts
@@ -60,6 +60,7 @@ describe("useMessagePlayback", () => {
         this.dispatchEvent(new Event("play"));
         this.dispatchEvent(new Event("ended"));
       });
+
       return Promise.resolve();
     });
 

--- a/src/features/board/obf/obf-to-board.ts
+++ b/src/features/board/obf/obf-to-board.ts
@@ -119,8 +119,10 @@ function transformButton(
 
 function collectActions(obfButton: OBFButton): BoardAction[] {
   const raw = [obfButton.action, ...(obfButton.actions ?? [])];
+
   return raw.flatMap((value) => {
     const action = value ? parseAction(value) : null;
+
     return action ? [action] : [];
   });
 }

--- a/src/features/board/storage/board-sets-store.ts
+++ b/src/features/board/storage/board-sets-store.ts
@@ -61,11 +61,13 @@ export async function notifyBoardSetsChanged(): Promise<void> {
 export function subscribeBoardSets(listener: () => void): () => void {
   const unsubscribe = store.subscribe(listener);
   ensureLoaded();
+
   return unsubscribe;
 }
 
 export function getBoardSetsSnapshot(): BoardSetsSnapshot {
   ensureLoaded();
+
   return store.getSnapshot();
 }
 

--- a/src/features/board/storage/db.test.ts
+++ b/src/features/board/storage/db.test.ts
@@ -43,6 +43,7 @@ afterEach(() => {
 
 async function openTestDB(): Promise<BoardsDB> {
   db = await openCleanBoardsDB();
+
   return db;
 }
 

--- a/src/features/board/storage/db.ts
+++ b/src/features/board/storage/db.ts
@@ -176,6 +176,7 @@ export async function getBoardSet(
   setId: string,
 ): Promise<BoardSetRecord | undefined> {
   validateId(setId, "setId");
+
   return db.get("boardSets", setId);
 }
 
@@ -194,6 +195,7 @@ export async function listBoardSets(db: BoardsDB): Promise<BoardSetRecord[]> {
   }
 
   await tx.done;
+
   return boardSets;
 }
 
@@ -254,6 +256,7 @@ export async function getBoard(
 ): Promise<BoardRecord | undefined> {
   validateId(setId, "setId");
   validateId(boardId, "boardId");
+
   return db.get("boards", [setId, boardId]);
 }
 

--- a/src/features/board/storage/queries.test.ts
+++ b/src/features/board/storage/queries.test.ts
@@ -19,6 +19,7 @@ async function seedTestBoard(): Promise<void> {
   if (!pngResponse.ok) {
     throw new Error(`Could not fetch ${REAL_PNG_URL} for fixture image`);
   }
+
   const pngBlob = await pngResponse.blob();
 
   const obfBoard: OBFBoard = {
@@ -53,6 +54,7 @@ async function expectThrown(promise: Promise<unknown>): Promise<unknown> {
   } catch (error) {
     return error;
   }
+
   throw new Error("Expected hydrateBoard to throw, but it resolved");
 }
 
@@ -67,6 +69,7 @@ function isObjectUrlAlive(url: string): Promise<boolean> {
       img.onerror = null;
       resolve(result);
     };
+
     img.onload = () => settle(true);
     img.onerror = () => settle(false);
     img.src = url;

--- a/src/features/board/storage/queries.ts
+++ b/src/features/board/storage/queries.ts
@@ -54,6 +54,7 @@ export async function hydrateBoard(
     const board = await withBoardsDB(async (db) => {
       const obf = await fetchOBFBoard(db, setId, boardId);
       const hydrated = await hydrateOBFBoard(db, setId, obf, registry);
+
       return obfToBoard(hydrated);
     });
 
@@ -80,6 +81,7 @@ async function fetchOBFBoard(
   if (!record) {
     throw new BoardNotFoundError(setId, boardId);
   }
+
   return record.obf;
 }
 
@@ -93,6 +95,7 @@ async function hydrateOBFBoard(
     hydrateAssets(db, setId, board.images, registry),
     hydrateAssets(db, setId, board.sounds, registry),
   ]);
+
   return { ...board, images, sounds };
 }
 
@@ -115,6 +118,7 @@ async function hydrateAssets(
       try {
         const blob = await getAssetBlob(db, setId, asset.path);
         const url = blob ? registry.create(blob) : null;
+
         return url ? { ...asset, data: url } : asset;
       } catch {
         return asset;

--- a/src/features/board/storage/test-helpers.ts
+++ b/src/features/board/storage/test-helpers.ts
@@ -18,6 +18,7 @@ async function clearAllStores(db: BoardsDB): Promise<void> {
   for (const name of STORE_NAMES) {
     await tx.objectStore(name).clear();
   }
+
   await tx.done;
 }
 
@@ -33,6 +34,7 @@ export async function resetBoardsDB(): Promise<void> {
 export async function openCleanBoardsDB(): Promise<BoardsDB> {
   const db = await openBoardsDB();
   await clearAllStores(db);
+
   return db;
 }
 
@@ -45,5 +47,6 @@ export async function seedBoardSets(records: SeedBoardSet[]): Promise<void> {
   } finally {
     db.close();
   }
+
   await invalidateBoardSets();
 }

--- a/src/features/board/suggestions/use-suggestions.ts
+++ b/src/features/board/suggestions/use-suggestions.ts
@@ -83,6 +83,7 @@ export function useSuggestions(text: string): UseSuggestionsReturn {
     };
 
     void generateSuggestions();
+
     return () => controller.abort();
   }, [text, isProofreaderReady, isRewriterReady, proofread, rewrite]);
 

--- a/src/features/board/translation/board-translation-core.ts
+++ b/src/features/board/translation/board-translation-core.ts
@@ -10,7 +10,9 @@ export function resolveSyncTranslation(
   if (getBoardLanguage(board) === language) {
     return board;
   }
+
   const cached = findTranslations(board.strings, language);
+
   return cached ? applyTranslations(board, cached) : undefined;
 }
 
@@ -29,6 +31,7 @@ export function findTranslations(
   const match = Object.entries(strings).find(
     ([locale]) => getLanguageCode(locale) === language,
   );
+
   return match?.[1];
 }
 
@@ -61,6 +64,7 @@ export function collectTranslatableStrings(board: Board): Set<string> {
     if (button.label) {
       translatableStrings.add(button.label);
     }
+
     if (button.vocalization) {
       translatableStrings.add(button.vocalization);
     }

--- a/src/features/board/translation/use-board-translation.test.tsx
+++ b/src/features/board/translation/use-board-translation.test.tsx
@@ -31,6 +31,7 @@ function makeBoard(overrides: Partial<Board> = {}): Board {
 function useTranslationHarness(options: UseBoardTranslationOptions) {
   const translation = useBoardTranslation(options);
   const { setLanguage } = useLanguage();
+
   return { translation, setLanguage };
 }
 
@@ -39,6 +40,7 @@ function setup(board: Board, language?: string) {
     // LanguageProvider seeds its state from this key on mount.
     localStorage.setItem("language", JSON.stringify(language));
   }
+
   return renderHook(() => useTranslationHarness({ setId: "set-1", board }), {
     wrapper: LanguageProvider,
   });
@@ -178,6 +180,7 @@ describe("useBoardTranslation", () => {
     for (const { input, resolve } of calls.slice(3)) {
       resolve(`de:${input}`);
     }
+
     for (const { input, resolve } of calls.slice(0, 3)) {
       resolve(`es:${input}`);
     }

--- a/src/features/board/translation/use-board-translation.ts
+++ b/src/features/board/translation/use-board-translation.ts
@@ -37,6 +37,7 @@ export function useBoardTranslation({
       const cached = resolveSyncTranslation(board, language);
       if (cached) {
         setTranslatedBoard(cached);
+
         return;
       }
 
@@ -81,6 +82,7 @@ async function translatePhrases(
   const entries = await Promise.all(
     Array.from(translatableStrings).map(async (phrase) => {
       const translated = await translator.translate(phrase, { signal });
+
       return [phrase, translated] as const;
     }),
   );

--- a/src/shared/hooks/use-audio.test.ts
+++ b/src/shared/hooks/use-audio.test.ts
@@ -27,6 +27,7 @@ describe("useAudio", () => {
         this.dispatchEvent(new Event("pause"));
         this.dispatchEvent(new Event("error"));
       });
+
       return Promise.resolve();
     });
 

--- a/src/shared/hooks/use-persistent-state.ts
+++ b/src/shared/hooks/use-persistent-state.ts
@@ -12,6 +12,7 @@ export function usePersistentState<T>(
   const [value, setValue] = useState<T>(() => {
     try {
       const stored = localStorage.getItem(key);
+
       return stored ? (JSON.parse(stored) as T) : initial;
     } catch {
       return initial;

--- a/src/shared/speech/speech-store.ts
+++ b/src/shared/speech/speech-store.ts
@@ -47,7 +47,9 @@ function loadPersistedConfig(): SpeechConfig {
     if (!raw) {
       return DEFAULT_CONFIG;
     }
+
     const parsed = JSON.parse(raw) as Partial<SpeechConfig>;
+
     return {
       voiceURI: typeof parsed.voiceURI === "string" ? parsed.voiceURI : null,
       rate: clamp(parsed.rate, SPEECH_RATE),

--- a/src/shared/testing/built-in-ai.ts
+++ b/src/shared/testing/built-in-ai.ts
@@ -44,6 +44,7 @@ function installNamespace(
   );
 
   vi.stubGlobal(name, { availability, create });
+
   return { create, availability };
 }
 
@@ -58,6 +59,7 @@ export function stubProofreader(
 ): ProofreaderStub {
   const action = vi.fn(proofread);
   const spies = installNamespace("Proofreader", () => ({ proofread: action }));
+
   return { proofread: action, ...spies };
 }
 
@@ -66,6 +68,7 @@ export function stubRewriter(
 ): RewriterStub {
   const action = vi.fn(rewrite);
   const spies = installNamespace("Rewriter", () => ({ rewrite: action }));
+
   return { rewrite: action, ...spies };
 }
 
@@ -74,6 +77,7 @@ export function stubTranslator(
 ): TranslatorStub {
   const action = vi.fn(translate);
   const spies = installNamespace("Translator", () => ({ translate: action }));
+
   return { translate: action, ...spies };
 }
 

--- a/src/shared/testing/device-output.ts
+++ b/src/shared/testing/device-output.ts
@@ -15,6 +15,7 @@ export function stubSpeech(): {
       });
     });
   const cancel = vi.spyOn(speechSynthesis, "cancel").mockReturnValue(undefined);
+
   return { speak, cancel };
 }
 
@@ -29,10 +30,12 @@ export function stubAudio(): {
         this.dispatchEvent(new Event("play"));
         this.dispatchEvent(new Event("ended"));
       });
+
       return Promise.resolve();
     });
   const pause = vi
     .spyOn(HTMLAudioElement.prototype, "pause")
     .mockReturnValue(undefined);
+
   return { play, pause };
 }

--- a/src/shared/utils/external-store.ts
+++ b/src/shared/utils/external-store.ts
@@ -16,6 +16,7 @@ export function createExternalStore<T>(initialState: T): ExternalStore<T> {
 
   function subscribe(listener: () => void) {
     listeners.add(listener);
+
     return () => {
       listeners.delete(listener);
     };

--- a/src/shared/utils/html.ts
+++ b/src/shared/utils/html.ts
@@ -1,4 +1,5 @@
 export function htmlToText(html: string): string {
   const doc = new DOMParser().parseFromString(html, "text/html");
+
   return doc.body.textContent ?? "";
 }

--- a/src/shared/utils/object-url.ts
+++ b/src/shared/utils/object-url.ts
@@ -10,6 +10,7 @@ export function createObjectUrlRegistry(): ObjectUrlRegistry {
     create(blob: Blob): string {
       const url = URL.createObjectURL(blob);
       urls.add(url);
+
       return url;
     },
 
@@ -17,6 +18,7 @@ export function createObjectUrlRegistry(): ObjectUrlRegistry {
       for (const url of urls) {
         URL.revokeObjectURL(url);
       }
+
       urls.clear();
     },
   };


### PR DESCRIPTION
## Summary

Adds two `padding-line-between-statements` ESLint rules:
- Blank line required before every `return`
- Blank line required after block-like statements (`if`, `for`, `switch`, etc.)

## Test plan
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)