### PR TITLE
chore: remove section-divider and step-narration comments

### DIFF
--- a/src/features/board/storage/db.ts
+++ b/src/features/board/storage/db.ts
@@ -2,8 +2,6 @@ import type { OBFBoard } from "@shayc/open-board-format";
 import type { DBSchema, IDBPDatabase } from "idb";
 import { openDB } from "idb";
 
-// Stored records
-
 export interface BoardSetRecord {
   setId: string;
   name: string;
@@ -34,8 +32,6 @@ export interface AssetRecord {
   size?: number;
 }
 
-// Input shapes
-
 export interface UpsertBoardSetInput {
   setId: string;
   name: string;
@@ -62,8 +58,6 @@ export interface UpsertAssetInput {
   mediaId?: string;
 }
 
-// Schema
-
 export interface BoardsDBSchema extends DBSchema {
   boardSets: {
     key: string;
@@ -87,8 +81,6 @@ export type BoardsDB = IDBPDatabase<BoardsDBSchema>;
 const DB_NAME = "aac-boards-db";
 const DB_VERSION = 1;
 
-// Helpers
-
 function normalizePath(rawPath: string): string {
   if (!rawPath) {
     throw new Error("Path cannot be empty");
@@ -107,8 +99,6 @@ function validateId(id: string, fieldName: string): void {
     throw new Error(`Invalid ${fieldName}: must be 1-255 characters`);
   }
 }
-
-// Connection
 
 export async function openBoardsDB(): Promise<BoardsDB> {
   const db = await openDB<BoardsDBSchema>(DB_NAME, DB_VERSION, {
@@ -142,8 +132,6 @@ export async function withBoardsDB<T>(
     db.close();
   }
 }
-
-// Board sets — upsert / get / list / delete
 
 export async function upsertBoardSet(
   db: BoardsDB,
@@ -217,8 +205,6 @@ export async function deleteBoardSet(
   await tx.done;
 }
 
-// Boards — put / get / updateStrings
-
 export async function putBoards(
   db: BoardsDB,
   setId: string,
@@ -284,8 +270,6 @@ export async function updateBoardStrings(
   await tx.store.put({ ...record, obf: updatedObf });
   await tx.done;
 }
-
-// Assets — put / get
 
 export async function putAssets(
   db: BoardsDB,

--- a/src/features/board/suggestions/use-suggestions.test.ts
+++ b/src/features/board/suggestions/use-suggestions.test.ts
@@ -134,18 +134,15 @@ describe("useSuggestions", () => {
       { initialProps: { text: "old" } },
     );
 
-    // First request is in flight once the proofreader has provisioned.
     await vi.waitFor(() => {
       expect(resolvers.has("old")).toBe(true);
     });
 
-    // Changing the text aborts the "old" run and starts a fresh one.
     await rerender({ text: "new" });
     await vi.waitFor(() => {
       expect(resolvers.has("new")).toBe(true);
     });
 
-    // Resolve the current request first, then let the aborted one settle.
     resolvers.get("new")?.(makeProofreadResult("corrected new"));
     resolvers.get("old")?.(makeProofreadResult("corrected old"));
 

--- a/src/features/board/translation/board-translation-core.test.ts
+++ b/src/features/board/translation/board-translation-core.test.ts
@@ -64,8 +64,8 @@ describe("board-translation-core", () => {
 
     expect(translated.name).toBe("Mi Tablero");
     expect(translated.buttons[0].label).toBe("Hola");
-    expect(translated.buttons[0].vocalization).toBe("Hello there"); // Missing translation falls back to original
-    expect(translated.buttons[1].label).toBeUndefined(); // Undefined stays undefined
+    expect(translated.buttons[0].vocalization).toBe("Hello there");
+    expect(translated.buttons[1].label).toBeUndefined();
   });
 
   test("collectTranslatableStrings() extracts all unique UI text", () => {

--- a/src/features/board/translation/use-board-translation.test.tsx
+++ b/src/features/board/translation/use-board-translation.test.tsx
@@ -136,7 +136,6 @@ describe("useBoardTranslation", () => {
 
     const { result } = await setup(board);
 
-    // Starts in English, matching the board — so it goes untranslated.
     expect(result.current.translation.translatedBoard).toBe(board);
     expect(translate).not.toHaveBeenCalled();
 

--- a/src/shared/speech/speech-store.ts
+++ b/src/shared/speech/speech-store.ts
@@ -70,8 +70,6 @@ function buildVoiceCatalog(voices: SpeechSynthesisVoice[]): VoiceCatalogState {
   };
 }
 
-// Module init
-
 const synthesis: SpeechSynthesis | undefined = globalThis.speechSynthesis;
 
 const voiceCatalogStore = createExternalStore<VoiceCatalogState>(

--- a/src/shared/speech/use-voice-language-sync.test.ts
+++ b/src/shared/speech/use-voice-language-sync.test.ts
@@ -23,7 +23,6 @@ describe("useVoiceLanguageSync", () => {
       makeVoice("en-US", "en-voice"),
       makeVoice("he-IL", "he-voice"),
     ]);
-    // Rebuild the in-memory catalog from the stubbed voices.
     speechSynthesis.dispatchEvent(new Event("voiceschanged"));
     setVoiceURI(null);
   });
@@ -51,7 +50,6 @@ describe("useVoiceLanguageSync", () => {
 
     await renderHook(() => useVoiceLanguageSync({ language: "en" }));
 
-    // Effect runs but sees a matching voice and returns early without writing.
     expect(getSpeechConfig().voiceURI).toBe("en-voice");
   });
 


### PR DESCRIPTION
Removes comments that fall outside the codebase's bar (comment only when the code is weird or intent is obscured).

## Removed
- **db.ts** — section-divider labels (`Stored records`, `Input shapes`, `Schema`, `Helpers`, `Connection`, `Board sets`, `Boards`, `Assets`); the exports already make the structure clear.
- **speech-store.ts** — `Module init` divider.
- **Tests** — step-narration that restated the line below it (suggestions choreography, voice-sync setup, translation assertions).

## Kept
Comments encoding external facts the code can't reveal — IDB key ordering, `getAll()` direction limits, react-aria pressure/propagation quirks, and AAC UX invariants.

Comment-only changes; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)