### PR TITLE
refactor(message): plan playback into steps, interpret in play()

### DIFF
--- a/src/features/board/message/message-bar.tsx
+++ b/src/features/board/message/message-bar.tsx
@@ -54,6 +54,9 @@ export function MessageBar({
     }
 
     const index = parts.findIndex((part) => part.id === activePartId);
+    if (index === -1) {
+      return;
+    }
 
     return scrollElementIntoView(
       scrollContainerRef.current?.children[index],

--- a/src/features/board/message/use-message-playback.ts
+++ b/src/features/board/message/use-message-playback.ts
@@ -2,12 +2,16 @@ import { useAudio } from "@shared/hooks/use-audio";
 import { speak, stop as stopSpeaking } from "@shared/speech/speech-store";
 import { useRef, useState } from "react";
 import { getSpokenText } from "../types";
-import { createPartTracker, type SpokenPart } from "./part-tracker";
+import {
+  createPartTracker,
+  type PartTracker,
+  type SpokenPart,
+} from "./part-tracker";
 import type { MessagePart } from "./use-message";
 
-type PlaybackSegment =
-  | { kind: "sound"; src: string; partId: string }
-  | { kind: "text"; parts: SpokenPart[] };
+type PlaybackStep =
+  | { kind: "sound"; partId: string; src: string }
+  | { kind: "speech"; tracker: PartTracker };
 
 export interface UseMessagePlaybackReturn {
   isPlaying: boolean;
@@ -24,7 +28,7 @@ export function useMessagePlayback(
   const [activePartId, setActivePartId] = useState<string | null>(null);
   // Bumped by stop() (and each play()) to invalidate an in-flight loop: a
   // superseded utterance resolves via cancel(), so without this the loop would
-  // march on to the next segment after the user stopped.
+  // march on to the next step after the user stopped.
   const playbackGenerationRef = useRef(0);
 
   async function play() {
@@ -32,30 +36,39 @@ export function useMessagePlayback(
 
     try {
       setIsPlaying(true);
-      const segments = convertPartsToSegments(parts);
 
-      for (const segment of segments) {
+      for (const step of planPlayback(parts)) {
         if (playbackGenerationRef.current !== generation) {
           return;
         }
 
-        if (segment.kind === "sound") {
-          setActivePartId(segment.partId);
-          await audio.play(segment.src);
-        }
+        switch (step.kind) {
+          case "sound":
+            setActivePartId(step.partId);
+            await audio.play(step.src);
+            break;
 
-        if (segment.kind === "text") {
-          const tracker = createPartTracker(segment.parts);
-          setActivePartId(tracker.firstId);
-          await speak(tracker.text, {
-            onBoundary: (charIndex) => {
-              // A boundary event can arrive after stop()/cancel(); ignore it so
-              // it can't re-highlight a part the user already stopped.
-              if (playbackGenerationRef.current === generation) {
-                setActivePartId(tracker.partIdAt(charIndex));
-              }
-            },
-          });
+          case "speech": {
+            const { tracker } = step;
+            setActivePartId(tracker.firstId);
+            await speak(tracker.text, {
+              onBoundary: (charIndex) => {
+                // A boundary event can arrive after stop()/cancel(); ignore it
+                // so it can't re-highlight a part the user already stopped.
+                if (playbackGenerationRef.current === generation) {
+                  setActivePartId(tracker.partIdAt(charIndex));
+                }
+              },
+            });
+            break;
+          }
+
+          default: {
+            const _exhaustiveCheck: never = step;
+            throw new Error(
+              `Unhandled playback step: ${JSON.stringify(_exhaustiveCheck)}`,
+            );
+          }
         }
       }
     } catch {
@@ -85,27 +98,35 @@ export function useMessagePlayback(
   };
 }
 
-function convertPartsToSegments(parts: MessagePart[]): PlaybackSegment[] {
-  const segments: PlaybackSegment[] = [];
+// Consecutive spoken parts merge into one utterance for prosody; building each
+// run's tracker here keeps play() a plain interpreter over the steps.
+function planPlayback(parts: MessagePart[]): PlaybackStep[] {
+  const steps: PlaybackStep[] = [];
+  let spokenRun: SpokenPart[] = [];
+
+  function flushSpeech() {
+    if (spokenRun.length === 0) {
+      return;
+    }
+
+    steps.push({ kind: "speech", tracker: createPartTracker(spokenRun) });
+    spokenRun = [];
+  }
 
   for (const part of parts) {
     if (part.soundSrc) {
-      segments.push({ kind: "sound", src: part.soundSrc, partId: part.id });
+      flushSpeech();
+      steps.push({ kind: "sound", partId: part.id, src: part.soundSrc });
       continue;
     }
 
     const text = getSpokenText(part);
-    if (!text) {
-      continue;
-    }
-
-    const previous = segments.at(-1);
-    if (previous?.kind === "text") {
-      previous.parts.push({ id: part.id, text });
-    } else {
-      segments.push({ kind: "text", parts: [{ id: part.id, text }] });
+    if (text) {
+      spokenRun.push({ id: part.id, text });
     }
   }
 
-  return segments;
+  flushSpeech();
+
+  return steps;
 }


### PR DESCRIPTION
First of two deferred-refactor passes from #424. **Behavior is unchanged** — all 16 playback + 8 part-tracker tests pass unedited; full suite 299 green. Cancellation (the `playbackGenerationRef` counter) is deliberately untouched here and split into a follow-up PR.

### What changed (3 of the items from #424)

- **Planner builds trackers; `play()` reads as a summary.** `planPlayback` now returns fully-formed `PlaybackStep[]` — a speech step carries its `PartTracker`, a sound step carries `{ partId, src }`. `play()` stops calling `createPartTracker` mid-loop and becomes a clean `switch` over steps. Pushes tracker construction below the surface (iceberg rule) and ends the double meaning of *parts* (the `MessagePart[]` parameter vs a segment's `SpokenPart[]` field).
- **Rename `convertPartsToSegments` → `planPlayback`.** A role verb for the planner half of the planner/interpreter pair; `PlaybackStep[]` names the imperative sequence `play()` executes.
- **`message-bar` scroll effect: explicit not-found guard.** `if (index === -1) return;` instead of relying on `children[-1]` being `undefined` — intent over coincidence, and immune to a future switch to `Array.prototype.at`, where `-1` would silently scroll to the last part.

### Deliberately out of scope
- **AbortSignal / retire `playbackGenerationRef`** → follow-up PR (touches the shared `speech-store` and other `speak()` callers; isolated so its only claim is "tests still green").
- **`useMessage` API consistency** → deferred per #424; no feature brings us back into that module.

### Verification
- `npm run lint` — clean
- `tsc --noEmit` — clean
- `vitest run` — 299 passed, **no test file edited** (the kill criterion for "behavior unchanged")

Refs #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)