### PR TITLE
refactor(message): cancel playback with AbortSignal, retire the generation counter

### DIFF
--- a/src/features/board/message/use-message-playback.ts
+++ b/src/features/board/message/use-message-playback.ts
@@ -1,5 +1,5 @@
 import { useAudio } from "@shared/hooks/use-audio";
-import { speak, stop as stopSpeaking } from "@shared/speech/speech-store";
+import { speak } from "@shared/speech/speech-store";
 import { useRef, useState } from "react";
 import { getSpokenText } from "../types";
 import {
@@ -26,19 +26,21 @@ export function useMessagePlayback(
   const audio = useAudio();
   const [isPlaying, setIsPlaying] = useState(false);
   const [activePartId, setActivePartId] = useState<string | null>(null);
-  // Bumped by stop() (and each play()) to invalidate an in-flight loop: a
-  // superseded utterance resolves via cancel(), so without this the loop would
-  // march on to the next step after the user stopped.
-  const playbackGenerationRef = useRef(0);
+  // The token for the current playback. stop() (and each new play()) aborts it,
+  // which silences the in-flight utterance and ends the loop below.
+  const playbackRef = useRef<AbortController | null>(null);
 
   async function play() {
-    const generation = ++playbackGenerationRef.current;
+    playbackRef.current?.abort();
+    const controller = new AbortController();
+    playbackRef.current = controller;
+    const { signal } = controller;
 
     try {
       setIsPlaying(true);
 
       for (const step of planPlayback(parts)) {
-        if (playbackGenerationRef.current !== generation) {
+        if (signal.aborted) {
           return;
         }
 
@@ -52,13 +54,9 @@ export function useMessagePlayback(
             const { tracker } = step;
             setActivePartId(tracker.firstId);
             await speak(tracker.text, {
-              onBoundary: (charIndex) => {
-                // A boundary event can arrive after stop()/cancel(); ignore it
-                // so it can't re-highlight a part the user already stopped.
-                if (playbackGenerationRef.current === generation) {
-                  setActivePartId(tracker.partIdAt(charIndex));
-                }
-              },
+              signal,
+              onBoundary: (charIndex) =>
+                setActivePartId(tracker.partIdAt(charIndex)),
             });
             break;
           }
@@ -72,10 +70,10 @@ export function useMessagePlayback(
         }
       }
     } catch {
-      // Playback failures (TTS hiccup, cancellation from stop(), etc.) reset
-      // via `finally` — the button returning to idle is the user signal.
+      // A genuine playback failure (a TTS hiccup, a missing sound) resets via
+      // `finally` — the button returning to idle is feedback enough.
     } finally {
-      if (playbackGenerationRef.current === generation) {
+      if (!signal.aborted) {
         setIsPlaying(false);
         setActivePartId(null);
       }
@@ -83,8 +81,7 @@ export function useMessagePlayback(
   }
 
   function stop() {
-    playbackGenerationRef.current++;
-    stopSpeaking();
+    playbackRef.current?.abort();
     audio.stop();
     setIsPlaying(false);
     setActivePartId(null);

--- a/src/shared/speech/speech-store.cancellation.test.ts
+++ b/src/shared/speech/speech-store.cancellation.test.ts
@@ -1,0 +1,59 @@
+import {
+  type MockInstance,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+import { speak } from "./speech-store";
+
+// A live speechSynthesis is required here, so these tests live apart from the
+// no-API suite — that one needs the module first imported while the global is
+// stubbed away, which any import in the same file would defeat.
+describe("speak() under cancellation", () => {
+  let speakSpy: MockInstance<SpeechSynthesis["speak"]>;
+  let cancelSpy: MockInstance<SpeechSynthesis["cancel"]>;
+  let spokenUtterance: SpeechSynthesisUtterance | undefined;
+
+  beforeEach(() => {
+    spokenUtterance = undefined;
+    speakSpy = vi
+      .spyOn(speechSynthesis, "speak")
+      .mockImplementation((utterance) => {
+        spokenUtterance = utterance;
+      });
+    cancelSpy = vi.spyOn(speechSynthesis, "cancel").mockReturnValue(undefined);
+  });
+
+  test("resolves without speaking when the signal is already aborted", async () => {
+    await expect(
+      speak("hello", { signal: AbortSignal.abort() }),
+    ).resolves.toBeUndefined();
+
+    expect(speakSpy).not.toHaveBeenCalled();
+  });
+
+  test("resolves and cancels the utterance when the signal aborts", async () => {
+    const controller = new AbortController();
+    const promise = speak("hello", { signal: controller.signal });
+
+    controller.abort();
+
+    await expect(promise).resolves.toBeUndefined();
+    expect(cancelSpy).toHaveBeenCalled();
+  });
+
+  test("stops reporting boundaries once the signal aborts", () => {
+    const controller = new AbortController();
+    const onBoundary = vi.fn();
+    void speak("good morning", { signal: controller.signal, onBoundary });
+
+    spokenUtterance?.onboundary?.({ charIndex: 0 } as SpeechSynthesisEvent);
+    expect(onBoundary).toHaveBeenCalledExactlyOnceWith(0);
+
+    controller.abort();
+    spokenUtterance?.onboundary?.({ charIndex: 5 } as SpeechSynthesisEvent);
+    expect(onBoundary).toHaveBeenCalledExactlyOnceWith(0);
+  });
+});

--- a/src/shared/speech/speech-store.test.ts
+++ b/src/shared/speech/speech-store.test.ts
@@ -10,9 +10,4 @@ describe("speech-store without Web Speech API", () => {
     const { speak } = await import("./speech-store");
     await expect(speak("hello")).resolves.toBeUndefined();
   });
-
-  test("stop() is a no-op instead of throwing", async () => {
-    const { stop } = await import("./speech-store");
-    expect(() => stop()).not.toThrow();
-  });
 });

--- a/src/shared/speech/speech-store.ts
+++ b/src/shared/speech/speech-store.ts
@@ -17,6 +17,7 @@ export interface SpeechConfig {
 }
 
 export interface SpeakOptions {
+  signal?: AbortSignal;
   onBoundary?: (charIndex: number) => void;
 }
 
@@ -98,9 +99,9 @@ export function setVolume(volume: number): void {
 
 export function speak(
   text: string,
-  { onBoundary }: SpeakOptions = {},
+  { signal, onBoundary }: SpeakOptions = {},
 ): Promise<void> {
-  if (!synthesis) {
+  if (!synthesis || signal?.aborted) {
     return Promise.resolve();
   }
 
@@ -116,12 +117,18 @@ export function speak(
   utterance.volume = volume;
 
   if (onBoundary) {
-    utterance.onboundary = (event) => onBoundary(event.charIndex);
+    // A boundary can arrive after the signal aborts; drop it so a stopped
+    // utterance can't keep reporting progress.
+    utterance.onboundary = (event) => {
+      if (!signal?.aborted) {
+        onBoundary(event.charIndex);
+      }
+    };
   }
 
   utterance.onend = () => resolve();
   utterance.onerror = (event) => {
-    // Each speak() and stop() calls synthesis.cancel(), so "interrupted" is the
+    // Aborting (and each new speak()) calls cancel(), so "interrupted" is the
     // expected end of a superseded utterance — resolve it rather than reject.
     if (event.error === "interrupted") {
       resolve();
@@ -130,14 +137,20 @@ export function speak(
     }
   };
 
+  // Stopping is a clean end, not a failure: cancel the utterance and resolve.
+  signal?.addEventListener(
+    "abort",
+    () => {
+      synthesis.cancel();
+      resolve();
+    },
+    { once: true },
+  );
+
   synthesis.cancel();
   synthesis.speak(utterance);
 
   return promise;
-}
-
-export function stop(): void {
-  synthesis?.cancel();
 }
 
 export function useVoicesByLanguage(): VoicesByLanguage {


### PR DESCRIPTION
The second deferred-refactor pass from #424 — the cancellation half. Follows #426. **Behavior is unchanged**: all 16 playback tests pass with **no edit**; full suite **301 green** (+3 new cancellation tests, −1 obsolete).

### What changed
- **`speak(text, { signal, onBoundary })`** ([speech-store.ts](src/shared/speech/speech-store.ts)). The signal owns post-abort quiescence: it drops a late `onBoundary` event and, on abort, cancels the utterance and **resolves**. Resolving (not rejecting) matches `speak()`'s own existing contract — it already resolves on the `"interrupted"` error that `cancel()` triggers — and keeps cancellation out of the exception channel, so the consumer's `catch` stays reserved for genuine TTS failures.
- **`play()` owns an `AbortController`; `stop()` aborts it** ([use-message-playback.ts](src/features/board/message/use-message-playback.ts)). A new `play()` aborts the previous (the supersede invariant, now explicit). The three scattered `generation === current` checks collapse onto one token: a single `if (signal.aborted) return` at the loop's only non-await boundary, and `if (!signal.aborted)` on the `finally` reset. The `speech` case now reads at the same altitude as `sound`.
- **Retired `speech-store`'s `stop()`.** With the abort handler calling `synthesis.cancel()`, the standalone global teardown was orphaned — and a second cancellation channel is the exact smell this pass removes. *(Flagging explicitly: this deletes a module-internal export with no remaining callers.)*

### Why keep the loop-top guard instead of deleting all three checks
The `sound` case sets `activePartId` then `await`s — a synchronous window with no yield where a `stop()` could land. The kept `if (signal.aborted) return` covers it. The win here is *re-grounding* the checks on one real token, not chasing a check-free loop (that would trade correctness for aesthetics).

### Tests
- New [speech-store.cancellation.test.ts](src/shared/speech/speech-store.cancellation.test.ts) pins the signal contract (resolves-on-abort, cancels, no boundary after abort). It lives apart from the no-API suite because that one needs `speech-store` first imported while `speechSynthesis` is stubbed away — vitest browser mode can't re-evaluate an already-loaded ESM module, so any shared import would defeat it.
- `lint` clean · `tsc --noEmit` clean · `vitest run` → **301 passed**, hook test file **untouched**.

Refs #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)