### PR TITLE
refactor(speech): extract buildUtterance so speak() reads as a summary

### DIFF
--- a/src/shared/speech/speech-store.ts
+++ b/src/shared/speech/speech-store.ts
@@ -97,6 +97,19 @@ export function setVolume(volume: number): void {
   updateConfig({ volume });
 }
 
+function buildUtterance(text: string): SpeechSynthesisUtterance {
+  const { voices } = voiceCatalogStore.getSnapshot();
+  const { voiceURI, rate, pitch, volume } = speechConfigStore.getSnapshot();
+
+  const utterance = new SpeechSynthesisUtterance(text);
+  utterance.voice = voices.find((voice) => voice.voiceURI === voiceURI) ?? null;
+  utterance.rate = rate;
+  utterance.pitch = pitch;
+  utterance.volume = volume;
+
+  return utterance;
+}
+
 export function speak(
   text: string,
   { signal, onBoundary }: SpeakOptions = {},
@@ -106,15 +119,7 @@ export function speak(
   }
 
   const { promise, resolve, reject } = Promise.withResolvers<void>();
-
-  const { voices } = voiceCatalogStore.getSnapshot();
-  const { voiceURI, rate, pitch, volume } = speechConfigStore.getSnapshot();
-
-  const utterance = new SpeechSynthesisUtterance(text);
-  utterance.voice = voices.find((voice) => voice.voiceURI === voiceURI) ?? null;
-  utterance.rate = rate;
-  utterance.pitch = pitch;
-  utterance.volume = volume;
+  const utterance = buildUtterance(text);
 
   if (onBoundary) {
     // A boundary can arrive after the signal aborts; drop it so a stopped


### PR DESCRIPTION
A small, focused follow-up to the playback refactors (#426, #427). **Pure structural change** — behavior and the public surface are unchanged; full suite **301 green**.

### What
`speak()` mixed two altitudes: its narrative (*make the device say this, cancellably*) and the low-level *how* of pulling config and setting four utterance properties. This pulls the latter into a `buildUtterance(text)` helper.

`speak()` now reads as a clean summary:
- guard (no API / already aborted)
- build the utterance
- wire boundary / end / abort
- dispatch (`cancel()` + `speak()`)

The voice/rate/pitch/volume mechanics sit below the surface (iceberg rule), so a reader scanning `speak()` for the cancellation logic no longer wades through device configuration.

### Why a separate PR
This is unrelated to the cancellation work in #427 — bundling an utterance-building reorg into that diff would have muddied its story. Kept apart so each change reads as one idea.

### Verification
`lint` clean · `tsc --noEmit` clean · `vitest run` → **301 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)