### PR TITLE
refactor(speech): drop redundant comment on the abort listener

### DIFF
--- a/src/shared/speech/speech-store.ts
+++ b/src/shared/speech/speech-store.ts
@@ -142,7 +142,6 @@ export function speak(
     }
   };
 
-  // Stopping is a clean end, not a failure: cancel the utterance and resolve.
   signal?.addEventListener(
     "abort",
     () => {


### PR DESCRIPTION
Follow-up to #428. Removes the one comment in the playback/speech refactors that didn't earn its place:

```ts
// Stopping is a clean end, not a failure: cancel the utterance and resolve.
signal?.addEventListener("abort", () => { synthesis.cancel(); resolve(); }, { once: true });
```

- *"cancel the utterance and resolve"* literally restated the two lines beneath it.
- *"Stopping is a clean end, not a failure"* — the why (resolve, not reject) — is already stated where it's surprising, on the `onerror` handler a few lines up: *"interrupted is the expected end of a superseded utterance — resolve it rather than reject."* The abort path is just the programmatic trigger of that same model.

Comment-only change; full suite green.