### PR TITLE
fix(speech): resolve utterances that cancel before they start

### DIFF
--- a/src/shared/speech/speech-store.cancellation.test.ts
+++ b/src/shared/speech/speech-store.cancellation.test.ts
@@ -44,6 +44,27 @@ describe("speak() under cancellation", () => {
     expect(cancelSpy).toHaveBeenCalled();
   });
 
+  test.each(["canceled", "interrupted"] as const)(
+    "resolves when a superseded utterance reports '%s'",
+    async (error) => {
+      const promise = speak("hello");
+
+      spokenUtterance?.onerror?.({ error } as SpeechSynthesisErrorEvent);
+
+      await expect(promise).resolves.toBeUndefined();
+    },
+  );
+
+  test("rejects when the utterance reports a genuine failure", async () => {
+    const promise = speak("hello");
+
+    spokenUtterance?.onerror?.({
+      error: "synthesis-failed",
+    } as SpeechSynthesisErrorEvent);
+
+    await expect(promise).rejects.toThrow("synthesis-failed");
+  });
+
   test("stops reporting boundaries once the signal aborts", () => {
     const controller = new AbortController();
     const onBoundary = vi.fn();

--- a/src/shared/speech/speech-store.ts
+++ b/src/shared/speech/speech-store.ts
@@ -133,9 +133,10 @@ export function speak(
 
   utterance.onend = () => resolve();
   utterance.onerror = (event) => {
-    // Aborting (and each new speak()) calls cancel(), so "interrupted" is the
-    // expected end of a superseded utterance — resolve it rather than reject.
-    if (event.error === "interrupted") {
+    // Aborting (and each new speak()) calls cancel(), which ends a superseded
+    // utterance as "canceled" (still queued) or "interrupted" (mid-speech) —
+    // both expected, so resolve rather than reject.
+    if (event.error === "canceled" || event.error === "interrupted") {
       resolve();
     } else {
       reject(new Error(event.error));


### PR DESCRIPTION
## What

`speak()`'s `onerror` handler only treated `"interrupted"` as an expected end for a superseded utterance. But `cancel()` — which both abort and every new `speak()` call invokes — ends the utterance as:

- `"interrupted"` if it was **mid-speech**, or
- `"canceled"` if it was **still queued** (canceled before it started).

The `"canceled"` case fell through to the `else` and **rejected**. On the fire-and-forget button path (`void speak(intent.text)`), that surfaces as an unhandled rejection — and the triggering condition is the normal AAC interaction of tapping buttons in quick succession, which cancels the first utterance while it's still queued.

This treats both codes as supersession, completing the intent the existing comment already stated.

## Tests

- `test.each(["canceled", "interrupted"])` asserting both supersession codes resolve.
- A companion test that a genuine failure (`"synthesis-failed"`) still rejects — guards the `else` so the resolve condition can't later be widened into swallowing real errors.

6/6 pass, lint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)