### PR TITLE
fix(message): make the message bar ephemeral, not persisted

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,7 +113,6 @@ Access goes through helpers in `db.ts`. `withBoardsDB(op)` opens the DB, runs th
 | Key                 | Holds                                   | Owner                                                              |
 | ------------------- | --------------------------------------- | ------------------------------------------------------------------ |
 | `language`          | Selected primary language subtag.       | [LanguageProvider](../src/shared/language/language-provider.tsx)   |
-| `message`           | Current `MessagePart[]` draft.          | [useMessage](../src/features/board/message/use-message.ts)         |
 | `speech-config`     | Selected voice + rate / pitch / volume. | [speech-store](../src/shared/speech/speech-store.ts)               |
 | `ai-shared-context` | User-supplied custom prompt for AI.     | [useAISharedContext](../src/shared/hooks/use-ai-shared-context.ts) |
 | `hasSeenOnboarding` | Boolean — has the welcome dialog shown. | [useOnboarding](../src/app/onboarding/use-onboarding.ts)           |
@@ -168,7 +167,7 @@ OBF's raw `:space` / `+<text>` notation is parsed into `BoardAction` at the OBF 
 
 Adding a new button behavior means extending `ButtonIntent` (or `BoardAction`) and handling it in `useButtonActivation`'s execution loop — the dispatch surface is closed.
 
-**Message composition.** `useMessage` owns the draft as `MessagePart[]`, persisted to localStorage so a refresh doesn't lose work in progress. The derived `text` (`parts.map(p => p.label).join(" ")`) is what `useSuggestions` consumes.
+**Message composition.** `useMessage` owns the draft as `MessagePart[]` in component state — ephemeral by design: it survives in-board navigation (same route, no remount) but resets on reload, because a half-composed utterance is current speech, not a saved document. The derived `text` (`parts.map(p => p.label).join(" ")`) is what `useSuggestions` consumes.
 
 **Playback.** Two engines, interleaved by `useMessagePlayback`:
 

--- a/src/features/board/message/use-message.test.ts
+++ b/src/features/board/message/use-message.test.ts
@@ -124,20 +124,4 @@ describe("useMessage", () => {
 
     expect(result.current.parts).toHaveLength(0);
   });
-
-  test("persists parts across unmount and remount", async () => {
-    const first = await renderHook(() => useMessage());
-
-    first.result.current.addPart({ label: "hello" });
-    await first.rerender();
-    first.result.current.addPart({ label: "world" });
-    await first.rerender();
-
-    await first.unmount();
-
-    const second = await renderHook(() => useMessage());
-
-    expect(second.result.current.parts).toHaveLength(2);
-    expect(second.result.current.text).toBe("hello world");
-  });
 });

--- a/src/features/board/message/use-message.ts
+++ b/src/features/board/message/use-message.ts
@@ -1,4 +1,4 @@
-import { usePersistentState } from "@shared/hooks/use-persistent-state";
+import { useState } from "react";
 import type { BoardButton } from "../types";
 
 export type MessagePartContent = Pick<
@@ -6,9 +6,8 @@ export type MessagePartContent = Pick<
   "label" | "vocalization" | "imageSrc" | "soundSrc"
 >;
 
-// A part's content is copied from a button, but its identity is ours, minted at
-// creation — the button's id isn't unique across occurrences (same button added
-// twice, or colliding ids across boards), so it can't serve as part identity.
+// Identity is ours, minted at creation — a button's id can't serve, since it isn't
+// unique across occurrences (same button added twice, or ids colliding across boards).
 export type MessagePart = { id: string } & MessagePartContent;
 
 export interface UseMessageReturn {
@@ -27,7 +26,7 @@ function createPart(content: MessagePartContent): MessagePart {
 }
 
 export function useMessage(): UseMessageReturn {
-  const [parts, setParts] = usePersistentState<MessagePart[]>("message", []);
+  const [parts, setParts] = useState<MessagePart[]>([]);
   const text = parts.map((part) => part.label).join(" ");
 
   function addPart(content: MessagePartContent) {


### PR DESCRIPTION
## What

The composed message bar is a scratchpad for the *current* utterance, not a document. It was persisted across reloads via `usePersistentState`, which:

- resurrected a **stale, out-of-context** sentence on launch (wrong for an AAC communication surface — it should boot ready, not pre-loaded with old words), and
- did so **half-broken**: persisted `imageSrc` values were session-scoped `blob:` object URLs, dead on the next load — so text survived but images vanished (the original bug report).

## Change

Drop persistence entirely: `useState` instead of `usePersistentState`. The message now survives in-board navigation (same route param change, no remount) and **resets on reload** — the correct AAC behavior. Also tightened the `MessagePart` identity comment.

Net: 2 files, −21/+4. No new modules, no persistence layer.

## Why not persist + fix the images

Considered durable media persistence (IndexedDB snapshots), but it solves the wrong problem: an in-progress utterance shouldn't outlive the communicative moment. Durable content, if ever wanted, belongs in an explicit "saved phrases" feature, not silent auto-restore of the buffer.

## Test

Dropped the now-obsolete "persists across unmount and remount" test; 9 session-scoped tests pass. Lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)