### PR TITLE
style(message): drop horizontal padding on message parts

### DIFF
--- a/src/features/board/message/message-bar.tsx
+++ b/src/features/board/message/message-bar.tsx
@@ -91,7 +91,6 @@ export function MessageBar({
               key={part.id}
               direction="row"
               sx={{
-                px: 1,
                 borderRadius: 4,
                 bgcolor:
                   part.id === activePartId ? "action.selected" : "transparent",


### PR DESCRIPTION
Removes the `px: 1` inline padding on each message-part `Stack` in the message bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)