### PR TITLE
chore(i18n): add playbackHighlight key to all locales

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/da.json
+++ b/messages/da.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/de.json
+++ b/messages/de.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/el.json
+++ b/messages/el.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/id.json
+++ b/messages/id.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/it.json
+++ b/messages/it.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/te.json
+++ b/messages/te.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/th.json
+++ b/messages/th.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -45,6 +45,7 @@
   "speechVolume": "Volume",
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
+  "playbackHighlight": "Highlight while playing",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",


### PR DESCRIPTION
## What

`playbackHighlight` (the playback-settings toggle label, added in #423) shipped only to `en` and `he`. The generated Paraglide output aliased the other 33 locales to the English string, so the toggle silently rendered "Highlight while playing" for every UI language except English and Hebrew.

This backfills `playbackHighlight` into the 33 missing locales as an English placeholder pending real translation, restoring key parity across all 35 message files (it was the only missing key).

## Follow-up

Worth a CI assertion that every `messages/<locale>.json` key set matches `en.json`, to catch this class of regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)