### PR TITLE
feat(board): give the tile grid an accessible name

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/da.json
+++ b/messages/da.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/de.json
+++ b/messages/de.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/el.json
+++ b/messages/el.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/he.json
+++ b/messages/he.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "טעינת לוח...",
   "boardNotFound": "הלוח לא נמצא",
+  "boardGridLabel": "לוח תקשורת",
   "libraryLoading": "טעינת לוחות...",
   "libraryEmptyTitle": "הספרייה ריקה",
   "libraryEmptyDescription": "כדי להתחיל, יש לייבא לוחות תקשורת.",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/id.json
+++ b/messages/id.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/it.json
+++ b/messages/it.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/te.json
+++ b/messages/te.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/th.json
+++ b/messages/th.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
+  "boardGridLabel": "Communication board",
   "libraryLoading": "Loading boards...",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",

--- a/src/features/board/board-viewer.test.tsx
+++ b/src/features/board/board-viewer.test.tsx
@@ -18,6 +18,18 @@ const TWO_TILE_BOARD: OBFBoard = {
   grid: { rows: 1, columns: 2, order: [["btn-1", "btn-2"]] },
 };
 
+function renderBoardViewer(obfBoard: OBFBoard) {
+  return render(
+    <MemoryRouter>
+      <AppProviders>
+        <div style={{ height: "100vh" }}>
+          <BoardViewer board={obfToBoard(obfBoard)} />
+        </div>
+      </AppProviders>
+    </MemoryRouter>,
+  );
+}
+
 describe("BoardViewer", () => {
   let speech: ReturnType<typeof stubSpeech>;
 
@@ -27,15 +39,7 @@ describe("BoardViewer", () => {
   });
 
   test("composing tiles and pressing play speaks the merged message", async () => {
-    const screen = await render(
-      <MemoryRouter>
-        <AppProviders>
-          <div style={{ height: "100vh" }}>
-            <BoardViewer board={obfToBoard(TWO_TILE_BOARD)} />
-          </div>
-        </AppProviders>
-      </MemoryRouter>,
-    );
+    const screen = await renderBoardViewer(TWO_TILE_BOARD);
 
     await screen.getByRole("button", { name: "hello" }).click();
     await screen.getByRole("button", { name: "world" }).click();
@@ -48,5 +52,23 @@ describe("BoardViewer", () => {
       expect(speech.speak.mock.calls).toHaveLength(1);
       expect(speech.speak.mock.calls[0][0].text).toBe("hello world");
     });
+  });
+
+  test("names the tile grid with the board's name", async () => {
+    const namedBoard: OBFBoard = { ...TWO_TILE_BOARD, name: "Core words" };
+
+    const screen = await renderBoardViewer(namedBoard);
+
+    await expect
+      .element(screen.getByRole("grid", { name: "Core words" }))
+      .toBeVisible();
+  });
+
+  test("falls back to a generic grid name when the board is unnamed", async () => {
+    const screen = await renderBoardViewer(TWO_TILE_BOARD);
+
+    await expect
+      .element(screen.getByRole("grid", { name: "Communication board" }))
+      .toBeVisible();
   });
 });

--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -1,5 +1,6 @@
 import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
+import { m } from "@paraglide/messages.js";
 import { useLanguage } from "@shared/language/use-language";
 import { usePlaybackConfig } from "@shared/playback/playback-store";
 import { useButtonActivation } from "./activation/use-button-activation";
@@ -102,10 +103,11 @@ export function BoardViewer({ board }: BoardViewerProps) {
 
       <Box sx={{ flexGrow: 1, height: 0, overflow: "auto" }}>
         <Grid<BoardButton>
+          ariaLabel={board.name ?? m.boardGridLabel()}
+          items={board.buttons}
           rows={board.grid.rows}
           columns={board.grid.columns}
           order={board.grid.order}
-          items={board.buttons}
           renderItem={renderTile}
           dir={direction}
         />

--- a/src/features/board/grid/grid.test.tsx
+++ b/src/features/board/grid/grid.test.tsx
@@ -853,4 +853,24 @@ describe("Grid", () => {
       await expect.element(item1).toHaveFocus();
     });
   });
+
+  describe("accessibility", () => {
+    test("exposes ariaLabel as the grid's accessible name", async () => {
+      const items = [{ id: "1", label: "Item 1" }];
+
+      const screen = await render(
+        <Grid
+          ariaLabel="Core words"
+          items={items}
+          rows={1}
+          columns={1}
+          renderItem={(item, props) => <button {...props}>{item.label}</button>}
+        />,
+      );
+
+      await expect
+        .element(screen.getByRole("grid", { name: "Core words" }))
+        .toBeVisible();
+    });
+  });
 });

--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -6,6 +6,7 @@ export interface GridItemProps {
 }
 
 export interface GridProps<TItem extends { id: string }> {
+  ariaLabel?: string;
   items: TItem[];
   rows: number;
   columns: number;
@@ -16,6 +17,7 @@ export interface GridProps<TItem extends { id: string }> {
 }
 
 export function Grid<TItem extends { id: string }>({
+  ariaLabel,
   items,
   rows,
   columns,
@@ -35,6 +37,7 @@ export function Grid<TItem extends { id: string }>({
       {...rootProps}
       ref={rootRef}
       role="grid"
+      aria-label={ariaLabel}
       aria-rowcount={rows}
       aria-colcount={columns}
       direction="column"


### PR DESCRIPTION
## What

The tile grid renders as `role="grid"` with full row/cell ARIA structure but had **no accessible name** — a screen reader announced only "grid". For an AAC tool whose primary surface is the board, that's a real wayfinding gap for screen-reader users.

## How

- New optional `ariaLabel` prop on the generic `Grid`, applied to the `role="grid"` element.
- `BoardViewer` passes `board.name ?? m.boardGridLabel()` — the board's own name when present (it's also the page title), falling back to a translated generic so even an unnamed/imported board always has a name.
- New `boardGridLabel` message key (real `en`/`he`, English placeholder for the other 33).

The fallback value is "Communication board", not "Board grid", so it doesn't announce "grid grid" alongside the role.

## Tests

- `Grid` exposes `ariaLabel` as its accessible name.
- `BoardViewer` names the grid from the board name, and falls back to the generic when the board is unnamed.
- Full suite 308/308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)