### PR TITLE
refactor(board): own board route paths in the feature, not the app layer

### DIFF
--- a/src/app/app-router.tsx
+++ b/src/app/app-router.tsx
@@ -3,6 +3,7 @@ import { boardLoader } from "@app/loaders/board-loader";
 import { boardSetIndexLoader } from "@app/loaders/board-set-index-loader";
 import { rootIndexLoader } from "@app/loaders/root-index-loader";
 import { ROUTE_PATTERNS } from "@app/route-patterns";
+import { BOARD_PATTERN, BOARD_SET_PATTERN } from "@features/board";
 import Button from "@mui/material/Button";
 import { m } from "@paraglide/messages.js";
 import { ErrorState } from "@shared/components/error-state";
@@ -44,11 +45,11 @@ const router = createBrowserRouter([
         children: [
           { index: true, loader: rootIndexLoader },
           {
-            path: ROUTE_PATTERNS.BOARD_SET,
+            path: BOARD_SET_PATTERN,
             children: [
               { index: true, loader: boardSetIndexLoader },
               {
-                path: ROUTE_PATTERNS.BOARDS,
+                path: BOARD_PATTERN,
                 loader: boardLoader,
                 lazy: async () => import("@pages/board-page"),
               },

--- a/src/app/loaders/board-set-index-loader.ts
+++ b/src/app/loaders/board-set-index-loader.ts
@@ -1,5 +1,4 @@
-import { boardPath } from "@app/route-patterns";
-import { getBoardSet } from "@features/board";
+import { boardPath, getBoardSet } from "@features/board";
 import { m } from "@paraglide/messages.js";
 import { data, redirect, type LoaderFunctionArgs } from "react-router";
 

--- a/src/app/loaders/root-index-loader.ts
+++ b/src/app/loaders/root-index-loader.ts
@@ -1,5 +1,4 @@
-import { boardPath } from "@app/route-patterns";
-import { getBoardSets, importBoardFromUrl } from "@features/board";
+import { boardPath, getBoardSets, importBoardFromUrl } from "@features/board";
 import { redirect, type LoaderFunctionArgs } from "react-router";
 
 const DEFAULT_BOARD_URL = `${import.meta.env.BASE_URL}quick-core-24.obz`;

--- a/src/app/route-patterns.ts
+++ b/src/app/route-patterns.ts
@@ -1,25 +1,7 @@
-import { generatePath } from "react-router";
-
-const BOARD_SET = "sets/:setId";
-const BOARDS = "boards/:boardId";
 const LIBRARY = "library";
 const ABOUT = "about";
 
-export const ROUTE_PATTERNS = { BOARD_SET, BOARDS, LIBRARY, ABOUT } as const;
-
-export function boardSetPath({ setId }: { setId: string }): string {
-  return generatePath(`/${BOARD_SET}`, { setId });
-}
-
-export function boardPath({
-  setId,
-  boardId,
-}: {
-  setId: string;
-  boardId: string;
-}): string {
-  return generatePath(`/${BOARD_SET}/${BOARDS}`, { setId, boardId });
-}
+export const ROUTE_PATTERNS = { LIBRARY, ABOUT } as const;
 
 export const LIBRARY_PATH = `/${LIBRARY}` as const;
 export const ABOUT_PATH = `/${ABOUT}` as const;

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -4,7 +4,12 @@ export { BoardSetList } from "./board-set/list";
 export { BoardViewer } from "./board-viewer";
 export { importBoardFromUrl } from "./import/from-url";
 export { useImportBoardFiles } from "./import/use-import-board-files";
-export { getBoardSets, deleteBoardSet } from "./storage/board-sets-store";
+export {
+  BOARD_PATTERN,
+  BOARD_SET_PATTERN,
+  boardPath,
+} from "./navigation/board-paths";
+export { deleteBoardSet, getBoardSets } from "./storage/board-sets-store";
 export {
   BoardNotFoundError,
   getBoardSet,

--- a/src/features/board/navigation/board-paths.ts
+++ b/src/features/board/navigation/board-paths.ts
@@ -1,0 +1,17 @@
+import { generatePath } from "react-router";
+
+export const BOARD_SET_PATTERN = "sets/:setId";
+export const BOARD_PATTERN = "boards/:boardId";
+
+export function boardPath({
+  setId,
+  boardId,
+}: {
+  setId: string;
+  boardId: string;
+}): string {
+  return generatePath(`/${BOARD_SET_PATTERN}/${BOARD_PATTERN}`, {
+    setId,
+    boardId,
+  });
+}

--- a/src/features/board/navigation/use-board-navigation.ts
+++ b/src/features/board/navigation/use-board-navigation.ts
@@ -1,6 +1,6 @@
-import { boardPath } from "@app/route-patterns";
 import { useLocation, useNavigate, useParams } from "react-router";
 import { useBoardSets } from "../storage/use-board-sets";
+import { boardPath } from "./board-paths";
 
 export interface BoardRouteParams {
   [key: string]: string;

--- a/src/pages/library-page.tsx
+++ b/src/pages/library-page.tsx
@@ -1,10 +1,10 @@
 import { PageContainer } from "@app/layouts/page-container";
 import { PageTitle } from "@app/layouts/page-title";
-import { boardPath } from "@app/route-patterns";
 import {
   BoardSetDeleteDialog,
   BoardSetInfoDialog,
   BoardSetList,
+  boardPath,
   deleteBoardSet,
   useBoardSets,
   useImportBoardFiles,


### PR DESCRIPTION
## What

`use-board-navigation.ts` imported `boardPath` from `@app/route-patterns` — the only `@features → @app` import in production code, violating the documented layer rule (architecture.md §2: "@features must not import from @app").

## How

- Move the board URL shape — route segments + `boardPath` — into the feature as `navigation/board-paths.ts`, re-exported via the `@features/board` barrel (§2 already intends path helpers to live on the barrel).
- `app-router` composes the feature's route segments (`app → feature`, allowed).
- `route-patterns.ts` keeps only the app-level `library`/`about` routes.
- Drops the unused dead `boardSetPath`.

Net: the board feature declares what its URLs look like; the app shell composes them. `@features` imports zero `@app` in production code. Full suite 305/305.

## Follow-up (not in this PR)

Lint-enforce the layer boundaries (`import/no-restricted-paths` or `eslint-plugin-boundaries`) so `@features → @app` can't silently regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)