### PR TITLE
fix(board): keep the board-set list on a transient reload failure

### DIFF
--- a/src/features/board/storage/board-sets-store.ts
+++ b/src/features/board/storage/board-sets-store.ts
@@ -32,8 +32,9 @@ async function loadBoardSets(): Promise<void> {
     store.setState({ boardSets, isLoading: false, error: null });
     hasLoaded = true;
   } catch (error) {
+    const { boardSets } = store.getSnapshot();
     store.setState({
-      boardSets: [],
+      boardSets,
       isLoading: false,
       error: error instanceof Error ? error : new Error(String(error)),
     });


### PR DESCRIPTION
## What

`loadBoardSets()` re-runs on every import, delete, and cross-tab `BroadcastChannel` message. Its `catch` blanked `boardSets` to `[]` on **any** error, so a transient DB hiccup (the DB briefly locked while another tab writes/upgrades) made `library-page` render the **"import your first board" empty state over data that is fully intact in IndexedDB** — risking a confused re-import and duplicates.

## Fix

Preserve the last-known-good list on a reload failure (stale-while-revalidate): data is only ever replaced on a *successful* load. A genuine cold failure (never loaded) still shows `[]`, since that's the store's initial state — so the real empty state is unaffected.

## Note on testing

No dedicated test: exercising the failure branch means injecting a DB error, which would require stubbing `withBoardsDB`/IndexedDB — both off-limits under the repo's "no mocking internals / native web APIs" rule. The change is covered by the full suite for no-regression (308/308) + typecheck.

## Follow-up (separate)

`useBoardSets()` already returns `error`, but `library-page` ignores it — so a *persistent* failure is still silent. Surfacing it (snackbar/inline alert) would complete the error story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)