### PR TITLE
chore(lint): enforce layer boundaries, make board db internal

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,9 +18,9 @@ The codebase is **feature-sliced**. The single feature today is `board`. Layers 
 - `@shared/*` — cross-cutting code (Built-in AI hooks, speech, language, snackbar, theme, utilities). No knowledge of features.
 - `@paraglide/*` — generated UI translations (build artifact, never edited by hand).
 
-Aliases are declared in [tsconfig.app.json](../tsconfig.app.json) and mirrored in [vite.config.ts](../vite.config.ts).
+Aliases are declared in [tsconfig.app.json](../tsconfig.app.json) and mirrored in [vite.config.ts](../vite.config.ts). These import rules are enforced by `no-restricted-imports` in [eslint.config.js](../eslint.config.js), not left to convention.
 
-**Public-barrel rule.** UI layers consume the board feature through [`@features/board`](../src/features/board/index.ts). Reaching into `storage/`, `obf/`, or other internals from outside the feature is disallowed by convention; board-set dialogs, path helpers, and storage queries are all re-exported from the barrel so consumers never need a deeper import.
+**Public-barrel rule.** UI layers consume the board feature through [`@features/board`](../src/features/board/index.ts); board-set dialogs, path helpers, and storage queries are all re-exported from the barrel so consumers never need a deeper import. Tests that need to seed or reset feature state use the sanctioned [`@features/board/testing`](../src/features/board/testing.ts) entry — the only other path `@app`/`@pages` may reach. Everything deeper (`storage/`, `obf/`, …) is internal.
 
 **Tests.** Co-located as `*.test.ts` / `*.test.tsx` next to the file under test.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,18 @@ import { defineConfig, globalIgnores } from "eslint/config";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 
+const muiSubpaths = {
+  regex: "^@mui/(?!stylis-plugin-rtl)[^/]+$",
+  message: "Import from subpaths, e.g. @mui/material/Button",
+};
+
+// no-restricted-imports replaces (not merges) across overrides, so every block
+// builds its patterns here — keeping muiSubpaths in one place it can't be dropped.
+const restrictImports = (...patterns) => [
+  "error",
+  { patterns: [muiSubpaths, ...patterns] },
+];
+
 export default defineConfig([
   globalIgnores(["dist", "coverage", "src/paraglide"]),
   {
@@ -42,17 +54,7 @@ export default defineConfig([
         { blankLine: "always", prev: ["block", "block-like"], next: "*" },
       ],
       "react-x/no-array-index-key": "off",
-      "no-restricted-imports": [
-        "error",
-        {
-          patterns: [
-            {
-              regex: "^@mui/(?!stylis-plugin-rtl)[^/]+$",
-              message: "Import from subpaths, e.g. @mui/material/Button",
-            },
-          ],
-        },
-      ],
+      "no-restricted-imports": restrictImports(),
       curly: ["error"],
     },
   },
@@ -60,6 +62,57 @@ export default defineConfig([
     files: ["src/app/loaders/**/*-loader.ts"],
     rules: {
       "@typescript-eslint/only-throw-error": "off",
+    },
+  },
+
+  // Layer boundaries (architecture.md §2).
+  {
+    files: ["src/features/**/*.{ts,tsx}"],
+    ignores: ["src/features/**/*.test.{ts,tsx}"],
+    rules: {
+      "no-restricted-imports": restrictImports({
+        group: ["@app", "@app/*", "@features", "@features/*"],
+        message:
+          "A feature must not import @app or another feature — use @shared or relative paths within the feature.",
+      }),
+    },
+  },
+  {
+    // Feature tests may compose the real app shell, but still never another feature.
+    files: ["src/features/**/*.test.{ts,tsx}"],
+    rules: {
+      "no-restricted-imports": restrictImports({
+        group: ["@features", "@features/*"],
+        message: "Even in tests, a feature must not import another feature.",
+      }),
+    },
+  },
+  {
+    files: ["src/shared/**/*.{ts,tsx}"],
+    rules: {
+      "no-restricted-imports": restrictImports({
+        group: [
+          "@app",
+          "@app/*",
+          "@features",
+          "@features/*",
+          "@pages",
+          "@pages/*",
+        ],
+        message: "@shared is a leaf layer — no @app, @features, or @pages.",
+      }),
+    },
+  },
+  {
+    // @app / @pages consume a feature through its barrel (@features/board) or its
+    // sanctioned test entry (@features/board/testing) — never deeper internals.
+    files: ["src/app/**/*.{ts,tsx}", "src/pages/**/*.{ts,tsx}"],
+    rules: {
+      "no-restricted-imports": restrictImports({
+        regex: "^@features/[^/]+/(?!testing$).+",
+        message:
+          "Consume features through their barrel (@features/board) or test entry (@features/board/testing), not internal paths.",
+      }),
     },
   },
 ]);

--- a/src/app/loaders/board-set-index-loader.test.ts
+++ b/src/app/loaders/board-set-index-loader.test.ts
@@ -1,7 +1,4 @@
-import {
-  resetBoardsDB,
-  seedBoardSets,
-} from "@features/board/storage/test-helpers";
+import { resetBoardsDB, seedBoardSets } from "@features/board/testing";
 import type { LoaderFunctionArgs } from "react-router";
 import { beforeEach, describe, expect, test } from "vitest";
 import { boardSetIndexLoader } from "./board-set-index-loader";

--- a/src/app/loaders/root-index-loader.test.ts
+++ b/src/app/loaders/root-index-loader.test.ts
@@ -1,11 +1,7 @@
 import { beforeEach, describe, expect, test } from "vitest";
 import type { LoaderFunctionArgs } from "react-router";
-import { invalidateBoardSets } from "@features/board/storage/board-sets-store";
-import { listBoardSets, withBoardsDB } from "@features/board/storage/db";
-import {
-  resetBoardsDB,
-  seedBoardSets,
-} from "@features/board/storage/test-helpers";
+import { getBoardSets } from "@features/board";
+import { resetBoardsDB, seedBoardSets } from "@features/board/testing";
 import { rootIndexLoader } from "./root-index-loader";
 
 const FIXTURE_BOARD_URL = "/src/shared/testing/sample-boards/lots-of-stuff.obz";
@@ -23,10 +19,6 @@ function callLoader(searchParams = ""): Promise<Response> {
 describe("rootIndexLoader", () => {
   beforeEach(async () => {
     await resetBoardsDB();
-    // resetBoardsDB clears IDB but the board-sets-store keeps its cached
-    // snapshot from prior tests — explicitly invalidate so getBoardSets()
-    // reads fresh from the now-empty DB.
-    await invalidateBoardSets();
   });
 
   test("imports the URL from ?board and redirects to its board route", async () => {
@@ -38,12 +30,12 @@ describe("rootIndexLoader", () => {
     const location = response.headers.get("Location");
     expect(location).toMatch(/^\/sets\/[^/]+\/boards\/[^/]+$/);
 
-    const sets = await withBoardsDB((db) => listBoardSets(db));
+    const sets = await getBoardSets();
     expect(sets).toHaveLength(1);
   });
 
   test("redirects to the root board of the most recently updated set when no param is given", async () => {
-    // seedBoardSets inserts sequentially; listBoardSets orders by updatedAt
+    // seedBoardSets inserts sequentially; sets come back ordered by updatedAt
     // descending, so set-2 (inserted last) ends up first.
     await seedBoardSets([
       { setId: "set-1", rootBoardId: "root-1" },
@@ -69,7 +61,7 @@ describe("rootIndexLoader", () => {
       /^\/sets\/[^/]+\/boards\/[^/]+$/,
     );
 
-    const sets = await withBoardsDB((db) => listBoardSets(db));
+    const sets = await getBoardSets();
     expect(sets).toHaveLength(1);
   });
 });

--- a/src/features/board/storage/test-helpers.ts
+++ b/src/features/board/storage/test-helpers.ts
@@ -29,6 +29,8 @@ export async function resetBoardsDB(): Promise<void> {
   } finally {
     db.close();
   }
+
+  await invalidateBoardSets();
 }
 
 export async function openCleanBoardsDB(): Promise<BoardsDB> {

--- a/src/features/board/testing.ts
+++ b/src/features/board/testing.ts
@@ -1,0 +1,6 @@
+export {
+  openCleanBoardsDB,
+  resetBoardsDB,
+  seedBoardSets,
+  type SeedBoardSet,
+} from "./storage/test-helpers";


### PR DESCRIPTION
## Why

The layer rules in `architecture.md` §2 were **convention-only**. A feature could import `@app`, `@shared` could reach into a feature, and `@app`/`@pages` could bypass the board barrel — none of it caught by lint. #436 fixed one feature→app slip by hand; nothing stopped the next.

## What

Enforce the contract with `no-restricted-imports`, one block per layer:

- a **feature** may not import `@app` or another feature (its *tests* may compose the real app shell — they render via `AppProviders` — but still never another feature);
- **`@shared`** stays a leaf (no `@app` / `@features` / `@pages`);
- **`@app` / `@pages`** consume a feature only through its barrel (`@features/board`) or its sanctioned test entry (`@features/board/testing`) — nothing deeper.

Each rule was verified to actually fire (probed with throwaway violating imports), and the barrel + `testing` entry confirmed allowed.

## The `db` question

That last rule was only *honest* once the board `db` stopped leaking. The app loader tests reached into `@features/board/storage/db` to assert state — because `resetBoardsDB()` cleared IndexedDB but left the `board-sets-store` cache stale, and the empty-DB tests had no seed to refresh it. Rather than carve `db` out of the rule, the fix removes the need:

- complete `resetBoardsDB()` to invalidate the cache (as `seedBoardSets()` already does), so
- the tests assert through the **public `getBoardSets()`** instead, and
- `db`'s value exports (`withBoardsDB`, `listBoardSets`) are now imported **nowhere outside the feature** — genuinely internal.

The test-support API is re-exported from a deliberate `@features/board/testing` entry instead of a deep `storage/` path, so the only cross-layer test dependency is intentional and shallow.

## Verification

Lint **0 warnings** · `tsc` clean · **312 tests pass**. No production code changed — only the lint config, two loader tests, one test helper, the new `testing` barrel, and the §2 docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)