### PR TITLE
fix(speech): pick default voice by region, not arbitrary order

### DIFF
--- a/src/shared/speech/use-voice-language-sync.test.ts
+++ b/src/shared/speech/use-voice-language-sync.test.ts
@@ -1,7 +1,14 @@
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { renderHook } from "vitest-browser-react";
 import { getSpeechConfig, setVoiceURI } from "./speech-store";
 import { useVoiceLanguageSync } from "./use-voice-language-sync";
+
+function stubLanguages(languages: readonly string[]): void {
+  Object.defineProperty(navigator, "languages", {
+    configurable: true,
+    get: () => languages,
+  });
+}
 
 function makeVoice(
   lang: string,
@@ -25,6 +32,11 @@ describe("useVoiceLanguageSync", () => {
     ]);
     speechSynthesis.dispatchEvent(new Event("voiceschanged"));
     setVoiceURI(null);
+  });
+
+  afterEach(() => {
+    // Drop the instance override so the real navigator.languages getter returns.
+    Reflect.deleteProperty(navigator, "languages");
   });
 
   test("selects a voice in the new language when language changes", async () => {
@@ -64,6 +76,66 @@ describe("useVoiceLanguageSync", () => {
 
     await vi.waitFor(() => {
       expect(getSpeechConfig().voiceURI).toBe("en-default");
+    });
+  });
+
+  test("prefers the language's canonical region over the browser default flag", async () => {
+    stubLanguages(["en-US"]);
+    vi.spyOn(speechSynthesis, "getVoices").mockReturnValue([
+      makeVoice("fr-CA", "fr-ca-default", true),
+      makeVoice("fr-FR", "fr-fr-voice"),
+    ]);
+    speechSynthesis.dispatchEvent(new Event("voiceschanged"));
+
+    await renderHook(() => useVoiceLanguageSync({ language: "fr" }));
+
+    await vi.waitFor(() => {
+      expect(getSpeechConfig().voiceURI).toBe("fr-fr-voice");
+    });
+  });
+
+  test("prefers the user's OS region over the language's home region", async () => {
+    stubLanguages(["fr-CA"]);
+    vi.spyOn(speechSynthesis, "getVoices").mockReturnValue([
+      makeVoice("fr-FR", "fr-fr-voice"),
+      makeVoice("fr-CA", "fr-ca-voice"),
+    ]);
+    speechSynthesis.dispatchEvent(new Event("voiceschanged"));
+
+    await renderHook(() => useVoiceLanguageSync({ language: "fr" }));
+
+    await vi.waitFor(() => {
+      expect(getSpeechConfig().voiceURI).toBe("fr-ca-voice");
+    });
+  });
+
+  test("skips a region-less preferred locale and uses the next one for the language", async () => {
+    stubLanguages(["fr", "fr-CA"]);
+    vi.spyOn(speechSynthesis, "getVoices").mockReturnValue([
+      makeVoice("fr-FR", "fr-fr-voice"),
+      makeVoice("fr-CA", "fr-ca-voice"),
+    ]);
+    speechSynthesis.dispatchEvent(new Event("voiceschanged"));
+
+    await renderHook(() => useVoiceLanguageSync({ language: "fr" }));
+
+    await vi.waitFor(() => {
+      expect(getSpeechConfig().voiceURI).toBe("fr-ca-voice");
+    });
+  });
+
+  test("falls back to the default voice when no voice matches the canonical region", async () => {
+    stubLanguages(["en-US"]);
+    vi.spyOn(speechSynthesis, "getVoices").mockReturnValue([
+      makeVoice("fr-CA", "fr-ca-voice"),
+      makeVoice("fr-BE", "fr-be-default", true),
+    ]);
+    speechSynthesis.dispatchEvent(new Event("voiceschanged"));
+
+    await renderHook(() => useVoiceLanguageSync({ language: "fr" }));
+
+    await vi.waitFor(() => {
+      expect(getSpeechConfig().voiceURI).toBe("fr-be-default");
     });
   });
 });

--- a/src/shared/speech/use-voice-language-sync.ts
+++ b/src/shared/speech/use-voice-language-sync.ts
@@ -1,3 +1,8 @@
+import {
+  getLanguageCode,
+  getPreferredRegion,
+  getRegionCode,
+} from "@shared/utils/locale";
 import { useEffect } from "react";
 import {
   getSpeechConfig,
@@ -7,6 +12,24 @@ import {
 
 export interface UseVoiceLanguageSyncOptions {
   language: string;
+}
+
+/**
+ * The user's own region for a language, drawn from OS/browser preferences
+ * (e.g. a Canadian's "fr-CA" → "CA"). Undefined when none of the preferred
+ * locales name a region for this language.
+ */
+function getUserRegionForLanguage(language: string): string | undefined {
+  for (const tag of navigator.languages) {
+    if (getLanguageCode(tag) === language) {
+      const region = getRegionCode(tag);
+      if (region) {
+        return region;
+      }
+    }
+  }
+
+  return undefined;
 }
 
 export function useVoiceLanguageSync({
@@ -28,7 +51,15 @@ export function useVoiceLanguageSync({
       return;
     }
 
-    const fallbackVoice = voices.find((voice) => voice.default) ?? voices[0];
+    const preferredRegion =
+      getUserRegionForLanguage(language) ?? getPreferredRegion(language);
+    const regionVoices = voices.filter(
+      (voice) => getRegionCode(voice.lang) === preferredRegion,
+    );
+    const candidates = regionVoices.length > 0 ? regionVoices : voices;
+
+    const fallbackVoice =
+      candidates.find((voice) => voice.default) ?? candidates[0];
     if (fallbackVoice) {
       setVoiceURI(fallbackVoice.voiceURI);
     }

--- a/src/shared/utils/locale.ts
+++ b/src/shared/utils/locale.ts
@@ -28,6 +28,30 @@ export function getLanguageCode(locale: string): string {
 }
 
 /**
+ * Returns the uppercase region subtag of a locale code, or undefined when
+ * none is present (e.g. "fr-CA" → "CA", "fr" → undefined).
+ */
+export function getRegionCode(locale: string): string | undefined {
+  try {
+    return parseLocale(locale).region;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Returns the region most associated with a language via CLDR likely-subtags
+ * (e.g. "fr" → "FR", "en" → "US"). Undefined for unrecognized input.
+ */
+export function getPreferredRegion(language: string): string | undefined {
+  try {
+    return parseLocale(language).maximize().region;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Returns the writing direction for a BCP-47 locale code.
  * Falls back to "ltr" for structurally invalid input; unknown
  * but well-formed codes default to "ltr" via Intl.


### PR DESCRIPTION
## Problem

The default-voice picker in `useVoiceLanguageSync` grouped voices by **bare language code** (`fr-CA`, `fr-FR`, `fr-BE` all collapse into `"fr"`), then selected `voices.find(v => v.default) ?? voices[0]`. Region was lost before selection, so picking "French" yielded an arbitrary `fr-CA` vs `fr-FR` voice depending on the browser's default flag or array order.

## Fix

Choose the voice region deliberately:

1. **User's OS region for that language** — first region in `navigator.languages` whose language matches (a Canadian's `fr-CA` → `CA`).
2. **Language's home region** as fallback — via CLDR likely-subtags (`Intl.Locale.maximize()`): `fr` → `FR`, `en` → `US`, no hardcoded table.

Voices are filtered to that region first; the browser `default` flag only breaks ties *within* the chosen region. Falls back to the full voice list when no voice matches.

Two new locale helpers (`getRegionCode`, `getPreferredRegion`) added alongside the existing `Intl`-based utilities.

## Behavior

| User OS locale | French | English |
|---|---|---|
| `fr-CA` | fr-CA | en (home → US) |
| `en-GB` | fr-FR (home) | en-GB |
| `en-US` | fr-FR (home) | en-US |

## Notes

- Only governs the **auto-default**; a manually chosen voice is still respected (existing early-return).
- Not yet in production, so no persisted voices need migrating — applies to all first-time picks.

## Tests

7 passing, covering: language switch, keep-current, default-within-region, canonical-over-default, OS-region-over-home, region-less-locale skip, and no-match fallback. `navigator.languages` is stubbed per-test for determinism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)