### PR TITLE
fix(tile): gate hover background to real pointers

### DIFF
--- a/src/features/board/tile/tile.tsx
+++ b/src/features/board/tile/tile.tsx
@@ -35,12 +35,12 @@ export function Tile({
         display: "grid",
         alignItems: "stretch",
         justifyContent: "stretch",
-        textTransform: "none",
         padding: "4px 4px 0 4px",
-        position: "relative",
         border: `2px solid ${borderColor ?? backgroundColor ?? "transparent"}`,
         borderRadius: 4,
         overflow: "hidden",
+        position: "relative",
+        textTransform: "none",
         color: backgroundColor
           ? getReadableTextColor(backgroundColor)
           : "inherit",

--- a/src/features/board/tile/tile.tsx
+++ b/src/features/board/tile/tile.tsx
@@ -48,10 +48,12 @@ export function Tile({
         transition: theme.transitions.create("background-color", {
           duration: theme.transitions.duration.short,
         }),
-        "&:hover": {
-          backgroundColor: backgroundColor
-            ? `color-mix(in srgb, ${backgroundColor}, black 20%)`
-            : undefined,
+        "@media (hover: hover)": {
+          "&:hover": {
+            backgroundColor: backgroundColor
+              ? `color-mix(in srgb, ${backgroundColor}, black 20%)`
+              : undefined,
+          },
         },
         "&:active": {
           backgroundColor: backgroundColor


### PR DESCRIPTION
## Problem

On iOS, tapping a tile left its darkened hover background **stuck** until you tapped elsewhere. WebKit applies `:hover` on tap and keeps it applied — and the tile defines a custom `:hover` background that made the stick visible. Default MUI buttons don't show this because they gate hover behind a pointer media query.

## Fix

Wrap the tile's `:hover` rule in `@media (hover: hover)` so it only applies on hover-capable pointers (mouse/trackpad). On touch the rule is never emitted, so there's nothing to stick. Tap feedback is unaffected — it still comes from `:active`.

This mirrors MUI's own Button implementation, which gates contained/text/outlined hover backgrounds behind `@media (hover: hover)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)