### PR TITLE
fix(message): mint part ids without crypto.randomUUID in non-secure contexts

### DIFF
--- a/src/features/board/message/use-message.ts
+++ b/src/features/board/message/use-message.ts
@@ -1,3 +1,4 @@
+import { randomId } from "@shared/utils/random-id";
 import { useState } from "react";
 import type { BoardButton } from "../types";
 
@@ -22,7 +23,7 @@ export interface UseMessageReturn {
 }
 
 function createPart(content: MessagePartContent): MessagePart {
-  return { ...content, id: crypto.randomUUID() };
+  return { ...content, id: randomId() };
 }
 
 export function useMessage(): UseMessageReturn {

--- a/src/shared/utils/random-id.ts
+++ b/src/shared/utils/random-id.ts
@@ -1,0 +1,11 @@
+export function randomId(): string {
+  if (typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  );
+}


### PR DESCRIPTION
## Problem

Clicking a regular (non-link) tile crashed with `TypeError: crypto.randomUUID is not a function` when the app was served over plain HTTP on a LAN IP (e.g. `http://192.168.50.100:5173`). `crypto.randomUUID` only exists in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS or `localhost`), so it's `undefined` on a LAN IP — and minting a message part hit it directly.

Board-link tiles were unaffected because they don't add a message part.

## Fix

Add `randomId()` ([random-id.ts](src/shared/utils/random-id.ts)) which uses `crypto.randomUUID()` when available and falls back to `crypto.getRandomValues` (available in any context) otherwise. `useMessage` now mints part ids via `randomId()`.

The ids are ephemeral message-part keys — never persisted or compared across devices — so the fallback's 32-char hex shape (vs. a dashed UUID) is fine.

## Test

- Lint + typecheck pass.
- Reproduce by opening a board over a LAN IP and clicking a regular tile (was a crash, now mints a part).

🤖 Generated with [Claude Code](https://claude.com/claude-code)