### PR TITLE
fix(grid): keep trailing padding visible when rows overflow

### DIFF
--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -1,6 +1,9 @@
 import Stack from "@mui/material/Stack";
 import { useGridKeyboard } from "./use-grid-keyboard";
 
+const MIN_TILE_PX = 80;
+const PADDING = 2;
+
 export interface GridItemProps {
   tabIndex: number;
 }
@@ -42,7 +45,12 @@ export function Grid<TItem extends { id: string }>({
       aria-colcount={columns}
       direction="column"
       dir={dir}
-      sx={{ minHeight: "100%", p: 2, gap }}
+      sx={(theme) => ({
+        minHeight: "100%",
+        minWidth: `calc(${columns} * ${MIN_TILE_PX}px + ${columns - 1} * ${theme.spacing(gap)} + ${theme.spacing(PADDING * 2)})`,
+        p: PADDING,
+        gap,
+      })}
     >
       {grid.map((row, rowIndex) => (
         <Stack
@@ -61,7 +69,7 @@ export function Grid<TItem extends { id: string }>({
                 role="gridcell"
                 aria-rowindex={rowIndex + 1}
                 aria-colindex={colIndex + 1}
-                sx={{ flex: 1, minWidth: 80, minHeight: 80 }}
+                sx={{ flex: 1, minWidth: MIN_TILE_PX, minHeight: MIN_TILE_PX }}
               >
                 {item &&
                   renderItem(item, {


### PR DESCRIPTION
## Problem

When the viewport is narrower than the board's tiles, the grid scrolls horizontally — but the trailing (right/end) padding was missing. The leading padding showed normally; scrolling to the end left the last column flush against the screen edge.

The grid root's width was pinned to the scroll container's visible width, so its padding-box ended at the viewport edge while the overflowing rows scrolled past it.

## Fix

Floor the grid root's `minWidth` to the grid's **structure** — `columns × tile + gaps + padding` — so the padding-box grows to wrap the content when it overflows, keeping the trailing padding inside the scroll width.

Deriving the width from content (`width: max-content`) instead would balloon every column to the widest `noWrap` tile label and force horizontal scroll even on wide screens, so the floor is computed from layout constants (`MIN_TILE_PX`, `PADDING`, `gap`) shared with the cells to avoid drift.

## Behavior

- Wide screen: floor < viewport → grid fills, tiles flex-grow evenly. Unchanged.
- Narrow screen: viewport < floor → grid grows to contain tiles + gaps + **both** paddings → trailing padding visible at the scroll end.
- Label length never affects width (labels ellipsis within their floored tile).

## Test

- `grid.test.tsx` — 30/30 pass
- Worth a real-browser glance at a couple column counts and in RTL, since it's layout math.

🤖 Generated with [Claude Code](https://claude.com/claude-code)