### PR TITLE
fix(message): reconcile #357 gaps — no-boundary fallback + non-color highlight

### DIFF
--- a/src/features/board/message/message-bar.tsx
+++ b/src/features/board/message/message-bar.tsx
@@ -86,19 +86,25 @@ export function MessageBar({
           direction="row"
           sx={{ flexGrow: 1, padding: 2, gap: 1, overflow: "auto" }}
         >
-          {parts.map((part) => (
-            <Stack
-              key={part.id}
-              direction="row"
-              sx={{
-                borderRadius: 4,
-                bgcolor:
-                  part.id === activePartId ? "action.selected" : "transparent",
-              }}
-            >
-              <Pictogram label={part.label} src={part.imageSrc} />
-            </Stack>
-          ))}
+          {parts.map((part) => {
+            const isActive = part.id === activePartId;
+
+            return (
+              <Stack
+                key={part.id}
+                direction="row"
+                sx={(theme) => ({
+                  borderRadius: 4,
+                  outlineOffset: 2,
+                  outline: isActive
+                    ? `2px solid ${theme.vars?.palette.primary.main ?? theme.palette.primary.main}`
+                    : "none",
+                })}
+              >
+                <Pictogram label={part.label} src={part.imageSrc} />
+              </Stack>
+            );
+          })}
         </Stack>
 
         <BackspaceButton

--- a/src/features/board/message/part-tracker.test.ts
+++ b/src/features/board/message/part-tracker.test.ts
@@ -53,17 +53,4 @@ describe("createPartTracker", () => {
 
     expect(tracker.partIdAt(99)).toBeNull();
   });
-
-  test("exposes the first part id as the fallback when no boundaries fire", () => {
-    const tracker = createPartTracker([
-      { id: "1", text: "hi" },
-      { id: "2", text: "there" },
-    ]);
-
-    expect(tracker.firstId).toBe("1");
-  });
-
-  test("has no first part for an empty message", () => {
-    expect(createPartTracker([]).firstId).toBeNull();
-  });
 });

--- a/src/features/board/message/part-tracker.ts
+++ b/src/features/board/message/part-tracker.ts
@@ -5,7 +5,6 @@ export interface SpokenPart {
 
 export interface PartTracker {
   text: string;
-  firstId: string | null;
   partIdAt: (charIndex: number) => string | null;
 }
 
@@ -32,7 +31,6 @@ export function createPartTracker(parts: SpokenPart[]): PartTracker {
 
   return {
     text,
-    firstId: parts[0]?.id ?? null,
     partIdAt: (charIndex) =>
       spans.find((span) => charIndex >= span.start && charIndex < span.end)
         ?.id ?? null,

--- a/src/features/board/message/use-message-playback.ts
+++ b/src/features/board/message/use-message-playback.ts
@@ -51,7 +51,6 @@ export function useMessagePlayback(
 
           case "speech": {
             const { tracker } = step;
-            setActivePartId(tracker.firstId);
             await speak(tracker.text, {
               signal,
               onBoundary: (charIndex) =>


### PR DESCRIPTION
Closes #425. Reconciles the two #357 acceptance criteria that shipped unmet in #423.

## 1. No part stays lit on voices that emit no `boundary` events

#357 is explicit: *"When boundary events don't fire, no part becomes active … Don't fake it."* `useMessagePlayback` seeded the highlight with `tracker.firstId` before each text run, so on a voice with no `onboundary` support (Safari/iOS) the first part stayed lit for the whole utterance.

**Fix:** drop the seed. The highlight is now driven only by real `boundary` events. On Chrome the first word's boundary fires ~immediately, so nothing is lost there. `firstId` became dead surface area and is removed from `PartTracker` and its tests.

The audio branch is untouched: sound parts legitimately stay active `play`→`ended`, since audio has a known duration where speech-without-boundaries does not.

## 2. Highlight no longer relies on color alone (WCAG 1.4.1)

#357: *"Perceptible without color."* The active part was distinguished only by an `action.selected` fill — a faint low-alpha overlay that reads as a barely-there lightness change in grayscale.

**Fix:** replace the fill with a `primary.main` outline ring — a shape channel perceptible regardless of hue, layout-neutral (no reflow), and static (no motion under `prefers-reduced-motion`). The ring stands alone rather than chaperoning the fill the issue flagged as inadequate. Follows the existing outline idiom in `tile.tsx` (`theme.vars`-aware color, `outlineOffset: 2`). No `aria-current` added — #357 requires screen-reader behavior unchanged.

## Tests

Full message suite green (40). Removed the two `firstId` tracker tests; no playback test depended on the seed (the one asserting an active part drives it via a real `onboundary({charIndex: 0})`).

## Out of scope

Everything #357 lists: sub-word highlighting, time-based fallback, source-tile highlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)