### PR TITLE
fix(i18n): pluralize board import messages with Paraglide variants

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "المكتبة فارغة",
   "libraryEmptyDescription": "استورد لوحات تواصل للبدء.",
   "libraryImportBoards": "استيراد لوحات",
-  "libraryImportingBoard": "جارٍ استيراد اللوحة...",
-  "libraryImportingBoards": "جارٍ استيراد اللوحات...",
-  "libraryImportedBoard": "تم استيراد اللوحة",
-  "libraryImportedBoards": "تم استيراد اللوحات",
-  "libraryImportFailedBoard": "تعذّر استيراد اللوحة",
-  "libraryImportFailedBoards": "تعذّر استيراد اللوحات",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "جارٍ استيراد اللوحة...",
+        "countPlural=*": "جارٍ استيراد اللوحات..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "تم استيراد اللوحة",
+        "countPlural=*": "تم استيراد اللوحات"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "تعذّر استيراد اللوحة",
+        "countPlural=*": "تعذّر استيراد اللوحات"
+      }
+    }
+  ],
   "libraryInfo": "معلومات",
   "libraryDelete": "حذف",
   "libraryCancel": "إلغاء",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "Библиотеката е празна",
   "libraryEmptyDescription": "Импортирайте комуникационни дъски, за да започнете.",
   "libraryImportBoards": "Импортиране на дъски",
-  "libraryImportingBoard": "Импортиране на дъската...",
-  "libraryImportingBoards": "Импортиране на дъските...",
-  "libraryImportedBoard": "Дъската е импортирана",
-  "libraryImportedBoards": "Дъските са импортирани",
-  "libraryImportFailedBoard": "Дъската не може да бъде импортирана",
-  "libraryImportFailedBoards": "Дъските не могат да бъдат импортирани",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Импортиране на дъската...",
+        "countPlural=*": "Импортиране на дъските..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Дъската е импортирана",
+        "countPlural=*": "Дъските са импортирани"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Дъската не може да бъде импортирана",
+        "countPlural=*": "Дъските не могат да бъдат импортирани"
+      }
+    }
+  ],
   "libraryInfo": "Информация",
   "libraryDelete": "Изтриване",
   "libraryCancel": "Отказ",

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "লাইব্রেরি খালি",
   "libraryEmptyDescription": "শুরু করতে যোগাযোগ বোর্ড আমদানি করুন।",
   "libraryImportBoards": "বোর্ড আমদানি করুন",
-  "libraryImportingBoard": "বোর্ড আমদানি করা হচ্ছে…",
-  "libraryImportingBoards": "বোর্ড আমদানি করা হচ্ছে…",
-  "libraryImportedBoard": "বোর্ড আমদানি করা হয়েছে",
-  "libraryImportedBoards": "বোর্ড আমদানি করা হয়েছে",
-  "libraryImportFailedBoard": "বোর্ড আমদানি করা যায়নি",
-  "libraryImportFailedBoards": "বোর্ড আমদানি করা যায়নি",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "বোর্ড আমদানি করা হচ্ছে…",
+        "countPlural=*": "বোর্ড আমদানি করা হচ্ছে…"
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "বোর্ড আমদানি করা হয়েছে",
+        "countPlural=*": "বোর্ড আমদানি করা হয়েছে"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "বোর্ড আমদানি করা যায়নি",
+        "countPlural=*": "বোর্ড আমদানি করা যায়নি"
+      }
+    }
+  ],
   "libraryInfo": "তথ্য",
   "libraryDelete": "মুছুন",
   "libraryCancel": "বাতিল করুন",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "Knihovna je prázdná",
   "libraryEmptyDescription": "Začněte importem komunikačních tabulek.",
   "libraryImportBoards": "Importovat tabulky",
-  "libraryImportingBoard": "Importování tabulky...",
-  "libraryImportingBoards": "Importování tabulek...",
-  "libraryImportedBoard": "Tabulka importována",
-  "libraryImportedBoards": "Tabulky importovány",
-  "libraryImportFailedBoard": "Tabulku se nepodařilo importovat",
-  "libraryImportFailedBoards": "Tabulky se nepodařilo importovat",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Importování tabulky...",
+        "countPlural=*": "Importování tabulek..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tabulka importována",
+        "countPlural=*": "Tabulky importovány"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tabulku se nepodařilo importovat",
+        "countPlural=*": "Tabulky se nepodařilo importovat"
+      }
+    }
+  ],
   "libraryInfo": "Informace",
   "libraryDelete": "Smazat",
   "libraryCancel": "Zrušit",

--- a/messages/da.json
+++ b/messages/da.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "Biblioteket er tomt",
   "libraryEmptyDescription": "Importér kommunikationstavler for at komme i gang.",
   "libraryImportBoards": "Importér tavler",
-  "libraryImportingBoard": "Importerer tavle...",
-  "libraryImportingBoards": "Importerer tavler...",
-  "libraryImportedBoard": "Tavle importeret",
-  "libraryImportedBoards": "Tavler importeret",
-  "libraryImportFailedBoard": "Tavlen kunne ikke importeres",
-  "libraryImportFailedBoards": "Tavlerne kunne ikke importeres",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Importerer tavle...",
+        "countPlural=*": "Importerer tavler..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tavle importeret",
+        "countPlural=*": "Tavler importeret"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tavlen kunne ikke importeres",
+        "countPlural=*": "Tavlerne kunne ikke importeres"
+      }
+    }
+  ],
   "libraryInfo": "Info",
   "libraryDelete": "Slet",
   "libraryCancel": "Annullér",

--- a/messages/de.json
+++ b/messages/de.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "Die Bibliothek ist leer",
   "libraryEmptyDescription": "Importiere Kommunikationstafeln, um loszulegen.",
   "libraryImportBoards": "Tafeln importieren",
-  "libraryImportingBoard": "Tafel wird importiert...",
-  "libraryImportingBoards": "Tafeln werden importiert...",
-  "libraryImportedBoard": "Tafel importiert",
-  "libraryImportedBoards": "Tafeln importiert",
-  "libraryImportFailedBoard": "Tafel konnte nicht importiert werden",
-  "libraryImportFailedBoards": "Tafeln konnten nicht importiert werden",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tafel wird importiert...",
+        "countPlural=*": "Tafeln werden importiert..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tafel importiert",
+        "countPlural=*": "Tafeln importiert"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tafel konnte nicht importiert werden",
+        "countPlural=*": "Tafeln konnten nicht importiert werden"
+      }
+    }
+  ],
   "libraryInfo": "Info",
   "libraryDelete": "Löschen",
   "libraryCancel": "Abbrechen",

--- a/messages/el.json
+++ b/messages/el.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "Η βιβλιοθήκη είναι κενή",
   "libraryEmptyDescription": "Εισαγάγετε πίνακες επικοινωνίας για να ξεκινήσετε.",
   "libraryImportBoards": "Εισαγωγή πινάκων",
-  "libraryImportingBoard": "Εισαγωγή πίνακα...",
-  "libraryImportingBoards": "Εισαγωγή πινάκων...",
-  "libraryImportedBoard": "Ο πίνακας εισήχθη",
-  "libraryImportedBoards": "Οι πίνακες εισήχθησαν",
-  "libraryImportFailedBoard": "Δεν ήταν δυνατή η εισαγωγή του πίνακα",
-  "libraryImportFailedBoards": "Δεν ήταν δυνατή η εισαγωγή των πινάκων",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Εισαγωγή πίνακα...",
+        "countPlural=*": "Εισαγωγή πινάκων..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Ο πίνακας εισήχθη",
+        "countPlural=*": "Οι πίνακες εισήχθησαν"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Δεν ήταν δυνατή η εισαγωγή του πίνακα",
+        "countPlural=*": "Δεν ήταν δυνατή η εισαγωγή των πινάκων"
+      }
+    }
+  ],
   "libraryInfo": "Πληροφορίες",
   "libraryDelete": "Διαγραφή",
   "libraryCancel": "Άκυρο",

--- a/messages/en.json
+++ b/messages/en.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
   "libraryImportBoards": "Import boards",
-  "libraryImportingBoard": "Importing board...",
-  "libraryImportingBoards": "Importing boards...",
-  "libraryImportedBoard": "Board imported",
-  "libraryImportedBoards": "Boards imported",
-  "libraryImportFailedBoard": "Couldn't import board",
-  "libraryImportFailedBoards": "Couldn't import boards",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Importing board...",
+        "countPlural=*": "Importing boards..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Board imported",
+        "countPlural=*": "Boards imported"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Couldn't import board",
+        "countPlural=*": "Couldn't import boards"
+      }
+    }
+  ],
   "libraryInfo": "Info",
   "libraryDelete": "Delete",
   "libraryCancel": "Cancel",

--- a/messages/es.json
+++ b/messages/es.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "La biblioteca está vacía",
   "libraryEmptyDescription": "Importa tableros de comunicación para empezar.",
   "libraryImportBoards": "Importar tableros",
-  "libraryImportingBoard": "Importando tablero...",
-  "libraryImportingBoards": "Importando tableros...",
-  "libraryImportedBoard": "Tablero importado",
-  "libraryImportedBoards": "Tableros importados",
-  "libraryImportFailedBoard": "No se pudo importar el tablero",
-  "libraryImportFailedBoards": "No se pudieron importar los tableros",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Importando tablero...",
+        "countPlural=*": "Importando tableros..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tablero importado",
+        "countPlural=*": "Tableros importados"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "No se pudo importar el tablero",
+        "countPlural=*": "No se pudieron importar los tableros"
+      }
+    }
+  ],
   "libraryInfo": "Información",
   "libraryDelete": "Eliminar",
   "libraryCancel": "Cancelar",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "Kirjasto on tyhjä",
   "libraryEmptyDescription": "Tuo kommunikointitauluja päästäksesi alkuun.",
   "libraryImportBoards": "Tuo tauluja",
-  "libraryImportingBoard": "Tuodaan taulua...",
-  "libraryImportingBoards": "Tuodaan tauluja...",
-  "libraryImportedBoard": "Taulu tuotu",
-  "libraryImportedBoards": "Taulut tuotu",
-  "libraryImportFailedBoard": "Taulun tuonti epäonnistui",
-  "libraryImportFailedBoards": "Taulujen tuonti epäonnistui",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tuodaan taulua...",
+        "countPlural=*": "Tuodaan tauluja..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Taulu tuotu",
+        "countPlural=*": "Taulut tuotu"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Taulun tuonti epäonnistui",
+        "countPlural=*": "Taulujen tuonti epäonnistui"
+      }
+    }
+  ],
   "libraryInfo": "Tiedot",
   "libraryDelete": "Poista",
   "libraryCancel": "Peruuta",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "La bibliothèque est vide",
   "libraryEmptyDescription": "Importez des tableaux de communication pour commencer.",
   "libraryImportBoards": "Importer des tableaux",
-  "libraryImportingBoard": "Importation du tableau...",
-  "libraryImportingBoards": "Importation des tableaux...",
-  "libraryImportedBoard": "Tableau importé",
-  "libraryImportedBoards": "Tableaux importés",
-  "libraryImportFailedBoard": "Impossible d'importer le tableau",
-  "libraryImportFailedBoards": "Impossible d'importer les tableaux",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Importation du tableau...",
+        "countPlural=*": "Importation des tableaux..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tableau importé",
+        "countPlural=*": "Tableaux importés"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Impossible d'importer le tableau",
+        "countPlural=*": "Impossible d'importer les tableaux"
+      }
+    }
+  ],
   "libraryInfo": "Infos",
   "libraryDelete": "Supprimer",
   "libraryCancel": "Annuler",

--- a/messages/he.json
+++ b/messages/he.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "הספרייה ריקה",
   "libraryEmptyDescription": "כדי להתחיל, יש לייבא לוחות תקשורת.",
   "libraryImportBoards": "ייבוא לוחות",
-  "libraryImportingBoard": "ייבוא לוח...",
-  "libraryImportingBoards": "ייבוא לוחות...",
-  "libraryImportedBoard": "הלוח יובא",
-  "libraryImportedBoards": "הלוחות יובאו",
-  "libraryImportFailedBoard": "ייבוא הלוח נכשל",
-  "libraryImportFailedBoards": "ייבוא הלוחות נכשל",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "ייבוא לוח...",
+        "countPlural=*": "ייבוא לוחות..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "הלוח יובא",
+        "countPlural=*": "הלוחות יובאו"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "ייבוא הלוח נכשל",
+        "countPlural=*": "ייבוא הלוחות נכשל"
+      }
+    }
+  ],
   "libraryInfo": "פרטים",
   "libraryDelete": "מחיקה",
   "libraryCancel": "ביטול",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "लाइब्रेरी खाली है",
   "libraryEmptyDescription": "शुरू करने के लिए संचार बोर्ड आयात करें।",
   "libraryImportBoards": "बोर्ड आयात करें",
-  "libraryImportingBoard": "बोर्ड आयात हो रहा है…",
-  "libraryImportingBoards": "बोर्ड आयात हो रहे हैं…",
-  "libraryImportedBoard": "बोर्ड आयात हो गया",
-  "libraryImportedBoards": "बोर्ड आयात हो गए",
-  "libraryImportFailedBoard": "बोर्ड आयात नहीं किया जा सका",
-  "libraryImportFailedBoards": "बोर्ड आयात नहीं किए जा सके",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "बोर्ड आयात हो रहा है…",
+        "countPlural=*": "बोर्ड आयात हो रहे हैं…"
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "बोर्ड आयात हो गया",
+        "countPlural=*": "बोर्ड आयात हो गए"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "बोर्ड आयात नहीं किया जा सका",
+        "countPlural=*": "बोर्ड आयात नहीं किए जा सके"
+      }
+    }
+  ],
   "libraryInfo": "जानकारी",
   "libraryDelete": "हटाएँ",
   "libraryCancel": "रद्द करें",

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "Knjižnica je prazna",
   "libraryEmptyDescription": "Za početak uvezite komunikacijske ploče.",
   "libraryImportBoards": "Uvezi ploče",
-  "libraryImportingBoard": "Uvoz ploče...",
-  "libraryImportingBoards": "Uvoz ploča...",
-  "libraryImportedBoard": "Ploča uvezena",
-  "libraryImportedBoards": "Ploče uvezene",
-  "libraryImportFailedBoard": "Ploču nije moguće uvesti",
-  "libraryImportFailedBoards": "Ploče nije moguće uvesti",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Uvoz ploče...",
+        "countPlural=*": "Uvoz ploča..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Ploča uvezena",
+        "countPlural=*": "Ploče uvezene"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Ploču nije moguće uvesti",
+        "countPlural=*": "Ploče nije moguće uvesti"
+      }
+    }
+  ],
   "libraryInfo": "Informacije",
   "libraryDelete": "Izbriši",
   "libraryCancel": "Odustani",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "A könyvtár üres",
   "libraryEmptyDescription": "Az induláshoz importálj kommunikációs táblákat.",
   "libraryImportBoards": "Táblák importálása",
-  "libraryImportingBoard": "Tábla importálása...",
-  "libraryImportingBoards": "Táblák importálása...",
-  "libraryImportedBoard": "Tábla importálva",
-  "libraryImportedBoards": "Táblák importálva",
-  "libraryImportFailedBoard": "A tábla importálása nem sikerült",
-  "libraryImportFailedBoards": "A táblák importálása nem sikerült",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tábla importálása...",
+        "countPlural=*": "Táblák importálása..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tábla importálva",
+        "countPlural=*": "Táblák importálva"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "A tábla importálása nem sikerült",
+        "countPlural=*": "A táblák importálása nem sikerült"
+      }
+    }
+  ],
   "libraryInfo": "Információ",
   "libraryDelete": "Törlés",
   "libraryCancel": "Mégse",

--- a/messages/id.json
+++ b/messages/id.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "Pustaka kosong",
   "libraryEmptyDescription": "Impor papan komunikasi untuk memulai.",
   "libraryImportBoards": "Impor papan",
-  "libraryImportingBoard": "Mengimpor papan...",
-  "libraryImportingBoards": "Mengimpor papan...",
-  "libraryImportedBoard": "Papan diimpor",
-  "libraryImportedBoards": "Papan diimpor",
-  "libraryImportFailedBoard": "Tidak dapat mengimpor papan",
-  "libraryImportFailedBoards": "Tidak dapat mengimpor papan",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Mengimpor papan...",
+        "countPlural=*": "Mengimpor papan..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Papan diimpor",
+        "countPlural=*": "Papan diimpor"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tidak dapat mengimpor papan",
+        "countPlural=*": "Tidak dapat mengimpor papan"
+      }
+    }
+  ],
   "libraryInfo": "Info",
   "libraryDelete": "Hapus",
   "libraryCancel": "Batal",

--- a/messages/it.json
+++ b/messages/it.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "La libreria è vuota",
   "libraryEmptyDescription": "Importa tabelle di comunicazione per iniziare.",
   "libraryImportBoards": "Importa tabelle",
-  "libraryImportingBoard": "Importazione tabella...",
-  "libraryImportingBoards": "Importazione tabelle...",
-  "libraryImportedBoard": "Tabella importata",
-  "libraryImportedBoards": "Tabelle importate",
-  "libraryImportFailedBoard": "Impossibile importare la tabella",
-  "libraryImportFailedBoards": "Impossibile importare le tabelle",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Importazione tabella...",
+        "countPlural=*": "Importazione tabelle..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tabella importata",
+        "countPlural=*": "Tabelle importate"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Impossibile importare la tabella",
+        "countPlural=*": "Impossibile importare le tabelle"
+      }
+    }
+  ],
   "libraryInfo": "Informazioni",
   "libraryDelete": "Elimina",
   "libraryCancel": "Annulla",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "ライブラリは空です",
   "libraryEmptyDescription": "コミュニケーションボードをインポートして始めましょう。",
   "libraryImportBoards": "ボードをインポート",
-  "libraryImportingBoard": "ボードをインポートしています…",
-  "libraryImportingBoards": "ボードをインポートしています…",
-  "libraryImportedBoard": "ボードをインポートしました",
-  "libraryImportedBoards": "ボードをインポートしました",
-  "libraryImportFailedBoard": "ボードをインポートできませんでした",
-  "libraryImportFailedBoards": "ボードをインポートできませんでした",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "ボードをインポートしています…",
+        "countPlural=*": "ボードをインポートしています…"
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "ボードをインポートしました",
+        "countPlural=*": "ボードをインポートしました"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "ボードをインポートできませんでした",
+        "countPlural=*": "ボードをインポートできませんでした"
+      }
+    }
+  ],
   "libraryInfo": "情報",
   "libraryDelete": "削除",
   "libraryCancel": "キャンセル",

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "ಗ್ರಂಥಾಲಯ ಖಾಲಿಯಾಗಿದೆ",
   "libraryEmptyDescription": "ಪ್ರಾರಂಭಿಸಲು ಸಂವಹನ ಬೋರ್ಡ್‌ಗಳನ್ನು ಆಮದು ಮಾಡಿ.",
   "libraryImportBoards": "ಬೋರ್ಡ್‌ಗಳನ್ನು ಆಮದು ಮಾಡಿ",
-  "libraryImportingBoard": "ಬೋರ್ಡ್ ಆಮದು ಆಗುತ್ತಿದೆ…",
-  "libraryImportingBoards": "ಬೋರ್ಡ್‌ಗಳು ಆಮದು ಆಗುತ್ತಿವೆ…",
-  "libraryImportedBoard": "ಬೋರ್ಡ್ ಆಮದಾಗಿದೆ",
-  "libraryImportedBoards": "ಬೋರ್ಡ್‌ಗಳು ಆಮದಾಗಿವೆ",
-  "libraryImportFailedBoard": "ಬೋರ್ಡ್ ಆಮದು ಮಾಡಲಾಗಲಿಲ್ಲ",
-  "libraryImportFailedBoards": "ಬೋರ್ಡ್‌ಗಳನ್ನು ಆಮದು ಮಾಡಲಾಗಲಿಲ್ಲ",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "ಬೋರ್ಡ್ ಆಮದು ಆಗುತ್ತಿದೆ…",
+        "countPlural=*": "ಬೋರ್ಡ್‌ಗಳು ಆಮದು ಆಗುತ್ತಿವೆ…"
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "ಬೋರ್ಡ್ ಆಮದಾಗಿದೆ",
+        "countPlural=*": "ಬೋರ್ಡ್‌ಗಳು ಆಮದಾಗಿವೆ"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "ಬೋರ್ಡ್ ಆಮದು ಮಾಡಲಾಗಲಿಲ್ಲ",
+        "countPlural=*": "ಬೋರ್ಡ್‌ಗಳನ್ನು ಆಮದು ಮಾಡಲಾಗಲಿಲ್ಲ"
+      }
+    }
+  ],
   "libraryInfo": "ಮಾಹಿತಿ",
   "libraryDelete": "ಅಳಿಸಿ",
   "libraryCancel": "ರದ್ದುಮಾಡಿ",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "라이브러리가 비어 있습니다",
   "libraryEmptyDescription": "의사소통 보드를 가져와 시작하세요.",
   "libraryImportBoards": "보드 가져오기",
-  "libraryImportingBoard": "보드를 가져오는 중…",
-  "libraryImportingBoards": "보드를 가져오는 중…",
-  "libraryImportedBoard": "보드를 가져왔습니다",
-  "libraryImportedBoards": "보드를 가져왔습니다",
-  "libraryImportFailedBoard": "보드를 가져올 수 없습니다",
-  "libraryImportFailedBoards": "보드를 가져올 수 없습니다",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "보드를 가져오는 중…",
+        "countPlural=*": "보드를 가져오는 중…"
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "보드를 가져왔습니다",
+        "countPlural=*": "보드를 가져왔습니다"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "보드를 가져올 수 없습니다",
+        "countPlural=*": "보드를 가져올 수 없습니다"
+      }
+    }
+  ],
   "libraryInfo": "정보",
   "libraryDelete": "삭제",
   "libraryCancel": "취소",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "De bibliotheek is leeg",
   "libraryEmptyDescription": "Importeer communicatieborden om te beginnen.",
   "libraryImportBoards": "Borden importeren",
-  "libraryImportingBoard": "Bord importeren...",
-  "libraryImportingBoards": "Borden importeren...",
-  "libraryImportedBoard": "Bord geïmporteerd",
-  "libraryImportedBoards": "Borden geïmporteerd",
-  "libraryImportFailedBoard": "Kan bord niet importeren",
-  "libraryImportFailedBoards": "Kan borden niet importeren",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Bord importeren...",
+        "countPlural=*": "Borden importeren..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Bord geïmporteerd",
+        "countPlural=*": "Borden geïmporteerd"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Kan bord niet importeren",
+        "countPlural=*": "Kan borden niet importeren"
+      }
+    }
+  ],
   "libraryInfo": "Info",
   "libraryDelete": "Verwijderen",
   "libraryCancel": "Annuleren",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "Biblioteka jest pusta",
   "libraryEmptyDescription": "Zaimportuj tablice komunikacyjne, aby rozpocząć.",
   "libraryImportBoards": "Importuj tablice",
-  "libraryImportingBoard": "Importowanie tablicy...",
-  "libraryImportingBoards": "Importowanie tablic...",
-  "libraryImportedBoard": "Zaimportowano tablicę",
-  "libraryImportedBoards": "Zaimportowano tablice",
-  "libraryImportFailedBoard": "Nie udało się zaimportować tablicy",
-  "libraryImportFailedBoards": "Nie udało się zaimportować tablic",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Importowanie tablicy...",
+        "countPlural=*": "Importowanie tablic..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Zaimportowano tablicę",
+        "countPlural=*": "Zaimportowano tablice"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Nie udało się zaimportować tablicy",
+        "countPlural=*": "Nie udało się zaimportować tablic"
+      }
+    }
+  ],
   "libraryInfo": "Informacje",
   "libraryDelete": "Usuń",
   "libraryCancel": "Anuluj",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "A biblioteca está vazia",
   "libraryEmptyDescription": "Importe pranchas de comunicação para começar.",
   "libraryImportBoards": "Importar pranchas",
-  "libraryImportingBoard": "Importando prancha...",
-  "libraryImportingBoards": "Importando pranchas...",
-  "libraryImportedBoard": "Prancha importada",
-  "libraryImportedBoards": "Pranchas importadas",
-  "libraryImportFailedBoard": "Não foi possível importar a prancha",
-  "libraryImportFailedBoards": "Não foi possível importar as pranchas",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Importando prancha...",
+        "countPlural=*": "Importando pranchas..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Prancha importada",
+        "countPlural=*": "Pranchas importadas"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Não foi possível importar a prancha",
+        "countPlural=*": "Não foi possível importar as pranchas"
+      }
+    }
+  ],
   "libraryInfo": "Informações",
   "libraryDelete": "Excluir",
   "libraryCancel": "Cancelar",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "Biblioteca este goală",
   "libraryEmptyDescription": "Importă table de comunicare pentru a începe.",
   "libraryImportBoards": "Importă table",
-  "libraryImportingBoard": "Se importă tabla...",
-  "libraryImportingBoards": "Se importă tablele...",
-  "libraryImportedBoard": "Tablă importată",
-  "libraryImportedBoards": "Table importate",
-  "libraryImportFailedBoard": "Tabla nu a putut fi importată",
-  "libraryImportFailedBoards": "Tablele nu au putut fi importate",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Se importă tabla...",
+        "countPlural=*": "Se importă tablele..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tablă importată",
+        "countPlural=*": "Table importate"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tabla nu a putut fi importată",
+        "countPlural=*": "Tablele nu au putut fi importate"
+      }
+    }
+  ],
   "libraryInfo": "Informații",
   "libraryDelete": "Șterge",
   "libraryCancel": "Anulează",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "Библиотека пуста",
   "libraryEmptyDescription": "Импортируйте коммуникационные доски, чтобы начать.",
   "libraryImportBoards": "Импортировать доски",
-  "libraryImportingBoard": "Импорт доски...",
-  "libraryImportingBoards": "Импорт досок...",
-  "libraryImportedBoard": "Доска импортирована",
-  "libraryImportedBoards": "Доски импортированы",
-  "libraryImportFailedBoard": "Не удалось импортировать доску",
-  "libraryImportFailedBoards": "Не удалось импортировать доски",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Импорт доски...",
+        "countPlural=*": "Импорт досок..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Доска импортирована",
+        "countPlural=*": "Доски импортированы"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Не удалось импортировать доску",
+        "countPlural=*": "Не удалось импортировать доски"
+      }
+    }
+  ],
   "libraryInfo": "Сведения",
   "libraryDelete": "Удалить",
   "libraryCancel": "Отмена",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "Knižnica je prázdna",
   "libraryEmptyDescription": "Začnite importovaním komunikačných tabuliek.",
   "libraryImportBoards": "Importovať tabuľky",
-  "libraryImportingBoard": "Importovanie tabuľky...",
-  "libraryImportingBoards": "Importovanie tabuliek...",
-  "libraryImportedBoard": "Tabuľka importovaná",
-  "libraryImportedBoards": "Tabuľky importované",
-  "libraryImportFailedBoard": "Tabuľku sa nepodarilo importovať",
-  "libraryImportFailedBoards": "Tabuľky sa nepodarilo importovať",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Importovanie tabuľky...",
+        "countPlural=*": "Importovanie tabuliek..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tabuľka importovaná",
+        "countPlural=*": "Tabuľky importované"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tabuľku sa nepodarilo importovať",
+        "countPlural=*": "Tabuľky sa nepodarilo importovať"
+      }
+    }
+  ],
   "libraryInfo": "Informácie",
   "libraryDelete": "Odstrániť",
   "libraryCancel": "Zrušiť",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "Knjižnica je prazna",
   "libraryEmptyDescription": "Za začetek uvozite komunikacijske table.",
   "libraryImportBoards": "Uvozi table",
-  "libraryImportingBoard": "Uvažanje table...",
-  "libraryImportingBoards": "Uvažanje tabel...",
-  "libraryImportedBoard": "Tabla uvožena",
-  "libraryImportedBoards": "Table uvožene",
-  "libraryImportFailedBoard": "Table ni bilo mogoče uvoziti",
-  "libraryImportFailedBoards": "Tabel ni bilo mogoče uvoziti",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Uvažanje table...",
+        "countPlural=*": "Uvažanje tabel..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tabla uvožena",
+        "countPlural=*": "Table uvožene"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Table ni bilo mogoče uvoziti",
+        "countPlural=*": "Tabel ni bilo mogoče uvoziti"
+      }
+    }
+  ],
   "libraryInfo": "Informacije",
   "libraryDelete": "Izbriši",
   "libraryCancel": "Prekliči",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "Biblioteket är tomt",
   "libraryEmptyDescription": "Importera kommunikationstavlor för att komma igång.",
   "libraryImportBoards": "Importera tavlor",
-  "libraryImportingBoard": "Importerar tavla...",
-  "libraryImportingBoards": "Importerar tavlor...",
-  "libraryImportedBoard": "Tavla importerad",
-  "libraryImportedBoards": "Tavlor importerade",
-  "libraryImportFailedBoard": "Det gick inte att importera tavlan",
-  "libraryImportFailedBoards": "Det gick inte att importera tavlorna",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Importerar tavla...",
+        "countPlural=*": "Importerar tavlor..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tavla importerad",
+        "countPlural=*": "Tavlor importerade"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Det gick inte att importera tavlan",
+        "countPlural=*": "Det gick inte att importera tavlorna"
+      }
+    }
+  ],
   "libraryInfo": "Info",
   "libraryDelete": "Ta bort",
   "libraryCancel": "Avbryt",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "நூலகம் காலியாக உள்ளது",
   "libraryEmptyDescription": "தொடங்க தொடர்பு பலகைகளை இறக்குமதி செய்யுங்கள்.",
   "libraryImportBoards": "பலகைகளை இறக்குமதி செய்",
-  "libraryImportingBoard": "பலகை இறக்குமதி செய்யப்படுகிறது…",
-  "libraryImportingBoards": "பலகைகள் இறக்குமதி செய்யப்படுகின்றன…",
-  "libraryImportedBoard": "பலகை இறக்குமதி செய்யப்பட்டது",
-  "libraryImportedBoards": "பலகைகள் இறக்குமதி செய்யப்பட்டன",
-  "libraryImportFailedBoard": "பலகையை இறக்குமதி செய்ய முடியவில்லை",
-  "libraryImportFailedBoards": "பலகைகளை இறக்குமதி செய்ய முடியவில்லை",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "பலகை இறக்குமதி செய்யப்படுகிறது…",
+        "countPlural=*": "பலகைகள் இறக்குமதி செய்யப்படுகின்றன…"
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "பலகை இறக்குமதி செய்யப்பட்டது",
+        "countPlural=*": "பலகைகள் இறக்குமதி செய்யப்பட்டன"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "பலகையை இறக்குமதி செய்ய முடியவில்லை",
+        "countPlural=*": "பலகைகளை இறக்குமதி செய்ய முடியவில்லை"
+      }
+    }
+  ],
   "libraryInfo": "தகவல்",
   "libraryDelete": "நீக்கு",
   "libraryCancel": "ரத்துசெய்",

--- a/messages/te.json
+++ b/messages/te.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "లైబ్రరీ ఖాళీగా ఉంది",
   "libraryEmptyDescription": "ప్రారంభించడానికి సంభాషణ బోర్డులను దిగుమతి చేయండి.",
   "libraryImportBoards": "బోర్డులను దిగుమతి చేయి",
-  "libraryImportingBoard": "బోర్డు దిగుమతి అవుతోంది…",
-  "libraryImportingBoards": "బోర్డులు దిగుమతి అవుతున్నాయి…",
-  "libraryImportedBoard": "బోర్డు దిగుమతి చేయబడింది",
-  "libraryImportedBoards": "బోర్డులు దిగుమతి చేయబడ్డాయి",
-  "libraryImportFailedBoard": "బోర్డును దిగుమతి చేయలేకపోయాం",
-  "libraryImportFailedBoards": "బోర్డులను దిగుమతి చేయలేకపోయాం",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "బోర్డు దిగుమతి అవుతోంది…",
+        "countPlural=*": "బోర్డులు దిగుమతి అవుతున్నాయి…"
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "బోర్డు దిగుమతి చేయబడింది",
+        "countPlural=*": "బోర్డులు దిగుమతి చేయబడ్డాయి"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "బోర్డును దిగుమతి చేయలేకపోయాం",
+        "countPlural=*": "బోర్డులను దిగుమతి చేయలేకపోయాం"
+      }
+    }
+  ],
   "libraryInfo": "సమాచారం",
   "libraryDelete": "తొలగించు",
   "libraryCancel": "రద్దు చేయి",

--- a/messages/th.json
+++ b/messages/th.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "คลังว่างเปล่า",
   "libraryEmptyDescription": "นำเข้าบอร์ดสื่อสารเพื่อเริ่มต้น",
   "libraryImportBoards": "นำเข้าบอร์ด",
-  "libraryImportingBoard": "กำลังนำเข้าบอร์ด...",
-  "libraryImportingBoards": "กำลังนำเข้าบอร์ด...",
-  "libraryImportedBoard": "นำเข้าบอร์ดแล้ว",
-  "libraryImportedBoards": "นำเข้าบอร์ดแล้ว",
-  "libraryImportFailedBoard": "นำเข้าบอร์ดไม่สำเร็จ",
-  "libraryImportFailedBoards": "นำเข้าบอร์ดไม่สำเร็จ",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "กำลังนำเข้าบอร์ด...",
+        "countPlural=*": "กำลังนำเข้าบอร์ด..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "นำเข้าบอร์ดแล้ว",
+        "countPlural=*": "นำเข้าบอร์ดแล้ว"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "นำเข้าบอร์ดไม่สำเร็จ",
+        "countPlural=*": "นำเข้าบอร์ดไม่สำเร็จ"
+      }
+    }
+  ],
   "libraryInfo": "ข้อมูล",
   "libraryDelete": "ลบ",
   "libraryCancel": "ยกเลิก",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "Kitaplık boş",
   "libraryEmptyDescription": "Başlamak için iletişim panoları içe aktarın.",
   "libraryImportBoards": "Panoları içe aktar",
-  "libraryImportingBoard": "Pano içe aktarılıyor...",
-  "libraryImportingBoards": "Panolar içe aktarılıyor...",
-  "libraryImportedBoard": "Pano içe aktarıldı",
-  "libraryImportedBoards": "Panolar içe aktarıldı",
-  "libraryImportFailedBoard": "Pano içe aktarılamadı",
-  "libraryImportFailedBoards": "Panolar içe aktarılamadı",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Pano içe aktarılıyor...",
+        "countPlural=*": "Panolar içe aktarılıyor..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Pano içe aktarıldı",
+        "countPlural=*": "Panolar içe aktarıldı"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Pano içe aktarılamadı",
+        "countPlural=*": "Panolar içe aktarılamadı"
+      }
+    }
+  ],
   "libraryInfo": "Bilgi",
   "libraryDelete": "Sil",
   "libraryCancel": "İptal",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "Бібліотека порожня",
   "libraryEmptyDescription": "Імпортуйте комунікаційні дошки, щоб почати.",
   "libraryImportBoards": "Імпортувати дошки",
-  "libraryImportingBoard": "Імпортування дошки...",
-  "libraryImportingBoards": "Імпортування дошок...",
-  "libraryImportedBoard": "Дошку імпортовано",
-  "libraryImportedBoards": "Дошки імпортовано",
-  "libraryImportFailedBoard": "Не вдалося імпортувати дошку",
-  "libraryImportFailedBoards": "Не вдалося імпортувати дошки",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Імпортування дошки...",
+        "countPlural=*": "Імпортування дошок..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Дошку імпортовано",
+        "countPlural=*": "Дошки імпортовано"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Не вдалося імпортувати дошку",
+        "countPlural=*": "Не вдалося імпортувати дошки"
+      }
+    }
+  ],
   "libraryInfo": "Інформація",
   "libraryDelete": "Видалити",
   "libraryCancel": "Скасувати",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "Thư viện trống",
   "libraryEmptyDescription": "Nhập các bảng giao tiếp để bắt đầu.",
   "libraryImportBoards": "Nhập bảng",
-  "libraryImportingBoard": "Đang nhập bảng...",
-  "libraryImportingBoards": "Đang nhập các bảng...",
-  "libraryImportedBoard": "Đã nhập bảng",
-  "libraryImportedBoards": "Đã nhập các bảng",
-  "libraryImportFailedBoard": "Không thể nhập bảng",
-  "libraryImportFailedBoards": "Không thể nhập các bảng",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Đang nhập bảng...",
+        "countPlural=*": "Đang nhập các bảng..."
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Đã nhập bảng",
+        "countPlural=*": "Đã nhập các bảng"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Không thể nhập bảng",
+        "countPlural=*": "Không thể nhập các bảng"
+      }
+    }
+  ],
   "libraryInfo": "Thông tin",
   "libraryDelete": "Xóa",
   "libraryCancel": "Hủy",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -7,12 +7,36 @@
   "libraryEmptyTitle": "板库为空",
   "libraryEmptyDescription": "导入沟通板即可开始。",
   "libraryImportBoards": "导入沟通板",
-  "libraryImportingBoard": "正在导入沟通板……",
-  "libraryImportingBoards": "正在导入沟通板……",
-  "libraryImportedBoard": "已导入沟通板",
-  "libraryImportedBoards": "已导入沟通板",
-  "libraryImportFailedBoard": "无法导入沟通板",
-  "libraryImportFailedBoards": "无法导入沟通板",
+  "libraryImportingBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "正在导入沟通板……",
+        "countPlural=*": "正在导入沟通板……"
+      }
+    }
+  ],
+  "libraryImportedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "已导入沟通板",
+        "countPlural=*": "已导入沟通板"
+      }
+    }
+  ],
+  "libraryImportFailedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "无法导入沟通板",
+        "countPlural=*": "无法导入沟通板"
+      }
+    }
+  ],
   "libraryInfo": "信息",
   "libraryDelete": "删除",
   "libraryCancel": "取消",

--- a/src/features/board/import/use-import-board-files.ts
+++ b/src/features/board/import/use-import-board-files.ts
@@ -22,33 +22,22 @@ export function useImportBoardFiles(): UseImportBoardFilesReturn {
       return;
     }
 
-    const isPlural = files.length > 1;
-    const pickMessage = (single: string, plural: string) =>
-      isPlural ? plural : single;
+    const count = files.length;
 
     showSnackbar({
-      message: pickMessage(
-        m.libraryImportingBoard(),
-        m.libraryImportingBoards(),
-      ),
+      message: m.libraryImportingBoards({ count }),
     });
 
     try {
       await importBoardFiles(files);
 
       showSnackbar({
-        message: pickMessage(
-          m.libraryImportedBoard(),
-          m.libraryImportedBoards(),
-        ),
+        message: m.libraryImportedBoards({ count }),
         severity: "success",
       });
     } catch {
       showSnackbar({
-        message: pickMessage(
-          m.libraryImportFailedBoard(),
-          m.libraryImportFailedBoards(),
-        ),
+        message: m.libraryImportFailedBoards({ count }),
         severity: "error",
       });
     }


### PR DESCRIPTION
## What

Replaces the manual `isPlural`/`pickMessage` helper in `useImportBoardFiles` with count-driven [Paraglide](https://inlang.com/m/gerre34r/library-inlang-paraglideJs) plural variants. The six singular/plural key pairs collapse into three `count`-selected messages across all 35 locales.

## Why `countPlural=*` and not `=other`

Paraglide compiles `countPlural=other` as an **exact** equality check, then falls through to `return "<keyName>"`. Locales whose `Intl.PluralRules` return `few`/`many`/`two` (ar, pl, ru, uk, cs, sk, …) would have rendered the literal key (e.g. `"libraryImportingBoards"`) for any count > 1. The `*` wildcard compiles to an unconditional catch-all, so every category renders a real string. CLDR `one` also correctly renders singular for cases like Russian 21/31, which the old `length > 1` check wrongly forced to plural.

## Test plan

- `paraglide-js compile` ✓
- `tsc -b` ✓ · `eslint` ✓
- `vitest run` → **314/314 pass**
- Runtime-verified all three messages render real strings (no key-name leak) across en / pl / ar at counts 1, 2, 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)