### PR TITLE
feat(theme): theme-following browser chrome from a single color source

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,21 @@
       content="AAC Board AI helps people who can't speak communicate naturally with Built-in AI — proofreading, rephrasing, and translating safely on their device."
     />
 
+    <meta name="color-scheme" content="light dark" />
+
+    <!-- Injected from theme-colors.ts. Static so the Safari chrome (<body>) and
+         content surface (#root) are correct on first paint, before MUI's JS runs. -->
+    <style>
+      body {
+        margin: 0;
+        background-color: light-dark(__SHELL_LIGHT__, __SHELL_DARK__);
+      }
+      #root {
+        min-height: 100svh;
+        background-color: light-dark(__CONTENT_LIGHT__, __CONTENT_DARK__);
+      }
+    </style>
+
     <link rel="icon" type="image/svg+xml" href="/board.svg" />
     <link rel="apple-touch-icon" href="/pwa-192x192.png" />
   </head>

--- a/src/shared/theme/theme-color-meta.tsx
+++ b/src/shared/theme/theme-color-meta.tsx
@@ -1,0 +1,17 @@
+import { useColorScheme } from "@mui/material/styles";
+import { SHELL_DARK, SHELL_LIGHT } from "@shared/theme/theme-colors";
+
+// Syncs the theme-color meta to the active scheme so Android chrome tracks the
+// manual toggle (a static media-scoped tag would follow the OS instead). React 19
+// hoists the <meta> to <head>; Safari ignores it and samples <body>.
+export function ThemeColorMeta() {
+  const { mode, systemMode } = useColorScheme();
+  const resolved = mode === "system" ? systemMode : mode;
+
+  return (
+    <meta
+      name="theme-color"
+      content={resolved === "dark" ? SHELL_DARK : SHELL_LIGHT}
+    />
+  );
+}

--- a/src/shared/theme/theme-colors.ts
+++ b/src/shared/theme/theme-colors.ts
@@ -1,0 +1,7 @@
+// Single source for the app's colors — edit here to recolor. The chrome follows
+// SHELL because Safari 26 samples <body>; other engines read the theme-color meta.
+export const SHELL_LIGHT = "#ffffff";
+export const SHELL_DARK = "#222222";
+
+export const CONTENT_LIGHT = "#ffffff";
+export const CONTENT_DARK = "#121212";

--- a/src/shared/theme/theme-provider.tsx
+++ b/src/shared/theme/theme-provider.tsx
@@ -4,9 +4,12 @@ import CssBaseline from "@mui/material/CssBaseline";
 import {
   createTheme,
   ThemeProvider as MUIThemeProvider,
+  type ThemeOptions,
 } from "@mui/material/styles";
 import rtlPlugin from "@mui/stylis-plugin-rtl";
 import { useLanguage } from "@shared/language/use-language";
+import { ThemeColorMeta } from "@shared/theme/theme-color-meta";
+import { SHELL_DARK, SHELL_LIGHT } from "@shared/theme/theme-colors";
 import type { ReactNode } from "react";
 import { prefixer } from "stylis";
 
@@ -25,8 +28,11 @@ const themeOptions = {
     colorSchemeSelector: "class",
   },
   colorSchemes: {
-    light: true,
-    dark: true,
+    // Safari 26 samples <body>, which CssBaseline paints from background.default —
+    // so the page default is the chrome color; the reading surface is #root, not
+    // a palette surface.
+    light: { palette: { background: { default: SHELL_LIGHT } } },
+    dark: { palette: { background: { default: SHELL_DARK } } },
   },
   typography: {
     button: {
@@ -41,8 +47,41 @@ const themeOptions = {
         },
       },
     },
+    MuiAppBar: {
+      defaultProps: {
+        elevation: 0,
+      },
+      styleOverrides: {
+        root: ({ theme }) => {
+          const palette = theme.vars?.palette ?? theme.palette;
+
+          return {
+            backgroundColor: SHELL_LIGHT,
+            color: palette.text.primary,
+            backgroundImage: "none",
+            borderBottom: `1px solid ${palette.divider}`,
+            // MUI sets a competing dark background at higher specificity via
+            // applyStyles; match it so the bar follows the shell in dark.
+            ...theme.applyStyles("dark", {
+              backgroundColor: SHELL_DARK,
+            }),
+          };
+        },
+      },
+    },
+    MuiDrawer: {
+      styleOverrides: {
+        // Override MUI's lighter dark elevation overlay so drawers match the chrome.
+        paper: ({ theme }) => ({
+          ...theme.applyStyles("dark", {
+            backgroundColor: SHELL_DARK,
+            backgroundImage: "none",
+          }),
+        }),
+      },
+    },
   },
-} as const;
+} satisfies ThemeOptions;
 
 const ltrTheme = createTheme({ ...themeOptions, direction: "ltr" });
 const rtlTheme = createTheme({ ...themeOptions, direction: "rtl" });
@@ -55,6 +94,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     <CacheProvider value={isRtl ? rtlCache : ltrCache}>
       <MUIThemeProvider theme={isRtl ? rtlTheme : ltrTheme}>
         <CssBaseline />
+        <ThemeColorMeta />
         {children}
       </MUIThemeProvider>
     </CacheProvider>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,13 +3,31 @@ import babel from "@rolldown/plugin-babel";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import { playwright } from "@vitest/browser-playwright";
 import path from "node:path";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
 import { coverageConfigDefaults } from "vitest/config";
+import {
+  CONTENT_DARK,
+  CONTENT_LIGHT,
+  SHELL_DARK,
+  SHELL_LIGHT,
+} from "./src/shared/theme/theme-colors";
+
+// Share theme-colors.ts with index.html's static styles instead of duplicating hex.
+const themeColorHtmlPlugin: Plugin = {
+  name: "theme-color-html",
+  transformIndexHtml: (html) =>
+    html
+      .replaceAll("__SHELL_LIGHT__", SHELL_LIGHT)
+      .replaceAll("__SHELL_DARK__", SHELL_DARK)
+      .replaceAll("__CONTENT_LIGHT__", CONTENT_LIGHT)
+      .replaceAll("__CONTENT_DARK__", CONTENT_DARK),
+};
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
+    themeColorHtmlPlugin,
     react(),
     babel({ presets: [reactCompilerPreset()] }),
     paraglideVitePlugin({
@@ -27,8 +45,8 @@ export default defineConfig({
           "AAC Board AI helps people who can't speak communicate naturally with Built-in AI — proofreading, rephrasing, and translating safely on their device.",
         start_url: "/",
         display: "standalone",
-        theme_color: "#222222",
-        background_color: "#222222",
+        theme_color: SHELL_DARK,
+        background_color: SHELL_DARK,
         icons: [
           {
             src: "pwa-192x192.png",


### PR DESCRIPTION
## What

Gives the browser chrome (Safari status bar, Android address bar, installed PWA) a single source of truth and makes it follow the app theme — a light surface in light mode, charcoal in dark — with the AppBar and drawers matching.

## How

- **[theme-colors.ts](src/shared/theme/theme-colors.ts)** — four values recolor the whole app: `SHELL_*` (bars + chrome) and `CONTENT_*` (reading surface).
- **Safari 26** ignores `theme-color` and samples `<body>`. So `<body>` is painted from `background.default` (the SHELL color); the reading surface sits on `#root`. Both are set statically in `index.html` (injected from `theme-colors.ts` at build) so the first paint is correct before MUI's JS runs.
- **AppBar / Drawer** use `applyStyles("dark")` to win over MUI's higher-specificity dark-surface rule.
- **`theme-color` meta** is synced to the active scheme via **React 19 document metadata**, so Android Chrome tracks the manual light/dark toggle (a static media-scoped tag would follow the OS instead).

## Notes

- Verified on iPhone 16 Pro / iOS 26 (Safari chrome follows the theme, light + dark) and via the full test suite (314 passing), lint, and production build.
- A sticky-AppBar approach was tested and rejected: in this non-scrolling layout Safari samples `<body>`, not the sticky bar.
- Known minor edge: a manually-chosen mode that disagrees with the OS can flash the OS color for one frame before MUI's class lands (would need a pre-React inline script to fully close).

Closes #364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
