### PR TITLE
refactor(theme): trim redundant comments in theme-provider

### DIFF
--- a/src/shared/theme/theme-provider.tsx
+++ b/src/shared/theme/theme-provider.tsx
@@ -64,6 +64,7 @@ const themeOptions = {
             // applyStyles; match it so the bar follows the shell in dark.
             ...theme.applyStyles("dark", {
               backgroundColor: SHELL_DARK,
+              borderBottom: "none",
             }),
           };
         },

--- a/src/shared/theme/theme-provider.tsx
+++ b/src/shared/theme/theme-provider.tsx
@@ -28,9 +28,6 @@ const themeOptions = {
     colorSchemeSelector: "class",
   },
   colorSchemes: {
-    // Safari 26 samples <body>, which CssBaseline paints from background.default —
-    // so the page default is the chrome color; the reading surface is #root, not
-    // a palette surface.
     light: { palette: { background: { default: SHELL_LIGHT } } },
     dark: { palette: { background: { default: SHELL_DARK } } },
   },
@@ -60,8 +57,7 @@ const themeOptions = {
             color: palette.text.primary,
             backgroundImage: "none",
             borderBottom: `1px solid ${palette.divider}`,
-            // MUI sets a competing dark background at higher specificity via
-            // applyStyles; match it so the bar follows the shell in dark.
+            // applyStyles beats MUI's higher-specificity dark background; a plain value loses.
             ...theme.applyStyles("dark", {
               backgroundColor: SHELL_DARK,
               borderBottom: "none",
@@ -72,7 +68,6 @@ const themeOptions = {
     },
     MuiDrawer: {
       styleOverrides: {
-        // Override MUI's lighter dark elevation overlay so drawers match the chrome.
         paper: ({ theme }) => ({
           ...theme.applyStyles("dark", {
             backgroundColor: SHELL_DARK,

--- a/src/shared/theme/theme-provider.tsx
+++ b/src/shared/theme/theme-provider.tsx
@@ -57,10 +57,8 @@ const themeOptions = {
             color: palette.text.primary,
             backgroundImage: "none",
             borderBottom: `1px solid ${palette.divider}`,
-            // applyStyles beats MUI's higher-specificity dark background; a plain value loses.
             ...theme.applyStyles("dark", {
               backgroundColor: SHELL_DARK,
-              borderBottom: "none",
             }),
           };
         },


### PR DESCRIPTION
## What

Removes three redundant comments from `theme-provider.tsx` — the `colorSchemes`, AppBar `applyStyles`, and `Drawer` notes that either restated the code or duplicated the explanation already in `theme-colors.ts`.

No behavior change: the AppBar border remains `1px solid ${palette.divider}` in both modes (the MUI theme divider token, consistent with every `<Divider>` and `<hr>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
