### PR TITLE
docs: center README footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,6 @@ While I'm thrilled if you find this code useful, this repository serves as my pe
 
 ---
 
-<footer align="center">
+<div align="center">
   <small>Designed by a Human. Assembled by AI.</small>
-</footer>
+</div>


### PR DESCRIPTION
GitHub ignores `align` on `<footer>`, so the footer rendered left-aligned. Switched to `<div align="center">` so it actually centers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)