### PR TITLE
refactor(layout): default PageContainer maxWidth to sm

### DIFF
--- a/src/app/layouts/page-container.tsx
+++ b/src/app/layouts/page-container.tsx
@@ -8,7 +8,7 @@ export interface PageContainerProps {
 
 export function PageContainer({
   children,
-  maxWidth = "md",
+  maxWidth = "sm",
 }: PageContainerProps) {
   return (
     <Container

--- a/src/pages/about-page.tsx
+++ b/src/pages/about-page.tsx
@@ -10,7 +10,7 @@ import { ExternalLink } from "@shared/components/external-link";
 
 export const Component = function AboutPage() {
   return (
-    <PageContainer maxWidth="sm">
+    <PageContainer>
       <PageTitle>{m.aboutHeading()}</PageTitle>
 
       <Stack spacing={{ xs: 3, sm: 4 }}>


### PR DESCRIPTION
Both `PageContainer` consumers (library and about pages) used `maxWidth="sm"`, so make `sm` the default and drop the now-redundant explicit props.

🤖 Generated with [Claude Code](https://claude.com/claude-code)