### PR TITLE
fix(a11y): hide decorative backspace progress ring from a11y tree

### DIFF
--- a/src/features/board/message/backspace-button.tsx
+++ b/src/features/board/message/backspace-button.tsx
@@ -62,6 +62,7 @@ export function BackspaceButton({
         </IconButton>
 
         <StyledCircularProgress
+          aria-hidden
           variant="determinate"
           value={progress}
           active={progress > 0}


### PR DESCRIPTION
## Summary
The long-press progress ring on the backspace button renders `role="progressbar"` with no accessible name, failing axe's `aria-required-attr` check.

The ring is purely visual feedback for the long-press fill — the actual action is already exposed via the `IconButton`'s `aria-label`. Marking it `aria-hidden` removes the unnamed progressbar from the accessibility tree entirely.

## Testing
- `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)