### PR TITLE
chore(html): drop static title in favor of dynamic PageTitle

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
 
-    <title>AAC Board AI</title>
     <meta
       name="description"
       content="AAC Board AI helps people who can't speak communicate naturally with Built-in AI — proofreading, rephrasing, and translating safely on their device."


### PR DESCRIPTION
## Summary
The document title is set per-route by the `<title>` element in [`PageTitle`](src/app/layouts/page-title.tsx), making the static `<title>` in index.html redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)