### PR TITLE
fix(suggestions): clear stale suggestions when the message changes

### DIFF
--- a/src/features/board/suggestions/use-suggestions.test.ts
+++ b/src/features/board/suggestions/use-suggestions.test.ts
@@ -6,7 +6,31 @@ import {
 } from "@shared/testing/built-in-ai";
 import { describe, expect, test, vi } from "vitest";
 import { renderHook } from "vitest-browser-react";
-import { useSuggestions } from "./use-suggestions";
+import { phrasesFor, useSuggestions } from "./use-suggestions";
+
+describe("phrasesFor", () => {
+  test("returns the phrases when they were generated for the current text", () => {
+    expect(
+      phrasesFor("want eat", {
+        forText: "want eat",
+        phrases: ["I want to eat."],
+      }),
+    ).toEqual(["I want to eat."]);
+  });
+
+  test("returns empty once the text has moved on from what was generated", () => {
+    expect(
+      phrasesFor("want eat now", {
+        forText: "want eat",
+        phrases: ["I want to eat."],
+      }),
+    ).toEqual([]);
+  });
+
+  test("returns empty before anything has been generated", () => {
+    expect(phrasesFor("want eat", null)).toEqual([]);
+  });
+});
 
 describe("useSuggestions", () => {
   test("reports unsupported and stays empty when no Built-in AI is available", async () => {
@@ -149,5 +173,33 @@ describe("useSuggestions", () => {
     await vi.waitFor(() => {
       expect(result.current.phrases).toEqual(["corrected new"]);
     });
+  });
+
+  test("clears stale suggestions immediately when the text changes, before new ones resolve", async () => {
+    const resolvers = new Map<string, (result: ProofreadResult) => void>();
+    stubProofreader(
+      (input) =>
+        new Promise<ProofreadResult>((resolve) => {
+          resolvers.set(input, resolve);
+        }),
+    );
+    stubBuiltInAIUnsupported("Rewriter");
+
+    const { result, rerender } = await renderHook(
+      ({ text }: { text: string } = { text: "old" }) => useSuggestions(text),
+      { initialProps: { text: "old" } },
+    );
+
+    await vi.waitFor(() => {
+      expect(resolvers.has("old")).toBe(true);
+    });
+    resolvers.get("old")?.(makeProofreadResult("corrected old"));
+    await vi.waitFor(() => {
+      expect(result.current.phrases).toEqual(["corrected old"]);
+    });
+
+    // Changing the message must drop the prior suggestions even while the next request is in flight.
+    await rerender({ text: "new" });
+    expect(result.current.phrases).toEqual([]);
   });
 });

--- a/src/features/board/suggestions/use-suggestions.ts
+++ b/src/features/board/suggestions/use-suggestions.ts
@@ -42,7 +42,6 @@ interface SuggestionEngines {
   rewrite?: RewriterHookReturn["rewrite"];
 }
 
-// Runs whichever engines are ready; an absent engine simply contributes nothing.
 async function generateSuggestions(
   text: string,
   { proofread, rewrite }: SuggestionEngines,
@@ -58,7 +57,7 @@ async function generateSuggestions(
   );
 }
 
-export interface GeneratedSuggestions {
+interface GeneratedSuggestions {
   forText: string;
   phrases: string[];
 }
@@ -92,17 +91,21 @@ export function useSuggestions(text: string): UseSuggestionsReturn {
   const [generated, setGenerated] = useState<GeneratedSuggestions | null>(null);
 
   useEffect(() => {
-    if (!isProofreaderReady && !isRewriterReady) {
+    if (!text.trim()) {
       return;
     }
 
-    const controller = new AbortController();
-    const { signal } = controller;
+    if (!isProofreaderReady && !isRewriterReady) {
+      return;
+    }
 
     const engines: SuggestionEngines = {
       proofread: isProofreaderReady ? proofread : undefined,
       rewrite: isRewriterReady ? rewrite : undefined,
     };
+
+    const controller = new AbortController();
+    const { signal } = controller;
 
     void (async () => {
       try {
@@ -112,7 +115,7 @@ export function useSuggestions(text: string): UseSuggestionsReturn {
           setGenerated({ forText: text, phrases });
         }
       } catch {
-        // Aborted (message changed) or engine error: the prior result stays tagged to its old text and is gated out by phrasesFor.
+        // Abort or engine error: keep the prior result as-is — phrasesFor surfaces it only while its text still matches.
       }
     })();
 

--- a/src/features/board/suggestions/use-suggestions.ts
+++ b/src/features/board/suggestions/use-suggestions.ts
@@ -1,5 +1,10 @@
 import { useAISharedContext } from "@shared/hooks/use-ai-shared-context";
-import { useProofreader, useRewriter } from "@shayc/react-built-in-ai";
+import {
+  type ProofreaderHookReturn,
+  type RewriterHookReturn,
+  useProofreader,
+  useRewriter,
+} from "@shayc/react-built-in-ai";
 import { useEffect, useState } from "react";
 import type { SuggestionTone } from "./types";
 
@@ -32,6 +37,39 @@ function cleanSuggestions(
   return [...cleaned];
 }
 
+interface SuggestionEngines {
+  proofread?: ProofreaderHookReturn["proofread"];
+  rewrite?: RewriterHookReturn["rewrite"];
+}
+
+// Runs whichever engines are ready; an absent engine simply contributes nothing.
+async function generateSuggestions(
+  text: string,
+  { proofread, rewrite }: SuggestionEngines,
+  signal: AbortSignal,
+): Promise<string[]> {
+  const [proofreadResult, rewritten] = await Promise.all([
+    proofread?.(text, { signal }),
+    rewrite?.(text, { signal }),
+  ]);
+
+  return cleanSuggestions([proofreadResult?.correctedInput, rewritten]).filter(
+    (suggestion) => suggestion !== text,
+  );
+}
+
+export interface GeneratedSuggestions {
+  forText: string;
+  phrases: string[];
+}
+
+export function phrasesFor(
+  text: string,
+  generated: GeneratedSuggestions | null,
+): string[] {
+  return generated?.forText === text ? generated.phrases : [];
+}
+
 export function useSuggestions(text: string): UseSuggestionsReturn {
   const [sharedContext] = useAISharedContext();
   const [tone, setTone] = useState<SuggestionTone>("as-is");
@@ -51,7 +89,7 @@ export function useSuggestions(text: string): UseSuggestionsReturn {
   const isProofreaderReady = proofreaderStatus === "ready";
   const isRewriterReady = rewriterStatus === "ready";
 
-  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [generated, setGenerated] = useState<GeneratedSuggestions | null>(null);
 
   useEffect(() => {
     if (!isProofreaderReady && !isRewriterReady) {
@@ -61,35 +99,29 @@ export function useSuggestions(text: string): UseSuggestionsReturn {
     const controller = new AbortController();
     const { signal } = controller;
 
-    const generateSuggestions = async () => {
-      try {
-        const [proofreadResult, rewritten] = await Promise.all([
-          isProofreaderReady ? proofread(text, { signal }) : undefined,
-          isRewriterReady ? rewrite(text, { signal }) : undefined,
-        ]);
-
-        if (signal.aborted) {
-          return;
-        }
-
-        setSuggestions(
-          cleanSuggestions([proofreadResult?.correctedInput, rewritten]).filter(
-            (suggestion) => suggestion !== text,
-          ),
-        );
-      } catch {
-        // Suggestion failures (engine error, or abort from cleanup) leave the prior suggestions in place.
-      }
+    const engines: SuggestionEngines = {
+      proofread: isProofreaderReady ? proofread : undefined,
+      rewrite: isRewriterReady ? rewrite : undefined,
     };
 
-    void generateSuggestions();
+    void (async () => {
+      try {
+        const phrases = await generateSuggestions(text, engines, signal);
+
+        if (!signal.aborted) {
+          setGenerated({ forText: text, phrases });
+        }
+      } catch {
+        // Aborted (message changed) or engine error: the prior result stays tagged to its old text and is gated out by phrasesFor.
+      }
+    })();
 
     return () => controller.abort();
   }, [text, isProofreaderReady, isRewriterReady, proofread, rewrite]);
 
   return {
     isSupported,
-    phrases: suggestions,
+    phrases: phrasesFor(text, generated),
     tone,
     setTone,
   };


### PR DESCRIPTION
## Problem

The suggestion bar kept showing **stale** suggestions after the message bar changed. `useSuggestions` only replaced its phrases once the next `proofread`/`rewrite` call resolved, so between a message change and the new result arriving, the bar displayed phrases generated for the *previous* message. A user could tap one that no longer matches the current parts — and on engine error/abort, the stale list lingered indefinitely.

## Fix

Tag each generated result with the text it was produced for (`{ forText, phrases }`) and gate it during render via `phrasesFor(text, generated)` — a result is surfaced only while `forText` still matches the current message.

Because the gate is a **render derivation** rather than a `setState` in the effect, clearing is:
- **instant** — no stale frame; the gate is evaluated in the same render the message changes
- **effect-free** — no extra `setSuggestions([])` (which the `react-hooks` rule flags as a cascading-render anti-pattern)
- **robust** — clears even when the engines aren't `ready` (e.g. the rewriter re-provisioning after a tone/shared-context change), a path that an effect-based clear would skip

## Refactor (same change)

- Extracted a pure `generateSuggestions(text, engines, signal)` producer.
- Derived `SuggestionEngines` from the library's `ProofreaderHookReturn`/`RewriterHookReturn` so the engine types track the lib (no hand-written signatures).
- `null` initial state instead of an empty-string sentinel.

## Tests

- Added a hook test: suggestions clear immediately on message change, before the next result resolves.
- Added direct unit tests for `phrasesFor` (match / moved-on / not-yet-generated).
- 14/14 pass; lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)