### PR TITLE
perf(suggestions): surface each engine's result as it resolves

### DIFF
--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -95,6 +95,7 @@ export function BoardViewer({ board }: BoardViewerProps) {
           <SuggestionBar
             suggestions={suggestions.phrases}
             tone={suggestions.tone}
+            canChangeTone={suggestions.isRewriterSupported}
             onToneChange={suggestions.setTone}
             onSuggestionClick={message.setFromText}
           />

--- a/src/features/board/suggestions/suggestion-bar.test.tsx
+++ b/src/features/board/suggestions/suggestion-bar.test.tsx
@@ -15,7 +15,12 @@ describe("SuggestionBar", () => {
     const suggestions = ["Hello", "How are you?", "Thank you"];
 
     const screen = await render(
-      <SuggestionBar suggestions={suggestions} tone="as-is" {...handlers} />,
+      <SuggestionBar
+        suggestions={suggestions}
+        tone="as-is"
+        canChangeTone
+        {...handlers}
+      />,
     );
 
     for (const suggestion of suggestions) {
@@ -30,7 +35,12 @@ describe("SuggestionBar", () => {
     const suggestions = ["Hello", "Goodbye"];
 
     const screen = await render(
-      <SuggestionBar suggestions={suggestions} tone="as-is" {...handlers} />,
+      <SuggestionBar
+        suggestions={suggestions}
+        tone="as-is"
+        canChangeTone
+        {...handlers}
+      />,
     );
 
     const firstChip = screen.getByRole("button", { name: "Hello" });
@@ -44,5 +54,39 @@ describe("SuggestionBar", () => {
 
     expect(handlers.onSuggestionClick).toHaveBeenCalledWith("Goodbye");
     expect(handlers.onSuggestionClick).toHaveBeenCalledTimes(2);
+  });
+
+  test("shows the tone selector when tone can be changed", async () => {
+    const handlers = createHandlers();
+
+    const screen = await render(
+      <SuggestionBar
+        suggestions={["Hello"]}
+        tone="as-is"
+        canChangeTone
+        {...handlers}
+      />,
+    );
+
+    await expect
+      .element(screen.getByRole("button", { name: "direct tone" }))
+      .toBeVisible();
+  });
+
+  test("hides the tone selector when tone cannot be changed", async () => {
+    const handlers = createHandlers();
+
+    const screen = await render(
+      <SuggestionBar
+        suggestions={["Hello"]}
+        tone="as-is"
+        canChangeTone={false}
+        {...handlers}
+      />,
+    );
+
+    await expect
+      .element(screen.getByRole("button", { name: "direct tone" }))
+      .not.toBeInTheDocument();
   });
 });

--- a/src/features/board/suggestions/suggestion-bar.tsx
+++ b/src/features/board/suggestions/suggestion-bar.tsx
@@ -7,6 +7,7 @@ import type { SuggestionTone } from "./types";
 export interface SuggestionBarProps {
   suggestions: string[];
   tone: SuggestionTone;
+  canChangeTone: boolean;
   onToneChange: (tone: SuggestionTone) => void;
   onSuggestionClick: (suggestion: string) => void;
 }
@@ -14,6 +15,7 @@ export interface SuggestionBarProps {
 export function SuggestionBar({
   suggestions,
   tone,
+  canChangeTone,
   onToneChange,
   onSuggestionClick,
 }: SuggestionBarProps) {
@@ -39,7 +41,7 @@ export function SuggestionBar({
         ))}
       </Box>
 
-      <ToneSelector tone={tone} onChange={onToneChange} />
+      {canChangeTone && <ToneSelector tone={tone} onChange={onToneChange} />}
     </Stack>
   );
 }

--- a/src/features/board/suggestions/use-suggestions.test.ts
+++ b/src/features/board/suggestions/use-suggestions.test.ts
@@ -45,7 +45,7 @@ describe("useSuggestions", () => {
     expect(result.current.phrases).toEqual([]);
   });
 
-  test("reports supported when only one capability is available", async () => {
+  test("reports per-engine support when only one capability is available", async () => {
     stubProofreader();
     stubBuiltInAIUnsupported("Rewriter");
 
@@ -53,6 +53,8 @@ describe("useSuggestions", () => {
 
     await vi.waitFor(() => {
       expect(result.current.isSupported).toBe(true);
+      expect(result.current.isProofreaderSupported).toBe(true);
+      expect(result.current.isRewriterSupported).toBe(false);
     });
   });
 

--- a/src/features/board/suggestions/use-suggestions.test.ts
+++ b/src/features/board/suggestions/use-suggestions.test.ts
@@ -9,20 +9,21 @@ import { renderHook } from "vitest-browser-react";
 import { phrasesFor, useSuggestions } from "./use-suggestions";
 
 describe("phrasesFor", () => {
-  test("returns the phrases when they were generated for the current text", () => {
+  test("derives the cleaned phrases from each engine slot for the current text", () => {
     expect(
       phrasesFor("want eat", {
         forText: "want eat",
-        phrases: ["I want to eat."],
+        corrected: "I want to eat.",
+        rewritten: "I would like to eat.",
       }),
-    ).toEqual(["I want to eat."]);
+    ).toEqual(["I want to eat.", "I would like to eat."]);
   });
 
   test("returns empty once the text has moved on from what was generated", () => {
     expect(
       phrasesFor("want eat now", {
         forText: "want eat",
-        phrases: ["I want to eat."],
+        corrected: "I want to eat.",
       }),
     ).toEqual([]);
   });

--- a/src/features/board/suggestions/use-suggestions.ts
+++ b/src/features/board/suggestions/use-suggestions.ts
@@ -5,6 +5,8 @@ import type { SuggestionTone } from "./types";
 
 export interface UseSuggestionsReturn {
   isSupported: boolean;
+  isProofreaderSupported: boolean;
+  isRewriterSupported: boolean;
   phrases: string[];
   tone: SuggestionTone;
   setTone: (tone: SuggestionTone) => void;
@@ -120,6 +122,8 @@ export function useSuggestions(text: string): UseSuggestionsReturn {
 
   return {
     isSupported,
+    isProofreaderSupported,
+    isRewriterSupported,
     phrases: phrasesFor(text, generated),
     tone,
     setTone,

--- a/src/features/board/suggestions/use-suggestions.ts
+++ b/src/features/board/suggestions/use-suggestions.ts
@@ -1,10 +1,5 @@
 import { useAISharedContext } from "@shared/hooks/use-ai-shared-context";
-import {
-  type ProofreaderHookReturn,
-  type RewriterHookReturn,
-  useProofreader,
-  useRewriter,
-} from "@shayc/react-built-in-ai";
+import { useProofreader, useRewriter } from "@shayc/react-built-in-ai";
 import { useEffect, useState } from "react";
 import type { SuggestionTone } from "./types";
 
@@ -37,36 +32,23 @@ function cleanSuggestions(
   return [...cleaned];
 }
 
-interface SuggestionEngines {
-  proofread?: ProofreaderHookReturn["proofread"];
-  rewrite?: RewriterHookReturn["rewrite"];
-}
-
-async function generateSuggestions(
-  text: string,
-  { proofread, rewrite }: SuggestionEngines,
-  signal: AbortSignal,
-): Promise<string[]> {
-  const [proofreadResult, rewritten] = await Promise.all([
-    proofread?.(text, { signal }),
-    rewrite?.(text, { signal }),
-  ]);
-
-  return cleanSuggestions([proofreadResult?.correctedInput, rewritten]).filter(
-    (suggestion) => suggestion !== text,
-  );
-}
-
 interface GeneratedSuggestions {
   forText: string;
-  phrases: string[];
+  corrected?: string;
+  rewritten?: string;
 }
 
 export function phrasesFor(
   text: string,
   generated: GeneratedSuggestions | null,
 ): string[] {
-  return generated?.forText === text ? generated.phrases : [];
+  if (generated?.forText !== text) {
+    return [];
+  }
+
+  return cleanSuggestions([generated.corrected, generated.rewritten]).filter(
+    (suggestion) => suggestion !== text,
+  );
 }
 
 export function useSuggestions(text: string): UseSuggestionsReturn {
@@ -99,25 +81,39 @@ export function useSuggestions(text: string): UseSuggestionsReturn {
       return;
     }
 
-    const engines: SuggestionEngines = {
-      proofread: isProofreaderReady ? proofread : undefined,
-      rewrite: isRewriterReady ? rewrite : undefined,
-    };
-
     const controller = new AbortController();
     const { signal } = controller;
 
-    void (async () => {
+    const merge = async (pending: Promise<Partial<GeneratedSuggestions>>) => {
       try {
-        const phrases = await generateSuggestions(text, engines, signal);
-
-        if (!signal.aborted) {
-          setGenerated({ forText: text, phrases });
+        const patch = await pending;
+        if (signal.aborted) {
+          return;
         }
+
+        setGenerated((prev) => ({
+          ...(prev?.forText === text ? prev : undefined),
+          forText: text,
+          ...patch,
+        }));
       } catch {
-        // Abort or engine error: keep the prior result as-is — phrasesFor surfaces it only while its text still matches.
+        // Ignore aborts and engine errors; the prior suggestions stay.
       }
-    })();
+    };
+
+    if (isProofreaderReady) {
+      void merge(
+        proofread(text, { signal }).then((result) => ({
+          corrected: result.correctedInput,
+        })),
+      );
+    }
+
+    if (isRewriterReady) {
+      void merge(
+        rewrite(text, { signal }).then((rewritten) => ({ rewritten })),
+      );
+    }
 
     return () => controller.abort();
   }, [text, isProofreaderReady, isRewriterReady, proofread, rewrite]);


### PR DESCRIPTION
## Summary

Two related improvements to the board suggestion bar:

- **Incremental results** — each engine (Proofreader, Rewriter) now surfaces its suggestion as soon as it resolves, instead of awaiting both via `Promise.all`. The faster engine no longer waits on the slower one. `GeneratedSuggestions` holds per-engine slots (`corrected`/`rewritten`) merged independently, with stale results discarded by text identity.
- **Tone selector gating** — tone is a Rewriter-only parameter, so the selector was dead UI whenever only the Proofreader was supported. `useSuggestions` now exposes per-engine support (`isProofreaderSupported`/`isRewriterSupported`) and the `ToneSelector` is shown only when the Rewriter is available (`canChangeTone`).

## Testing

- `npx vitest run src/features/board/suggestions/` — 23/23 green
- `npm run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)