### PR TITLE
refactor(suggestions): guard tone toggle values against drift

### DIFF
--- a/src/features/board/suggestions/tone-selector.tsx
+++ b/src/features/board/suggestions/tone-selector.tsx
@@ -12,6 +12,12 @@ export interface ToneSelectorProps {
   onChange: (tone: SuggestionTone) => void;
 }
 
+const TONE_VALUES = {
+  direct: "as-is",
+  professional: "more-formal",
+  friendly: "more-casual",
+} as const satisfies Record<string, SuggestionTone>;
+
 export function ToneSelector({ tone, onChange }: ToneSelectorProps) {
   const handleChange = (
     _event: React.MouseEvent<HTMLElement>,
@@ -31,19 +37,25 @@ export function ToneSelector({ tone, onChange }: ToneSelectorProps) {
       onChange={handleChange}
     >
       <Tooltip title={m.toneDirect()}>
-        <ToggleButton value="as-is" aria-label={m.toneDirect()}>
+        <ToggleButton value={TONE_VALUES.direct} aria-label={m.toneDirect()}>
           <ShortTextOutlinedIcon fontSize="medium" />
         </ToggleButton>
       </Tooltip>
 
       <Tooltip title={m.toneProfessional()}>
-        <ToggleButton value="more-formal" aria-label={m.toneProfessional()}>
+        <ToggleButton
+          value={TONE_VALUES.professional}
+          aria-label={m.toneProfessional()}
+        >
           <BusinessCenterOutlinedIcon fontSize="medium" />
         </ToggleButton>
       </Tooltip>
 
       <Tooltip title={m.toneFriendly()}>
-        <ToggleButton value="more-casual" aria-label={m.toneFriendly()}>
+        <ToggleButton
+          value={TONE_VALUES.friendly}
+          aria-label={m.toneFriendly()}
+        >
           <SentimentSatisfiedAltIcon fontSize="medium" />
         </ToggleButton>
       </Tooltip>


### PR DESCRIPTION
## Summary

MUI types `ToggleButton`'s `value` prop as `any` (`NonNullable<unknown>`), so the three tone literals in `ToneSelector` were never checked against `SuggestionTone` — a typo like `"more-formals"` would compile and silently break the toggle (its value would never match the `tone` state, and `onChange` would emit the bad string).

Hoist the values into a single `TONE_VALUES` constant typed with `satisfies Record<string, SuggestionTone>`, locking all three to `RewriterTone` in one place. The JSX stays explicit and compact (`value={TONE_VALUES.direct}`), and the keys mirror the existing `m.toneDirect`/`Professional`/`Friendly` vocabulary.

## Testing

- `tsc -b` — clean; a typo'd value now fails the build (`TS2820: ... Did you mean '"more-formal"'?`)
- `npm run lint` — clean
- `npx vitest run src/features/board/suggestions/` — green (no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)