### PR TITLE
fix(theme): seed the scheme class before first paint to kill the dark-mode flash

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,9 +15,13 @@
 
     <meta name="color-scheme" content="light dark" />
 
-    <!-- Injected from theme-colors.ts. Static so the Safari chrome (<body>) and
-         content surface (#root) are correct on first paint, before MUI's JS runs. -->
     <style>
+      html.light {
+        color-scheme: light;
+      }
+      html.dark {
+        color-scheme: dark;
+      }
       body {
         margin: 0;
         background-color: light-dark(__SHELL_LIGHT__, __SHELL_DARK__);
@@ -27,6 +31,18 @@
         background-color: light-dark(__CONTENT_LIGHT__, __CONTENT_DARK__);
       }
     </style>
+
+    <!-- Set the theme class before first paint so MUI adopts it without a flash. -->
+    <script>
+      {
+        const mode = localStorage.getItem("mui-mode") ?? "system";
+        const dark =
+          mode === "system"
+            ? matchMedia("(prefers-color-scheme: dark)").matches
+            : mode === "dark";
+        document.documentElement.classList.add(dark ? "dark" : "light");
+      }
+    </script>
 
     <link rel="icon" type="image/svg+xml" href="/board.svg" />
     <link rel="apple-touch-icon" href="/pwa-192x192.png" />

--- a/src/shared/theme/theme-colors.ts
+++ b/src/shared/theme/theme-colors.ts
@@ -1,5 +1,4 @@
-// Single source for the app's colors — edit here to recolor. The chrome follows
-// SHELL because Safari 26 samples <body>; other engines read the theme-color meta.
+// SHELL paints the bars and chrome; CONTENT is the reading surface.
 export const SHELL_LIGHT = "#ffffff";
 export const SHELL_DARK = "#222222";
 

--- a/src/shared/theme/theme-provider.tsx
+++ b/src/shared/theme/theme-provider.tsx
@@ -26,6 +26,8 @@ const rtlCache = createCache({
 const themeOptions = {
   cssVariables: {
     colorSchemeSelector: "class",
+    // index.html owns color-scheme; MUI only emits the palette vars.
+    disableCssColorScheme: true,
   },
   colorSchemes: {
     light: { palette: { background: { default: SHELL_LIGHT } } },
@@ -52,14 +54,12 @@ const themeOptions = {
         root: ({ theme }) => {
           const palette = theme.vars?.palette ?? theme.palette;
 
+          // Stock AppBar paints the primary color; repaint it as the shell surface.
           return {
-            backgroundColor: SHELL_LIGHT,
+            backgroundColor: palette.background.default,
             color: palette.text.primary,
             backgroundImage: "none",
             borderBottom: `1px solid ${palette.divider}`,
-            ...theme.applyStyles("dark", {
-              backgroundColor: SHELL_DARK,
-            }),
           };
         },
       },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
         start_url: "/",
         display: "standalone",
         theme_color: SHELL_DARK,
-        background_color: SHELL_DARK,
+        background_color: CONTENT_DARK,
         icons: [
           {
             src: "pwa-192x192.png",


### PR DESCRIPTION
## What

A user whose explicit light/dark choice disagreed with their OS saw a wrong-color full-viewport flash on every cold load, then a flip a render later. This makes the theme resolution coherent and kills the flash, while tidying the surrounding theme code.

## Why

"Which scheme is active" was decided by four uncoordinated mechanisms keyed to different signals — the static `index.html` `light-dark()` (OS), MUI's class + vars (the toggle), the `theme-color` meta (the toggle), and the frozen manifest. With no class on `<html>` before first paint, `light-dark()` fell back to the OS, so the first frame ignored the persisted choice.

This was a known, documented edge in #453 ("a manually-chosen mode that disagrees with the OS can flash the OS color for one frame… would need a pre-React inline script to fully close"). This is that script — done so the `<html>` class becomes the single piece of scheme state.

## How

- **`index.html`** — a tiny blocking script stamps `.light`/`.dark` from the same `mui-mode` key MUI reads; `html.light`/`html.dark` rules turn that class into the `color-scheme` that `light-dark()` and native controls resolve against. First paint follows the toggle, not the OS, and MUI's runtime adopts the same class with no flip.
- **`theme-provider.tsx`** — `disableCssColorScheme` so `index.html` solely owns `color-scheme` (clean split: static CSS owns `color-scheme`, MUI owns the palette vars). AppBar now derives its background from the SHELL token instead of re-hardcoding the hex pair.
- **`vite.config.ts`** — manifest `background_color` matches CONTENT (the `#root` surface the splash lands on) instead of the SHELL chrome.

## Notes

- One blocking inline script is irreducible here: in a CSR app a *persisted* override that must not flash is information only JS can deliver before paint. The script seeds the single state rather than running a parallel resolver.
- `ThemeColorMeta` is kept deliberately — it's the chrome-side of the toggle (Android/PWA address bar follows the user's choice, not the OS), which matters for the same accessibility reason the toggle exists.
- Full suite (320), lint, typecheck, and production build all pass; built `index.html` placeholders and manifest verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Follow-ups (deliberately out of scope)

- **CSP hash for the inline seed script.** The blocking script is irreducible (a CSR app can't deliver a persisted, no-flash override any other way), but under a strict Content-Security-Policy it needs a build-time `'sha256-…'` hash since a static build has no server to mint a nonce. Tracked for when CSP lands.
- **No-flash behavior is only manually verifiable.** The seed script runs at HTML parse; our browser tests are Vitest *component mode* (Playwright is only the Chromium provider) and never load `index.html`, so this behavior can't be asserted on the current stack — it's verified on the deploy preview. Automating it would require adopting a real e2e harness, a separate tooling decision rather than part of this PR.
- **Intentional manifest asymmetry.** `theme_color: SHELL_DARK` (chrome) vs `background_color: CONTENT_DARK` (the `#root` surface the splash lands on) is deliberate, not a typo — the token names carry it, so no inline comment.



