### PR TITLE
chore: readability cleanup + loading-state sizing/i18n fix

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,13 +45,6 @@ export default defineConfig([
       globals: globals.browser,
     },
     rules: {
-      "padding-line-between-statements": [
-        "error",
-        // A blank line precedes each return.
-        { blankLine: "always", prev: "*", next: "return" },
-        // A blank line follows each block (if/for/switch/…).
-        { blankLine: "always", prev: ["block", "block-like"], next: "*" },
-      ],
       "react-x/no-array-index-key": "off",
       "no-restricted-imports": restrictImports(),
       curly: "error",

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
         background-color: light-dark(__SHELL_LIGHT__, __SHELL_DARK__);
       }
       #root {
-        min-height: 100svh;
+        height: 100svh;
         background-color: light-dark(__CONTENT_LIGHT__, __CONTENT_DARK__);
       }
     </style>

--- a/index.html
+++ b/index.html
@@ -36,11 +36,11 @@
     <script>
       {
         const mode = localStorage.getItem("mui-mode") ?? "system";
-        const dark =
+        const isDark =
           mode === "system"
             ? matchMedia("(prefers-color-scheme: dark)").matches
             : mode === "dark";
-        document.documentElement.classList.add(dark ? "dark" : "light");
+        document.documentElement.classList.add(isDark ? "dark" : "light");
       }
     </script>
 

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "جارٍ التحميل...",
   "boardLoading": "جارٍ تحميل اللوحة...",
   "boardNotFound": "اللوحة غير موجودة",
   "boardGridLabel": "لوحة تواصل",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Зареждане...",
   "boardLoading": "Зареждане на дъската...",
   "boardNotFound": "Дъската не е намерена",
   "boardGridLabel": "Комуникационна дъска",

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "লোড হচ্ছে…",
   "boardLoading": "বোর্ড লোড হচ্ছে…",
   "boardNotFound": "বোর্ড পাওয়া যায়নি",
   "boardGridLabel": "যোগাযোগ বোর্ড",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Načítání...",
   "boardLoading": "Načítání tabulky...",
   "boardNotFound": "Tabulka nebyla nalezena",
   "boardGridLabel": "Komunikační tabulka",

--- a/messages/da.json
+++ b/messages/da.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Indlæser...",
   "boardLoading": "Indlæser tavle...",
   "boardNotFound": "Tavlen blev ikke fundet",
   "boardGridLabel": "Kommunikationstavle",

--- a/messages/de.json
+++ b/messages/de.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Wird geladen...",
   "boardLoading": "Tafel wird geladen...",
   "boardNotFound": "Tafel nicht gefunden",
   "boardGridLabel": "Kommunikationstafel",

--- a/messages/el.json
+++ b/messages/el.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Φόρτωση...",
   "boardLoading": "Φόρτωση πίνακα...",
   "boardNotFound": "Ο πίνακας δεν βρέθηκε",
   "boardGridLabel": "Πίνακας επικοινωνίας",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Loading...",
   "boardLoading": "Loading board...",
   "boardNotFound": "Board not found",
   "boardGridLabel": "Communication board",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Cargando...",
   "boardLoading": "Cargando tablero...",
   "boardNotFound": "Tablero no encontrado",
   "boardGridLabel": "Tablero de comunicación",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Ladataan...",
   "boardLoading": "Ladataan taulua...",
   "boardNotFound": "Taulua ei löytynyt",
   "boardGridLabel": "Kommunikointitaulu",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Chargement...",
   "boardLoading": "Chargement du tableau...",
   "boardNotFound": "Tableau introuvable",
   "boardGridLabel": "Tableau de communication",

--- a/messages/he.json
+++ b/messages/he.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "טעינה...",
   "boardLoading": "טעינת לוח...",
   "boardNotFound": "הלוח לא נמצא",
   "boardGridLabel": "לוח תקשורת",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "लोड हो रहा है…",
   "boardLoading": "बोर्ड लोड हो रहा है…",
   "boardNotFound": "बोर्ड नहीं मिला",
   "boardGridLabel": "संचार बोर्ड",

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Učitavanje...",
   "boardLoading": "Učitavanje ploče...",
   "boardNotFound": "Ploča nije pronađena",
   "boardGridLabel": "Komunikacijska ploča",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Betöltés...",
   "boardLoading": "Tábla betöltése...",
   "boardNotFound": "A tábla nem található",
   "boardGridLabel": "Kommunikációs tábla",

--- a/messages/id.json
+++ b/messages/id.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Memuat...",
   "boardLoading": "Memuat papan...",
   "boardNotFound": "Papan tidak ditemukan",
   "boardGridLabel": "Papan komunikasi",

--- a/messages/it.json
+++ b/messages/it.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Caricamento...",
   "boardLoading": "Caricamento tabella...",
   "boardNotFound": "Tabella non trovata",
   "boardGridLabel": "Tabella di comunicazione",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "読み込んでいます…",
   "boardLoading": "ボードを読み込んでいます…",
   "boardNotFound": "ボードが見つかりません",
   "boardGridLabel": "コミュニケーションボード",

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "ಲೋಡ್ ಆಗುತ್ತಿದೆ…",
   "boardLoading": "ಬೋರ್ಡ್ ಲೋಡ್ ಆಗುತ್ತಿದೆ…",
   "boardNotFound": "ಬೋರ್ಡ್ ಕಂಡುಬಂದಿಲ್ಲ",
   "boardGridLabel": "ಸಂವಹನ ಬೋರ್ಡ್",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "불러오는 중…",
   "boardLoading": "보드를 불러오는 중…",
   "boardNotFound": "보드를 찾을 수 없음",
   "boardGridLabel": "의사소통 보드",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Laden...",
   "boardLoading": "Bord laden...",
   "boardNotFound": "Bord niet gevonden",
   "boardGridLabel": "Communicatiebord",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Ładowanie...",
   "boardLoading": "Ładowanie tablicy...",
   "boardNotFound": "Nie znaleziono tablicy",
   "boardGridLabel": "Tablica komunikacyjna",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Carregando...",
   "boardLoading": "Carregando prancha...",
   "boardNotFound": "Prancha não encontrada",
   "boardGridLabel": "Prancha de comunicação",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Se încarcă...",
   "boardLoading": "Se încarcă tabla...",
   "boardNotFound": "Tabla nu a fost găsită",
   "boardGridLabel": "Tablă de comunicare",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Загрузка...",
   "boardLoading": "Загрузка доски...",
   "boardNotFound": "Доска не найдена",
   "boardGridLabel": "Коммуникационная доска",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Načítava sa...",
   "boardLoading": "Načítava sa tabuľka...",
   "boardNotFound": "Tabuľka sa nenašla",
   "boardGridLabel": "Komunikačná tabuľka",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Nalaganje...",
   "boardLoading": "Nalaganje table...",
   "boardNotFound": "Table ni mogoče najti",
   "boardGridLabel": "Komunikacijska tabla",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Laddar...",
   "boardLoading": "Laddar tavla...",
   "boardNotFound": "Tavlan hittades inte",
   "boardGridLabel": "Kommunikationstavla",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "ஏற்றப்படுகிறது…",
   "boardLoading": "பலகை ஏற்றப்படுகிறது…",
   "boardNotFound": "பலகை கிடைக்கவில்லை",
   "boardGridLabel": "தொடர்பு பலகை",

--- a/messages/te.json
+++ b/messages/te.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "లోడ్ అవుతోంది…",
   "boardLoading": "బోర్డు లోడ్ అవుతోంది…",
   "boardNotFound": "బోర్డు కనుగొనబడలేదు",
   "boardGridLabel": "సంభాషణ బోర్డు",

--- a/messages/th.json
+++ b/messages/th.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "กำลังโหลด...",
   "boardLoading": "กำลังโหลดบอร์ด...",
   "boardNotFound": "ไม่พบบอร์ด",
   "boardGridLabel": "บอร์ดสื่อสาร",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Yükleniyor...",
   "boardLoading": "Pano yükleniyor...",
   "boardNotFound": "Pano bulunamadı",
   "boardGridLabel": "İletişim panosu",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Завантаження...",
   "boardLoading": "Завантаження дошки...",
   "boardNotFound": "Дошку не знайдено",
   "boardGridLabel": "Комунікаційна дошка",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "Đang tải...",
   "boardLoading": "Đang tải bảng...",
   "boardNotFound": "Không tìm thấy bảng",
   "boardGridLabel": "Bảng giao tiếp",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "loading": "正在加载……",
   "boardLoading": "正在加载沟通板……",
   "boardNotFound": "未找到沟通板",
   "boardGridLabel": "沟通板",

--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -84,12 +84,12 @@ export function Grid<TItem extends { id: string }>({
   );
 }
 
-function buildGrid<T extends { id: string }>(
-  items: readonly T[],
+function buildGrid<TItem extends { id: string }>(
+  items: readonly TItem[],
   rows: number,
   columns: number,
   order?: (string | null)[][],
-): (T | undefined)[][] {
+): (TItem | undefined)[][] {
   if (order?.length) {
     const itemsById = new Map(items.map((item) => [item.id, item]));
 

--- a/src/features/board/storage/db.ts
+++ b/src/features/board/storage/db.ts
@@ -172,8 +172,6 @@ export async function listBoardSets(db: BoardsDB): Promise<BoardSetRecord[]> {
   const tx = db.transaction("boardSets", "readonly");
   const index = tx.store.index("byUpdatedAt");
 
-  // Manual cursor iteration is required to retrieve records in reverse chronological order;
-  // IDB's getAll() does not support a direction argument.
   const boardSets: BoardSetRecord[] = [];
   let cursor = await index.openCursor(undefined, "prev");
 
@@ -194,7 +192,6 @@ export async function deleteBoardSet(
   validateId(setId, "setId");
   const tx = db.transaction(["boards", "assets", "boardSets"], "readwrite");
 
-  // Three deletes share one transaction; tx.done commits them together.
   // The [] upper bound exploits IDB key ordering — arrays sort after strings,
   // so [setId, []] is the smallest key greater than every [setId, "..."].
   const setRange = IDBKeyRange.bound([setId], [setId, []]);

--- a/src/shared/audio/play-audio.test.ts
+++ b/src/shared/audio/play-audio.test.ts
@@ -2,8 +2,6 @@ import { stubAudio } from "@shared/testing/device-output";
 import { beforeEach, describe, expect, test } from "vitest";
 import { playAudio } from "./play-audio";
 
-// A play() that starts but never reaches "ended", so the clip stays in flight
-// until something supersedes or aborts it.
 function pendingPlayback(audio: ReturnType<typeof stubAudio>) {
   audio.play.mockImplementation(function (this: HTMLAudioElement) {
     queueMicrotask(() => this.dispatchEvent(new Event("play")));

--- a/src/shared/audio/play-audio.ts
+++ b/src/shared/audio/play-audio.ts
@@ -27,6 +27,7 @@ export function playAudio(
     audio.onended = null;
     audio.onerror = null;
     audio.pause();
+    signal?.removeEventListener("abort", stop);
 
     if (stopCurrent === stop) {
       stopCurrent = null;

--- a/src/shared/components/empty-state.tsx
+++ b/src/shared/components/empty-state.tsx
@@ -1,7 +1,7 @@
-import { StateLayout, type StateLayoutProps } from "./state-layout";
+import { StatusLayout, type StatusLayoutProps } from "./status-layout";
 
-export type EmptyStateProps = Omit<StateLayoutProps, "kind">;
+export type EmptyStateProps = Omit<StatusLayoutProps, "kind">;
 
 export function EmptyState(props: EmptyStateProps) {
-  return <StateLayout kind="empty" {...props} />;
+  return <StatusLayout kind="empty" {...props} />;
 }

--- a/src/shared/components/error-state.tsx
+++ b/src/shared/components/error-state.tsx
@@ -1,11 +1,11 @@
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutlineOutlined";
-import { StateLayout, type StateLayoutProps } from "./state-layout";
+import { StatusLayout, type StatusLayoutProps } from "./status-layout";
 
-export type ErrorStateProps = Omit<StateLayoutProps, "kind">;
+export type ErrorStateProps = Omit<StatusLayoutProps, "kind">;
 
 export function ErrorState({
   icon = <ErrorOutlineIcon />,
   ...props
 }: ErrorStateProps) {
-  return <StateLayout kind="error" icon={icon} {...props} />;
+  return <StatusLayout kind="error" icon={icon} {...props} />;
 }

--- a/src/shared/components/loading-state.tsx
+++ b/src/shared/components/loading-state.tsx
@@ -1,28 +1,27 @@
-import Box from "@mui/material/Box";
 import CircularProgress from "@mui/material/CircularProgress";
 import Fade from "@mui/material/Fade";
+import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
+import { m } from "@paraglide/messages.js";
 
 export interface LoadingStateProps {
   message?: string;
 }
 
-export function LoadingState({ message }: LoadingStateProps) {
+export function LoadingState({ message = m.loading() }: LoadingStateProps) {
   return (
     <Fade in timeout={400} style={{ transitionDelay: "500ms" }}>
-      <Box
+      <Stack
         sx={{
           height: "100%",
-          display: "flex",
-          flexDirection: "column",
           alignItems: "center",
           justifyContent: "center",
           gap: 2,
         }}
       >
         <CircularProgress />
-        {message && <Typography>{message}</Typography>}
-      </Box>
+        {message && <Typography color="text.secondary">{message}</Typography>}
+      </Stack>
     </Fade>
   );
 }

--- a/src/shared/components/status-layout.tsx
+++ b/src/shared/components/status-layout.tsx
@@ -3,21 +3,21 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import type { ReactNode } from "react";
 
-export interface StateLayoutProps {
+export interface StatusLayoutProps {
   kind: "empty" | "error";
+  icon?: ReactNode;
   title: string;
   description?: string;
-  icon?: ReactNode;
   action?: ReactNode;
 }
 
-export function StateLayout({
+export function StatusLayout({
   kind,
+  icon,
   title,
   description,
-  icon,
   action,
-}: StateLayoutProps) {
+}: StatusLayoutProps) {
   const iconColor = kind === "error" ? "error.main" : "text.disabled";
 
   return (

--- a/src/shared/speech/speech-store.cancellation.test.ts
+++ b/src/shared/speech/speech-store.cancellation.test.ts
@@ -44,6 +44,19 @@ describe("speak() under cancellation", () => {
     expect(cancelSpy).toHaveBeenCalled();
   });
 
+  test("stops reporting boundaries once the signal aborts", () => {
+    const controller = new AbortController();
+    const onBoundary = vi.fn();
+    void speak("good morning", { signal: controller.signal, onBoundary });
+
+    spokenUtterance?.onboundary?.({ charIndex: 0 } as SpeechSynthesisEvent);
+    expect(onBoundary).toHaveBeenCalledExactlyOnceWith(0);
+
+    controller.abort();
+    spokenUtterance?.onboundary?.({ charIndex: 5 } as SpeechSynthesisEvent);
+    expect(onBoundary).toHaveBeenCalledExactlyOnceWith(0);
+  });
+
   test.each(["canceled", "interrupted"] as const)(
     "resolves when a superseded utterance reports '%s'",
     async (error) => {
@@ -63,18 +76,5 @@ describe("speak() under cancellation", () => {
     } as SpeechSynthesisErrorEvent);
 
     await expect(promise).rejects.toThrow("synthesis-failed");
-  });
-
-  test("stops reporting boundaries once the signal aborts", () => {
-    const controller = new AbortController();
-    const onBoundary = vi.fn();
-    void speak("good morning", { signal: controller.signal, onBoundary });
-
-    spokenUtterance?.onboundary?.({ charIndex: 0 } as SpeechSynthesisEvent);
-    expect(onBoundary).toHaveBeenCalledExactlyOnceWith(0);
-
-    controller.abort();
-    spokenUtterance?.onboundary?.({ charIndex: 5 } as SpeechSynthesisEvent);
-    expect(onBoundary).toHaveBeenCalledExactlyOnceWith(0);
   });
 });

--- a/src/shared/speech/speech-store.cancellation.test.ts
+++ b/src/shared/speech/speech-store.cancellation.test.ts
@@ -8,9 +8,9 @@ import {
 } from "vitest";
 import { speak } from "./speech-store";
 
-// A live speechSynthesis is required here, so these tests live apart from the
-// no-API suite — that one needs the module first imported while the global is
-// stubbed away, which any import in the same file would defeat.
+// Kept separate from the no-API suite: that suite must import speech-store only
+// after stubbing speechSynthesis away, which a static import in a shared file
+// would defeat.
 describe("speak() under cancellation", () => {
   let speakSpy: MockInstance<SpeechSynthesis["speak"]>;
   let cancelSpy: MockInstance<SpeechSynthesis["cancel"]>;

--- a/src/shared/speech/speech-store.ts
+++ b/src/shared/speech/speech-store.ts
@@ -122,8 +122,6 @@ export function speak(
   const utterance = buildUtterance(text);
 
   if (onBoundary) {
-    // A boundary can arrive after the signal aborts; drop it so a stopped
-    // utterance can't keep reporting progress.
     utterance.onboundary = (event) => {
       if (!signal?.aborted) {
         onBoundary(event.charIndex);
@@ -133,9 +131,6 @@ export function speak(
 
   utterance.onend = () => resolve();
   utterance.onerror = (event) => {
-    // Aborting (and each new speak()) calls cancel(), which ends a superseded
-    // utterance as "canceled" (still queued) or "interrupted" (mid-speech) —
-    // both expected, so resolve rather than reject.
     if (event.error === "canceled" || event.error === "interrupted") {
       resolve();
     } else {

--- a/src/shared/testing/built-in-ai.ts
+++ b/src/shared/testing/built-in-ai.ts
@@ -1,12 +1,8 @@
 import { type Mock, vi } from "vitest";
 
-// Stubs the browser Built-in AI globals (Proofreader/Rewriter/Translator) that
-// @shayc/react-built-in-ai reads off globalThis. These APIs are absent in CI
-// Chromium and back a multi-gigabyte on-device model, so we replace them at the
-// global boundary and let the real library hooks and lifecycle run against a
-// fake model. availability() resolves "available", so the lifecycle provisions
-// silently (idle → ready) with no download or user-activation gate. Vitest's
-// `unstubGlobals` config restores the globals before each test.
+// Stubs the Built-in AI globals (Proofreader/Rewriter/Translator) that
+// @shayc/react-built-in-ai reads off globalThis. They're absent in CI Chromium,
+// so we fake them at the global boundary.
 
 type AINamespace = "Proofreader" | "Rewriter" | "Translator";
 

--- a/src/shared/testing/device-output.ts
+++ b/src/shared/testing/device-output.ts
@@ -1,8 +1,5 @@
 import { type MockInstance, vi } from "vitest";
 
-// Stubs fire onend/ended via microtask so awaited callers can settle in tests.
-// cancel/pause are no-op spies: suppress real side effects (a real pause fires onpause, flipping React state) and let tests assert the calls.
-
 export function stubSpeech(): {
   speak: MockInstance<SpeechSynthesis["speak"]>;
   cancel: MockInstance<SpeechSynthesis["cancel"]>;

--- a/src/shared/theme/theme-provider.tsx
+++ b/src/shared/theme/theme-provider.tsx
@@ -54,7 +54,6 @@ const themeOptions = {
         root: ({ theme }) => {
           const palette = theme.vars?.palette ?? theme.palette;
 
-          // Stock AppBar paints the primary color; repaint it as the shell surface.
           return {
             backgroundColor: palette.background.default,
             color: palette.text.primary,


### PR DESCRIPTION
## Summary

Readability/comment cleanup across components, audio, and speech, plus fixes to the app's loading state, a theme-script rename, and an ESLint deprecation cleanup.

## Changes

- **fix(loading)** — `#root` only had `min-height: 100svh`, so percentage heights couldn't resolve against it; `LoadingState`'s `height: 100%` collapsed to intrinsic size when rendered as the router `HydrateFallback` (directly into `#root`, before `AppShell` mounts). Switched to `height: 100svh` — a definite, viewport-anchored containing block matching `AppShell`. Also defaulted `LoadingState`'s message to a new translated `loading` key (all 35 locales, derived from each locale's existing `boardLoading` wording) so the fallback shows "Loading…" instead of a bare spinner.
- **refactor(theme)** — rename `dark` → `isDark` in the pre-paint scheme script (boolean reads better with the `is-` prefix and no longer shares a name with the `"dark"` class it toggles).
- **chore(eslint)** — drop the deprecated `padding-line-between-statements` rule (deprecated since ESLint 8.53.0, removed in 11). Not migrated to `@stylistic`; blank-line-before-`return` / after-block are no longer enforced.
- **refactor(components)** — rename `StateLayout` → `StatusLayout`.
- **chore(audio)** — detach abort listener on finish, drop test narration.
- **chore(review/comments)** — trim narration comments, group abort tests, align Grid generic.

## Notes for review

- The 34 non-English `loading` translations were derived from each locale's existing `boardLoading` term (stripped to the standalone form, ellipsis style preserved). High-confidence but not run through a formal translation flow — worth a glance if locale changes are normally gated.
- `src/paraglide` is gitignored and regenerated by the `prepare` compile step, so `m.loading` ships without staging generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)