### PR TITLE
refactor(settings): default FormControlLabel layout for highlight toggle

### DIFF
--- a/src/app/settings/playback-settings.tsx
+++ b/src/app/settings/playback-settings.tsx
@@ -11,15 +11,13 @@ export function PlaybackSettings() {
 
   return (
     <FormControlLabel
+      label={m.playbackHighlight()}
       control={
         <Switch
           checked={highlightActivePart}
           onChange={(event) => setHighlightActivePart(event.target.checked)}
         />
       }
-      label={m.playbackHighlight()}
-      labelPlacement="start"
-      sx={{ justifyContent: "space-between" }}
     />
   );
 }


### PR DESCRIPTION
Drop the custom `labelPlacement="start"` + `space-between` justification on the "Highlight while playing" toggle. It now uses MUI's default label-after-control placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)