### PR TITLE
fix(theme): restore AppBar dark background via applyStyles

### DIFF
--- a/src/shared/theme/theme-provider.tsx
+++ b/src/shared/theme/theme-provider.tsx
@@ -55,10 +55,13 @@ const themeOptions = {
           const palette = theme.vars?.palette ?? theme.palette;
 
           return {
-            backgroundColor: palette.background.default,
+            backgroundColor: SHELL_LIGHT,
             color: palette.text.primary,
             backgroundImage: "none",
             borderBottom: `1px solid ${palette.divider}`,
+            ...theme.applyStyles("dark", {
+              backgroundColor: SHELL_DARK,
+            }),
           };
         },
       },


### PR DESCRIPTION
## Problem

In dark mode the AppBar renders **darker than the shell** — it paints MUI's default dark surface (~`#121212`) instead of `SHELL_DARK` (`#222222`).

## Cause

#463 replaced the AppBar's `applyStyles("dark", { backgroundColor: SHELL_DARK })` with a plain `backgroundColor: palette.background.default`. The class-scoped `.dark &` selector that `applyStyles` generates was what out-specified MUI's built-in dark AppBar surface rule (documented in #453: *"AppBar/Drawer use applyStyles('dark') to win over MUI's dark-surface rule"*). The plain base override doesn't win that specificity battle, so MUI's darker surface shows through.

The Drawer kept its `applyStyles("dark", …)` and stayed correct — which is why **only the AppBar** regressed.

## Fix

Restore the class-scoped dark override on the AppBar so it matches the Drawer. No change to light mode or the #463 flash fix (which lives in `index.html` + `disableCssColorScheme` + the pre-paint `<html>` class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)