### PR TITLE
fix(import): random set ids + write boardSet record last

### DIFF
--- a/src/features/board/import/board-import.test.ts
+++ b/src/features/board/import/board-import.test.ts
@@ -12,7 +12,6 @@ import { writeBoardSetFiles } from "./board-import";
 const SAMPLE_BOARDS_DIR = "/src/shared/testing/sample-boards";
 const OBZ_FIXTURE = "lots-of-stuff.obz";
 const OBF_FIXTURE = "lots-of-stuff.obf";
-const IMPORTED_SET_ID = "lots-of-stuff";
 
 function assertDefined<T>(value: T | undefined | null): asserts value is T {
   expect(value).toBeDefined();
@@ -32,6 +31,14 @@ async function loadFixtureFile(name: string): Promise<File> {
   });
 }
 
+async function countBoards(setId: string): Promise<number> {
+  return withBoardsDB((db) => db.countFromIndex("boards", "bySetId", setId));
+}
+
+async function countAssets(setId: string): Promise<number> {
+  return withBoardsDB((db) => db.countFromIndex("assets", "bySetId", setId));
+}
+
 describe("writeBoardSetFiles", () => {
   beforeEach(async () => {
     await resetBoardsDB();
@@ -41,21 +48,19 @@ describe("writeBoardSetFiles", () => {
     const fixtureFile = await loadFixtureFile(OBF_FIXTURE);
     const board = await loadOBF(fixtureFile);
 
-    const importResults = await writeBoardSetFiles(fixtureFile);
+    const [result] = await writeBoardSetFiles(fixtureFile);
+    assertDefined(result);
+    const { setId } = result;
 
-    expect(importResults).toEqual([
-      {
-        setId: IMPORTED_SET_ID,
-        boardId: board.id,
-      },
-    ]);
+    expect(setId).toBeTruthy();
+    expect(result.boardId).toBe(board.id);
 
     await withBoardsDB(async (db) => {
       const boardSets = await listBoardSets(db);
 
       expect(boardSets).toHaveLength(1);
       expect(boardSets[0]).toMatchObject({
-        setId: IMPORTED_SET_ID,
+        setId,
         rootBoardId: board.id,
         boardCount: 1,
         name: board.name,
@@ -64,18 +69,14 @@ describe("writeBoardSetFiles", () => {
         gridColumns: board.grid.columns,
       });
 
-      const storedBoard = await getBoard(db, IMPORTED_SET_ID, board.id);
+      const storedBoard = await getBoard(db, setId, board.id);
       assertDefined(storedBoard);
 
       expect(storedBoard.name).toBe(board.name ?? board.id);
       expect(storedBoard.obf.buttons.length).toBe(board.buttons.length);
       expect(storedBoard.obf.grid).toEqual(board.grid);
 
-      const assetCount = await db.countFromIndex(
-        "assets",
-        "bySetId",
-        IMPORTED_SET_ID,
-      );
+      const assetCount = await db.countFromIndex("assets", "bySetId", setId);
       expect(assetCount).toBe(0);
     });
   });
@@ -102,21 +103,19 @@ describe("writeBoardSetFiles", () => {
     assertDefined(sampleAssetEntry);
     const [sampleAssetPath, sampleAssetBytes] = sampleAssetEntry;
 
-    const importResults = await writeBoardSetFiles(fixtureFile);
+    const [result] = await writeBoardSetFiles(fixtureFile);
+    assertDefined(result);
+    const { setId } = result;
 
-    expect(importResults).toEqual([
-      {
-        setId: IMPORTED_SET_ID,
-        boardId: rootBoardId,
-      },
-    ]);
+    expect(setId).toBeTruthy();
+    expect(result.boardId).toBe(rootBoardId);
 
     await withBoardsDB(async (db) => {
       const boardSets = await listBoardSets(db);
 
       expect(boardSets).toHaveLength(1);
       expect(boardSets[0]).toMatchObject({
-        setId: IMPORTED_SET_ID,
+        setId,
         rootBoardId,
         boardCount: archive.boards.size,
         name: archive.boards.get(rootBoardId)?.name,
@@ -126,17 +125,17 @@ describe("writeBoardSetFiles", () => {
       const storedBoardCount = await readTx
         .objectStore("boards")
         .index("bySetId")
-        .count(IMPORTED_SET_ID);
+        .count(setId);
       const storedAssetCount = await readTx
         .objectStore("assets")
         .index("bySetId")
-        .count(IMPORTED_SET_ID);
+        .count(setId);
       await readTx.done;
 
       expect(storedBoardCount).toBe(archive.boards.size);
       expect(storedAssetCount).toBe(assetEntries.length);
 
-      const storedRootBoard = await getBoard(db, IMPORTED_SET_ID, rootBoardId);
+      const storedRootBoard = await getBoard(db, setId, rootBoardId);
       assertDefined(storedRootBoard);
 
       const linkedButtons = storedRootBoard.obf.buttons.filter((button) =>
@@ -153,20 +152,69 @@ describe("writeBoardSetFiles", () => {
 
         const storedChildBoard = await getBoard(
           db,
-          IMPORTED_SET_ID,
+          setId,
           expectedChildBoardId,
         );
         expect(storedChildBoard).toBeDefined();
       }
 
-      const storedAsset = await getAssetBlob(
-        db,
-        IMPORTED_SET_ID,
-        sampleAssetPath,
-      );
+      const storedAsset = await getAssetBlob(db, setId, sampleAssetPath);
 
       expect(storedAsset).toBeInstanceOf(Blob);
       expect(storedAsset?.size).toBe(sampleAssetBytes.byteLength);
+    });
+  });
+
+  test("re-importing the same board creates a distinct set with a disambiguated name", async () => {
+    const fixtureFile = await loadFixtureFile(OBF_FIXTURE);
+    const board = await loadOBF(fixtureFile);
+    assertDefined(board.name);
+
+    const [first] = await writeBoardSetFiles(fixtureFile);
+    const [second] = await writeBoardSetFiles(fixtureFile);
+    assertDefined(first);
+    assertDefined(second);
+
+    // Identity comes from a random id, so the second import never overwrites
+    // the first — it lands as its own set the user can see and delete.
+    expect(second.setId).not.toBe(first.setId);
+
+    await withBoardsDB(async (db) => {
+      const boardSets = await listBoardSets(db);
+      const names = boardSets.map((set) => set.name).sort();
+
+      expect(boardSets).toHaveLength(2);
+      expect(names).toEqual([board.name, `${board.name} (2)`].sort());
+    });
+  });
+
+  test("a failed import leaves the existing library and stores unchanged", async () => {
+    const fixtureFile = await loadFixtureFile(OBZ_FIXTURE);
+    const [imported] = await writeBoardSetFiles(fixtureFile);
+    assertDefined(imported);
+
+    const boardsBefore = await countBoards(imported.setId);
+    const assetsBefore = await countAssets(imported.setId);
+
+    const corruptFile = new File(["this is not a board"], "broken.obf", {
+      type: "application/json",
+    });
+
+    await expect(writeBoardSetFiles(corruptFile)).rejects.toThrow();
+
+    // The boardSet record is written last, so a failed import surfaces nothing:
+    // no half-written set, and no orphaned boards/assets under a new id.
+    await withBoardsDB(async (db) => {
+      const boardSets = await listBoardSets(db);
+
+      expect(boardSets).toHaveLength(1);
+      expect(boardSets[0]?.setId).toBe(imported.setId);
+
+      const totalBoards = await db.count("boards");
+      const totalAssets = await db.count("assets");
+
+      expect(totalBoards).toBe(boardsBefore);
+      expect(totalAssets).toBe(assetsBefore);
     });
   });
 });

--- a/src/features/board/import/board-import.ts
+++ b/src/features/board/import/board-import.ts
@@ -1,5 +1,6 @@
 import { htmlToText } from "@shared/utils/html";
 import { normalizeLocale } from "@shared/utils/locale";
+import { randomId } from "@shared/utils/random-id";
 import { lookup } from "mrmime";
 import {
   loadOBF,
@@ -16,6 +17,7 @@ import type {
   UpsertBoardSetInput,
 } from "../storage/db";
 import {
+  listBoardSets,
   putAssets,
   putBoards,
   upsertBoardSet,
@@ -42,15 +44,20 @@ export async function writeBoardSetFiles(
   const fileList = Array.isArray(files) ? files : [files];
 
   return withBoardsDB(async (db) => {
+    // A board set's identity is a fresh random id, so re-importing never
+    // silently overwrites an unrelated set. Names can still collide, so we
+    // disambiguate display names against existing sets and earlier files in
+    // this batch (e.g. "Core" → "Core (2)").
+    const takenNames = new Set(
+      (await listBoardSets(db)).map((set) => set.name),
+    );
     const results: ImportResult[] = [];
 
     for (const file of fileList) {
-      const setId = deriveSetId(file.name);
-
       if (file.name.toLowerCase().endsWith(".obz")) {
-        results.push(await importOBZFile(db, file, setId));
+        results.push(await importOBZFile(db, file, takenNames));
       } else {
-        results.push(await importOBFFile(db, file, setId));
+        results.push(await importOBFFile(db, file, takenNames));
       }
     }
 
@@ -58,27 +65,50 @@ export async function writeBoardSetFiles(
   });
 }
 
+function reserveUniqueName(base: string, takenNames: Set<string>): string {
+  let name = base;
+  for (let suffix = 2; takenNames.has(name); suffix++) {
+    name = `${base} (${suffix})`;
+  }
+
+  takenNames.add(name);
+
+  return name;
+}
+
 async function importOBZFile(
   db: BoardsDB,
   file: File,
-  setId: string,
+  takenNames: Set<string>,
 ): Promise<ImportResult> {
+  const setId = randomId();
   const { manifest, boards, resources } = await loadOBZ(file);
   const boardPathToId = buildBoardPathIndex(manifest);
 
   const rootBoardId = resolveRootBoardId(manifest, boardPathToId);
   const rootBoard = boards.get(rootBoardId);
 
-  await upsertBoardSet(
-    db,
-    buildBoardSetInput(setId, rootBoard, rootBoardId, file.name),
-  );
-  await putBoards(db, setId, buildBoardRecords(boards, boardPathToId));
-
+  const boardRecords = buildBoardRecords(boards, boardPathToId);
   const assetRecords = buildAssetRecords(resources);
+  const name = reserveUniqueName(rootBoard?.name ?? file.name, takenNames);
+
+  // Write the boardSet record last: listBoardSets reads only that store, so a
+  // failure mid-import leaves nothing visible rather than a board whose
+  // pictograms never landed.
   if (assetRecords.length > 0) {
     await putAssets(db, setId, assetRecords);
   }
+  await putBoards(db, setId, boardRecords);
+  await upsertBoardSet(
+    db,
+    buildBoardSetInput(
+      setId,
+      rootBoard,
+      rootBoardId,
+      name,
+      boardRecords.length,
+    ),
+  );
 
   return { setId, boardId: rootBoardId };
 }
@@ -134,12 +164,14 @@ function buildBoardSetInput(
   setId: string,
   board: OBFBoard | undefined,
   rootBoardId: string,
-  fallbackSetName: string,
+  name: string,
+  boardCount: number,
 ): UpsertBoardSetInput {
   return {
     setId,
-    name: board?.name ?? fallbackSetName,
+    name,
     rootBoardId,
+    boardCount,
     author: board?.license?.author_name,
     description: board?.description_html
       ? htmlToText(board.description_html)
@@ -154,15 +186,13 @@ function buildBoardSetInput(
 async function importOBFFile(
   db: BoardsDB,
   file: File,
-  setId: string,
+  takenNames: Set<string>,
 ): Promise<ImportResult> {
+  const setId = randomId();
   const board = await loadOBF(file);
+  const name = reserveUniqueName(board.name ?? file.name, takenNames);
 
-  await upsertBoardSet(
-    db,
-    buildBoardSetInput(setId, board, board.id, file.name),
-  );
-
+  // boardSet record written last; see importOBZFile.
   await putBoards(db, setId, [
     {
       boardId: board.id,
@@ -170,10 +200,7 @@ async function importOBFFile(
       obf: board,
     },
   ]);
+  await upsertBoardSet(db, buildBoardSetInput(setId, board, board.id, name, 1));
 
   return { setId, boardId: board.id };
-}
-
-function deriveSetId(filename: string): string {
-  return filename.replace(/\.(obz|obf)$/i, "").toLowerCase();
 }

--- a/src/features/board/storage/db.ts
+++ b/src/features/board/storage/db.ts
@@ -36,6 +36,7 @@ export interface UpsertBoardSetInput {
   setId: string;
   name: string;
   rootBoardId: string;
+  boardCount?: number;
   author?: string;
   description?: string;
   license?: string;
@@ -146,7 +147,7 @@ export async function upsertBoardSet(
     name: input.name,
     rootBoardId: input.rootBoardId,
     updatedAt: Date.now(),
-    boardCount: existing?.boardCount ?? 0,
+    boardCount: input.boardCount ?? existing?.boardCount ?? 0,
     author: input.author ?? existing?.author,
     description: input.description ?? existing?.description,
     license: input.license ?? existing?.license,


### PR DESCRIPTION
Two minimal, additive import-integrity fixes from the design review.

## #1 — Identity: stop deriving `setId` from the filename
`setId` is now a random id ([random-id.ts](src/shared/utils/random-id.ts)) instead of the lowercased filename. Two distinct boards that share a filename can no longer **silently overwrite** each other — a re-import lands as its own visible, deletable set. Display names are disambiguated against existing sets (`"Core"` → `"Core (2)"`) so copies stay tellable apart.

**Tradeoff (intentional):** re-importing the *same* board now creates a duplicate rather than updating in place. A duplicate is visible and recoverable; the old clobber was invisible and permanent. A future conflict dialog ("Update existing / Keep both") composes cleanly on top of opaque identity.

## #2 — Atomicity: write the `boardSet` record last
`listBoardSets` reads **only** the `boardSets` store, so writing that record last makes it a commit marker: a failure mid-import leaves nothing visible instead of a board whose pictograms never landed. Adds an explicit `boardCount` to `UpsertBoardSetInput` (the count can't be back-filled from a set that doesn't exist yet).

## Tests
- Updated the two existing tests to capture the random `setId`.
- **New:** re-import → distinct set + disambiguated name.
- **New:** a failed import leaves the library and stores unchanged (no half-written set, no orphans).

**Scope note:** the failure test exercises the realistic failure (corrupt/unparseable file, which fails before any write). Pinning the exact write *ordering* would require injecting a fault into a storage internal, which the repo's testing rules (no mocking internals/native APIs) disallow — so the ordering is enforced by code + the success-path assertions rather than a fault-injection test.

## Deferred (additive, by design)
- Compensating delete + startup orphan-GC sweep for write-stage failures.
- Per-file import notifications.
- Conflict dialog for the duplicate case.

Verification: `npm run lint` clean · `npm test` 322 passed (38 files, real Chromium) · `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)