### PR TITLE
Revert "fix(import): random set ids + write boardSet record last" (#469)

### DIFF
--- a/src/features/board/import/board-import.test.ts
+++ b/src/features/board/import/board-import.test.ts
@@ -12,6 +12,7 @@ import { writeBoardSetFiles } from "./board-import";
 const SAMPLE_BOARDS_DIR = "/src/shared/testing/sample-boards";
 const OBZ_FIXTURE = "lots-of-stuff.obz";
 const OBF_FIXTURE = "lots-of-stuff.obf";
+const IMPORTED_SET_ID = "lots-of-stuff";
 
 function assertDefined<T>(value: T | undefined | null): asserts value is T {
   expect(value).toBeDefined();
@@ -31,14 +32,6 @@ async function loadFixtureFile(name: string): Promise<File> {
   });
 }
 
-async function countBoards(setId: string): Promise<number> {
-  return withBoardsDB((db) => db.countFromIndex("boards", "bySetId", setId));
-}
-
-async function countAssets(setId: string): Promise<number> {
-  return withBoardsDB((db) => db.countFromIndex("assets", "bySetId", setId));
-}
-
 describe("writeBoardSetFiles", () => {
   beforeEach(async () => {
     await resetBoardsDB();
@@ -48,19 +41,21 @@ describe("writeBoardSetFiles", () => {
     const fixtureFile = await loadFixtureFile(OBF_FIXTURE);
     const board = await loadOBF(fixtureFile);
 
-    const [result] = await writeBoardSetFiles(fixtureFile);
-    assertDefined(result);
-    const { setId } = result;
+    const importResults = await writeBoardSetFiles(fixtureFile);
 
-    expect(setId).toBeTruthy();
-    expect(result.boardId).toBe(board.id);
+    expect(importResults).toEqual([
+      {
+        setId: IMPORTED_SET_ID,
+        boardId: board.id,
+      },
+    ]);
 
     await withBoardsDB(async (db) => {
       const boardSets = await listBoardSets(db);
 
       expect(boardSets).toHaveLength(1);
       expect(boardSets[0]).toMatchObject({
-        setId,
+        setId: IMPORTED_SET_ID,
         rootBoardId: board.id,
         boardCount: 1,
         name: board.name,
@@ -69,14 +64,18 @@ describe("writeBoardSetFiles", () => {
         gridColumns: board.grid.columns,
       });
 
-      const storedBoard = await getBoard(db, setId, board.id);
+      const storedBoard = await getBoard(db, IMPORTED_SET_ID, board.id);
       assertDefined(storedBoard);
 
       expect(storedBoard.name).toBe(board.name ?? board.id);
       expect(storedBoard.obf.buttons.length).toBe(board.buttons.length);
       expect(storedBoard.obf.grid).toEqual(board.grid);
 
-      const assetCount = await db.countFromIndex("assets", "bySetId", setId);
+      const assetCount = await db.countFromIndex(
+        "assets",
+        "bySetId",
+        IMPORTED_SET_ID,
+      );
       expect(assetCount).toBe(0);
     });
   });
@@ -103,19 +102,21 @@ describe("writeBoardSetFiles", () => {
     assertDefined(sampleAssetEntry);
     const [sampleAssetPath, sampleAssetBytes] = sampleAssetEntry;
 
-    const [result] = await writeBoardSetFiles(fixtureFile);
-    assertDefined(result);
-    const { setId } = result;
+    const importResults = await writeBoardSetFiles(fixtureFile);
 
-    expect(setId).toBeTruthy();
-    expect(result.boardId).toBe(rootBoardId);
+    expect(importResults).toEqual([
+      {
+        setId: IMPORTED_SET_ID,
+        boardId: rootBoardId,
+      },
+    ]);
 
     await withBoardsDB(async (db) => {
       const boardSets = await listBoardSets(db);
 
       expect(boardSets).toHaveLength(1);
       expect(boardSets[0]).toMatchObject({
-        setId,
+        setId: IMPORTED_SET_ID,
         rootBoardId,
         boardCount: archive.boards.size,
         name: archive.boards.get(rootBoardId)?.name,
@@ -125,17 +126,17 @@ describe("writeBoardSetFiles", () => {
       const storedBoardCount = await readTx
         .objectStore("boards")
         .index("bySetId")
-        .count(setId);
+        .count(IMPORTED_SET_ID);
       const storedAssetCount = await readTx
         .objectStore("assets")
         .index("bySetId")
-        .count(setId);
+        .count(IMPORTED_SET_ID);
       await readTx.done;
 
       expect(storedBoardCount).toBe(archive.boards.size);
       expect(storedAssetCount).toBe(assetEntries.length);
 
-      const storedRootBoard = await getBoard(db, setId, rootBoardId);
+      const storedRootBoard = await getBoard(db, IMPORTED_SET_ID, rootBoardId);
       assertDefined(storedRootBoard);
 
       const linkedButtons = storedRootBoard.obf.buttons.filter((button) =>
@@ -152,69 +153,20 @@ describe("writeBoardSetFiles", () => {
 
         const storedChildBoard = await getBoard(
           db,
-          setId,
+          IMPORTED_SET_ID,
           expectedChildBoardId,
         );
         expect(storedChildBoard).toBeDefined();
       }
 
-      const storedAsset = await getAssetBlob(db, setId, sampleAssetPath);
+      const storedAsset = await getAssetBlob(
+        db,
+        IMPORTED_SET_ID,
+        sampleAssetPath,
+      );
 
       expect(storedAsset).toBeInstanceOf(Blob);
       expect(storedAsset?.size).toBe(sampleAssetBytes.byteLength);
-    });
-  });
-
-  test("re-importing the same board creates a distinct set with a disambiguated name", async () => {
-    const fixtureFile = await loadFixtureFile(OBF_FIXTURE);
-    const board = await loadOBF(fixtureFile);
-    assertDefined(board.name);
-
-    const [first] = await writeBoardSetFiles(fixtureFile);
-    const [second] = await writeBoardSetFiles(fixtureFile);
-    assertDefined(first);
-    assertDefined(second);
-
-    // Identity comes from a random id, so the second import never overwrites
-    // the first — it lands as its own set the user can see and delete.
-    expect(second.setId).not.toBe(first.setId);
-
-    await withBoardsDB(async (db) => {
-      const boardSets = await listBoardSets(db);
-      const names = boardSets.map((set) => set.name).sort();
-
-      expect(boardSets).toHaveLength(2);
-      expect(names).toEqual([board.name, `${board.name} (2)`].sort());
-    });
-  });
-
-  test("a failed import leaves the existing library and stores unchanged", async () => {
-    const fixtureFile = await loadFixtureFile(OBZ_FIXTURE);
-    const [imported] = await writeBoardSetFiles(fixtureFile);
-    assertDefined(imported);
-
-    const boardsBefore = await countBoards(imported.setId);
-    const assetsBefore = await countAssets(imported.setId);
-
-    const corruptFile = new File(["this is not a board"], "broken.obf", {
-      type: "application/json",
-    });
-
-    await expect(writeBoardSetFiles(corruptFile)).rejects.toThrow();
-
-    // The boardSet record is written last, so a failed import surfaces nothing:
-    // no half-written set, and no orphaned boards/assets under a new id.
-    await withBoardsDB(async (db) => {
-      const boardSets = await listBoardSets(db);
-
-      expect(boardSets).toHaveLength(1);
-      expect(boardSets[0]?.setId).toBe(imported.setId);
-
-      const totalBoards = await db.count("boards");
-      const totalAssets = await db.count("assets");
-
-      expect(totalBoards).toBe(boardsBefore);
-      expect(totalAssets).toBe(assetsBefore);
     });
   });
 });

--- a/src/features/board/import/board-import.ts
+++ b/src/features/board/import/board-import.ts
@@ -1,6 +1,5 @@
 import { htmlToText } from "@shared/utils/html";
 import { normalizeLocale } from "@shared/utils/locale";
-import { randomId } from "@shared/utils/random-id";
 import { lookup } from "mrmime";
 import {
   loadOBF,
@@ -17,7 +16,6 @@ import type {
   UpsertBoardSetInput,
 } from "../storage/db";
 import {
-  listBoardSets,
   putAssets,
   putBoards,
   upsertBoardSet,
@@ -44,20 +42,15 @@ export async function writeBoardSetFiles(
   const fileList = Array.isArray(files) ? files : [files];
 
   return withBoardsDB(async (db) => {
-    // A board set's identity is a fresh random id, so re-importing never
-    // silently overwrites an unrelated set. Names can still collide, so we
-    // disambiguate display names against existing sets and earlier files in
-    // this batch (e.g. "Core" → "Core (2)").
-    const takenNames = new Set(
-      (await listBoardSets(db)).map((set) => set.name),
-    );
     const results: ImportResult[] = [];
 
     for (const file of fileList) {
+      const setId = deriveSetId(file.name);
+
       if (file.name.toLowerCase().endsWith(".obz")) {
-        results.push(await importOBZFile(db, file, takenNames));
+        results.push(await importOBZFile(db, file, setId));
       } else {
-        results.push(await importOBFFile(db, file, takenNames));
+        results.push(await importOBFFile(db, file, setId));
       }
     }
 
@@ -65,50 +58,27 @@ export async function writeBoardSetFiles(
   });
 }
 
-function reserveUniqueName(base: string, takenNames: Set<string>): string {
-  let name = base;
-  for (let suffix = 2; takenNames.has(name); suffix++) {
-    name = `${base} (${suffix})`;
-  }
-
-  takenNames.add(name);
-
-  return name;
-}
-
 async function importOBZFile(
   db: BoardsDB,
   file: File,
-  takenNames: Set<string>,
+  setId: string,
 ): Promise<ImportResult> {
-  const setId = randomId();
   const { manifest, boards, resources } = await loadOBZ(file);
   const boardPathToId = buildBoardPathIndex(manifest);
 
   const rootBoardId = resolveRootBoardId(manifest, boardPathToId);
   const rootBoard = boards.get(rootBoardId);
 
-  const boardRecords = buildBoardRecords(boards, boardPathToId);
-  const assetRecords = buildAssetRecords(resources);
-  const name = reserveUniqueName(rootBoard?.name ?? file.name, takenNames);
+  await upsertBoardSet(
+    db,
+    buildBoardSetInput(setId, rootBoard, rootBoardId, file.name),
+  );
+  await putBoards(db, setId, buildBoardRecords(boards, boardPathToId));
 
-  // Write the boardSet record last: listBoardSets reads only that store, so a
-  // failure mid-import leaves nothing visible rather than a board whose
-  // pictograms never landed.
+  const assetRecords = buildAssetRecords(resources);
   if (assetRecords.length > 0) {
     await putAssets(db, setId, assetRecords);
   }
-  await putBoards(db, setId, boardRecords);
-  await upsertBoardSet(
-    db,
-    buildBoardSetInput(
-      setId,
-      rootBoard,
-      rootBoardId,
-      name,
-      boardRecords.length,
-    ),
-  );
 
   return { setId, boardId: rootBoardId };
 }
@@ -164,14 +134,12 @@ function buildBoardSetInput(
   setId: string,
   board: OBFBoard | undefined,
   rootBoardId: string,
-  name: string,
-  boardCount: number,
+  fallbackSetName: string,
 ): UpsertBoardSetInput {
   return {
     setId,
-    name,
+    name: board?.name ?? fallbackSetName,
     rootBoardId,
-    boardCount,
     author: board?.license?.author_name,
     description: board?.description_html
       ? htmlToText(board.description_html)
@@ -186,13 +154,15 @@ function buildBoardSetInput(
 async function importOBFFile(
   db: BoardsDB,
   file: File,
-  takenNames: Set<string>,
+  setId: string,
 ): Promise<ImportResult> {
-  const setId = randomId();
   const board = await loadOBF(file);
-  const name = reserveUniqueName(board.name ?? file.name, takenNames);
 
-  // boardSet record written last; see importOBZFile.
+  await upsertBoardSet(
+    db,
+    buildBoardSetInput(setId, board, board.id, file.name),
+  );
+
   await putBoards(db, setId, [
     {
       boardId: board.id,
@@ -200,7 +170,10 @@ async function importOBFFile(
       obf: board,
     },
   ]);
-  await upsertBoardSet(db, buildBoardSetInput(setId, board, board.id, name, 1));
 
   return { setId, boardId: board.id };
+}
+
+function deriveSetId(filename: string): string {
+  return filename.replace(/\.(obz|obf)$/i, "").toLowerCase();
 }

--- a/src/features/board/storage/db.ts
+++ b/src/features/board/storage/db.ts
@@ -36,7 +36,6 @@ export interface UpsertBoardSetInput {
   setId: string;
   name: string;
   rootBoardId: string;
-  boardCount?: number;
   author?: string;
   description?: string;
   license?: string;
@@ -147,7 +146,7 @@ export async function upsertBoardSet(
     name: input.name,
     rootBoardId: input.rootBoardId,
     updatedAt: Date.now(),
-    boardCount: input.boardCount ?? existing?.boardCount ?? 0,
+    boardCount: existing?.boardCount ?? 0,
     author: input.author ?? existing?.author,
     description: input.description ?? existing?.description,
     license: input.license ?? existing?.license,


### PR DESCRIPTION
Reverts #469 at the user's request.

Restores the prior import behavior: filename-derived `setId` and the original
write order (`boardSet` first). Brings back the original two import tests and
drops the `boardCount` field added to `UpsertBoardSetInput`.

Clean inverse of 0f0412d. Lint, import tests, and build verified green on the
reverted tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)