### PR TITLE
refactor(storage): single long-lived IndexedDB connection

### DIFF
--- a/src/features/board/import/board-import.test.ts
+++ b/src/features/board/import/board-import.test.ts
@@ -3,8 +3,8 @@ import { beforeEach, describe, expect, test } from "vitest";
 import {
   getAssetBlob,
   getBoard,
+  getBoardsDB,
   listBoardSets,
-  withBoardsDB,
 } from "../storage/db";
 import { resetBoardsDB } from "../storage/test-helpers";
 import { writeBoardSetFiles } from "./board-import";
@@ -50,34 +50,33 @@ describe("writeBoardSetFiles", () => {
       },
     ]);
 
-    await withBoardsDB(async (db) => {
-      const boardSets = await listBoardSets(db);
+    const db = await getBoardsDB();
+    const boardSets = await listBoardSets();
 
-      expect(boardSets).toHaveLength(1);
-      expect(boardSets[0]).toMatchObject({
-        setId: IMPORTED_SET_ID,
-        rootBoardId: board.id,
-        boardCount: 1,
-        name: board.name,
-        locale: board.locale,
-        gridRows: board.grid.rows,
-        gridColumns: board.grid.columns,
-      });
-
-      const storedBoard = await getBoard(db, IMPORTED_SET_ID, board.id);
-      assertDefined(storedBoard);
-
-      expect(storedBoard.name).toBe(board.name ?? board.id);
-      expect(storedBoard.obf.buttons.length).toBe(board.buttons.length);
-      expect(storedBoard.obf.grid).toEqual(board.grid);
-
-      const assetCount = await db.countFromIndex(
-        "assets",
-        "bySetId",
-        IMPORTED_SET_ID,
-      );
-      expect(assetCount).toBe(0);
+    expect(boardSets).toHaveLength(1);
+    expect(boardSets[0]).toMatchObject({
+      setId: IMPORTED_SET_ID,
+      rootBoardId: board.id,
+      boardCount: 1,
+      name: board.name,
+      locale: board.locale,
+      gridRows: board.grid.rows,
+      gridColumns: board.grid.columns,
     });
+
+    const storedBoard = await getBoard(IMPORTED_SET_ID, board.id);
+    assertDefined(storedBoard);
+
+    expect(storedBoard.name).toBe(board.name ?? board.id);
+    expect(storedBoard.obf.buttons.length).toBe(board.buttons.length);
+    expect(storedBoard.obf.grid).toEqual(board.grid);
+
+    const assetCount = await db.countFromIndex(
+      "assets",
+      "bySetId",
+      IMPORTED_SET_ID,
+    );
+    expect(assetCount).toBe(0);
   });
 
   test("imports an OBZ file into IndexedDB", async () => {
@@ -111,62 +110,56 @@ describe("writeBoardSetFiles", () => {
       },
     ]);
 
-    await withBoardsDB(async (db) => {
-      const boardSets = await listBoardSets(db);
+    const db = await getBoardsDB();
+    const boardSets = await listBoardSets();
 
-      expect(boardSets).toHaveLength(1);
-      expect(boardSets[0]).toMatchObject({
-        setId: IMPORTED_SET_ID,
-        rootBoardId,
-        boardCount: archive.boards.size,
-        name: archive.boards.get(rootBoardId)?.name,
-      });
-
-      const readTx = db.transaction(["boards", "assets"], "readonly");
-      const storedBoardCount = await readTx
-        .objectStore("boards")
-        .index("bySetId")
-        .count(IMPORTED_SET_ID);
-      const storedAssetCount = await readTx
-        .objectStore("assets")
-        .index("bySetId")
-        .count(IMPORTED_SET_ID);
-      await readTx.done;
-
-      expect(storedBoardCount).toBe(archive.boards.size);
-      expect(storedAssetCount).toBe(assetEntries.length);
-
-      const storedRootBoard = await getBoard(db, IMPORTED_SET_ID, rootBoardId);
-      assertDefined(storedRootBoard);
-
-      const linkedButtons = storedRootBoard.obf.buttons.filter((button) =>
-        Boolean(button.load_board?.path),
-      );
-
-      expect(linkedButtons.length).toBeGreaterThan(0);
-
-      for (const button of linkedButtons) {
-        const expectedChildBoardId = pathToId.get(button.load_board!.path!);
-        assertDefined(expectedChildBoardId);
-
-        expect(button.load_board?.id).toBe(expectedChildBoardId);
-
-        const storedChildBoard = await getBoard(
-          db,
-          IMPORTED_SET_ID,
-          expectedChildBoardId,
-        );
-        expect(storedChildBoard).toBeDefined();
-      }
-
-      const storedAsset = await getAssetBlob(
-        db,
-        IMPORTED_SET_ID,
-        sampleAssetPath,
-      );
-
-      expect(storedAsset).toBeInstanceOf(Blob);
-      expect(storedAsset?.size).toBe(sampleAssetBytes.byteLength);
+    expect(boardSets).toHaveLength(1);
+    expect(boardSets[0]).toMatchObject({
+      setId: IMPORTED_SET_ID,
+      rootBoardId,
+      boardCount: archive.boards.size,
+      name: archive.boards.get(rootBoardId)?.name,
     });
+
+    const readTx = db.transaction(["boards", "assets"], "readonly");
+    const storedBoardCount = await readTx
+      .objectStore("boards")
+      .index("bySetId")
+      .count(IMPORTED_SET_ID);
+    const storedAssetCount = await readTx
+      .objectStore("assets")
+      .index("bySetId")
+      .count(IMPORTED_SET_ID);
+    await readTx.done;
+
+    expect(storedBoardCount).toBe(archive.boards.size);
+    expect(storedAssetCount).toBe(assetEntries.length);
+
+    const storedRootBoard = await getBoard(IMPORTED_SET_ID, rootBoardId);
+    assertDefined(storedRootBoard);
+
+    const linkedButtons = storedRootBoard.obf.buttons.filter((button) =>
+      Boolean(button.load_board?.path),
+    );
+
+    expect(linkedButtons.length).toBeGreaterThan(0);
+
+    for (const button of linkedButtons) {
+      const expectedChildBoardId = pathToId.get(button.load_board!.path!);
+      assertDefined(expectedChildBoardId);
+
+      expect(button.load_board?.id).toBe(expectedChildBoardId);
+
+      const storedChildBoard = await getBoard(
+        IMPORTED_SET_ID,
+        expectedChildBoardId,
+      );
+      expect(storedChildBoard).toBeDefined();
+    }
+
+    const storedAsset = await getAssetBlob(IMPORTED_SET_ID, sampleAssetPath);
+
+    expect(storedAsset).toBeInstanceOf(Blob);
+    expect(storedAsset?.size).toBe(sampleAssetBytes.byteLength);
   });
 });

--- a/src/features/board/import/board-import.ts
+++ b/src/features/board/import/board-import.ts
@@ -10,17 +10,11 @@ import {
 import { resolveLoadBoardPaths } from "../obf/obf-to-board";
 import { notifyBoardSetsChanged } from "../storage/board-sets-store";
 import type {
-  BoardsDB,
   UpsertAssetInput,
   UpsertBoardInput,
   UpsertBoardSetInput,
 } from "../storage/db";
-import {
-  putAssets,
-  putBoards,
-  upsertBoardSet,
-  withBoardsDB,
-} from "../storage/db";
+import { putAssets, putBoards, upsertBoardSet } from "../storage/db";
 
 export interface ImportResult {
   setId: string;
@@ -40,29 +34,22 @@ export async function writeBoardSetFiles(
   files: File | File[],
 ): Promise<ImportResult[]> {
   const fileList = Array.isArray(files) ? files : [files];
+  const results: ImportResult[] = [];
 
-  return withBoardsDB(async (db) => {
-    const results: ImportResult[] = [];
+  for (const file of fileList) {
+    const setId = deriveSetId(file.name);
 
-    for (const file of fileList) {
-      const setId = deriveSetId(file.name);
-
-      if (file.name.toLowerCase().endsWith(".obz")) {
-        results.push(await importOBZFile(db, file, setId));
-      } else {
-        results.push(await importOBFFile(db, file, setId));
-      }
+    if (file.name.toLowerCase().endsWith(".obz")) {
+      results.push(await importOBZFile(file, setId));
+    } else {
+      results.push(await importOBFFile(file, setId));
     }
+  }
 
-    return results;
-  });
+  return results;
 }
 
-async function importOBZFile(
-  db: BoardsDB,
-  file: File,
-  setId: string,
-): Promise<ImportResult> {
+async function importOBZFile(file: File, setId: string): Promise<ImportResult> {
   const { manifest, boards, resources } = await loadOBZ(file);
   const boardPathToId = buildBoardPathIndex(manifest);
 
@@ -70,14 +57,13 @@ async function importOBZFile(
   const rootBoard = boards.get(rootBoardId);
 
   await upsertBoardSet(
-    db,
     buildBoardSetInput(setId, rootBoard, rootBoardId, file.name),
   );
-  await putBoards(db, setId, buildBoardRecords(boards, boardPathToId));
+  await putBoards(setId, buildBoardRecords(boards, boardPathToId));
 
   const assetRecords = buildAssetRecords(resources);
   if (assetRecords.length > 0) {
-    await putAssets(db, setId, assetRecords);
+    await putAssets(setId, assetRecords);
   }
 
   return { setId, boardId: rootBoardId };
@@ -151,19 +137,12 @@ function buildBoardSetInput(
   };
 }
 
-async function importOBFFile(
-  db: BoardsDB,
-  file: File,
-  setId: string,
-): Promise<ImportResult> {
+async function importOBFFile(file: File, setId: string): Promise<ImportResult> {
   const board = await loadOBF(file);
 
-  await upsertBoardSet(
-    db,
-    buildBoardSetInput(setId, board, board.id, file.name),
-  );
+  await upsertBoardSet(buildBoardSetInput(setId, board, board.id, file.name));
 
-  await putBoards(db, setId, [
+  await putBoards(setId, [
     {
       boardId: board.id,
       name: board.name ?? board.id,

--- a/src/features/board/storage/board-sets-store.ts
+++ b/src/features/board/storage/board-sets-store.ts
@@ -2,7 +2,6 @@ import { createExternalStore } from "@shared/utils/external-store";
 import {
   deleteBoardSet as deleteBoardSetRecord,
   listBoardSets,
-  withBoardsDB,
   type BoardSetRecord,
 } from "./db";
 
@@ -28,7 +27,7 @@ let pendingLoad: Promise<void> | null = null;
 
 async function loadBoardSets(): Promise<void> {
   try {
-    const boardSets = await withBoardsDB((db) => listBoardSets(db));
+    const boardSets = await listBoardSets();
     store.setState({ boardSets, isLoading: false, error: null });
     hasLoaded = true;
   } catch (error) {
@@ -83,6 +82,6 @@ export async function getBoardSets(): Promise<BoardSetRecord[]> {
 }
 
 export async function deleteBoardSet(setId: string): Promise<void> {
-  await withBoardsDB((db) => deleteBoardSetRecord(db, setId));
+  await deleteBoardSetRecord(setId);
   await notifyBoardSetsChanged();
 }

--- a/src/features/board/storage/db.test.ts
+++ b/src/features/board/storage/db.test.ts
@@ -1,19 +1,19 @@
 import type { OBFBoard } from "@shayc/open-board-format";
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
+  closeBoardsDB,
   deleteBoardSet,
   getAssetBlob,
   getBoard,
+  getBoardsDB,
   listBoardSets,
   putAssets,
   putBoards,
   updateBoardStrings,
   upsertBoardSet,
-  withBoardsDB,
-  type BoardsDB,
   type UpsertBoardSetInput,
 } from "./db";
-import { openCleanBoardsDB } from "./test-helpers";
+import { clearBoardsDB } from "./test-helpers";
 
 function makeBoardSetInput(
   overrides: Partial<UpsertBoardSetInput> = {},
@@ -35,25 +35,17 @@ function makeOBFBoard(overrides: Partial<OBFBoard> = {}): OBFBoard {
   };
 }
 
-let db: BoardsDB;
-
-afterEach(() => {
-  db?.close();
+beforeEach(async () => {
+  await clearBoardsDB();
 });
 
-async function openTestDB(): Promise<BoardsDB> {
-  db = await openCleanBoardsDB();
-
-  return db;
-}
+afterEach(closeBoardsDB);
 
 describe("upsertBoardSet", () => {
   test("inserts a new board set", async () => {
-    const db = await openTestDB();
+    await upsertBoardSet(makeBoardSetInput({ name: "My Set" }));
 
-    await upsertBoardSet(db, makeBoardSetInput({ name: "My Set" }));
-
-    const sets = await listBoardSets(db);
+    const sets = await listBoardSets();
     expect(sets).toHaveLength(1);
     expect(sets[0].setId).toBe("set-1");
     expect(sets[0].name).toBe("My Set");
@@ -61,32 +53,25 @@ describe("upsertBoardSet", () => {
   });
 
   test("preserves boardCount on upsert", async () => {
-    const db = await openTestDB();
-
-    await upsertBoardSet(db, makeBoardSetInput());
+    await upsertBoardSet(makeBoardSetInput());
     const obf = makeOBFBoard({ id: "b1" });
-    await putBoards(db, "set-1", [{ boardId: "b1", name: "B1", obf }]);
+    await putBoards("set-1", [{ boardId: "b1", name: "B1", obf }]);
 
-    await upsertBoardSet(db, makeBoardSetInput({ name: "Set Renamed" }));
+    await upsertBoardSet(makeBoardSetInput({ name: "Set Renamed" }));
 
-    const sets = await listBoardSets(db);
+    const sets = await listBoardSets();
     expect(sets[0].boardCount).toBe(1);
   });
 
   test("rejects empty setId", async () => {
-    const db = await openTestDB();
-
     await expect(
-      upsertBoardSet(db, makeBoardSetInput({ setId: "", name: "Bad" })),
+      upsertBoardSet(makeBoardSetInput({ setId: "", name: "Bad" })),
     ).rejects.toThrow("Invalid setId");
   });
 
   test("rejects setId longer than 255 characters", async () => {
-    const db = await openTestDB();
-
     await expect(
       upsertBoardSet(
-        db,
         makeBoardSetInput({ setId: "x".repeat(256), name: "Bad" }),
       ),
     ).rejects.toThrow("Invalid setId");
@@ -95,9 +80,7 @@ describe("upsertBoardSet", () => {
 
 describe("listBoardSets", () => {
   test("returns empty array when no sets exist", async () => {
-    const db = await openTestDB();
-
-    const sets = await listBoardSets(db);
+    const sets = await listBoardSets();
     expect(sets).toEqual([]);
   });
 
@@ -108,12 +91,10 @@ describe("listBoardSets", () => {
     let now = 1000;
     vi.spyOn(Date, "now").mockImplementation(() => (now += 1000));
 
-    const db = await openTestDB();
+    await upsertBoardSet(makeBoardSetInput({ setId: "old", name: "Old" }));
+    await upsertBoardSet(makeBoardSetInput({ setId: "new", name: "New" }));
 
-    await upsertBoardSet(db, makeBoardSetInput({ setId: "old", name: "Old" }));
-    await upsertBoardSet(db, makeBoardSetInput({ setId: "new", name: "New" }));
-
-    const sets = await listBoardSets(db);
+    const sets = await listBoardSets();
     expect(sets).toHaveLength(2);
     expect(sets[0].setId).toBe("new");
     expect(sets[1].setId).toBe("old");
@@ -122,13 +103,12 @@ describe("listBoardSets", () => {
 
 describe("putBoards and getBoard", () => {
   test("stores and retrieves a board", async () => {
-    const db = await openTestDB();
-    await upsertBoardSet(db, makeBoardSetInput());
+    await upsertBoardSet(makeBoardSetInput());
 
     const obf = makeOBFBoard({ id: "b1", name: "Board One" });
-    await putBoards(db, "set-1", [{ boardId: "b1", name: "Board One", obf }]);
+    await putBoards("set-1", [{ boardId: "b1", name: "Board One", obf }]);
 
-    const board = await getBoard(db, "set-1", "b1");
+    const board = await getBoard("set-1", "b1");
     expect(board).toBeDefined();
     expect(board!.boardId).toBe("b1");
     expect(board!.name).toBe("Board One");
@@ -136,24 +116,22 @@ describe("putBoards and getBoard", () => {
   });
 
   test("counts only unique boards", async () => {
-    const db = await openTestDB();
-    await upsertBoardSet(db, makeBoardSetInput());
+    await upsertBoardSet(makeBoardSetInput());
 
     const obf = makeOBFBoard({ id: "b1" });
-    await putBoards(db, "set-1", [{ boardId: "b1", name: "B1", obf }]);
+    await putBoards("set-1", [{ boardId: "b1", name: "B1", obf }]);
 
-    let sets = await listBoardSets(db);
+    let sets = await listBoardSets();
     expect(sets[0].boardCount).toBe(1);
 
-    await putBoards(db, "set-1", [{ boardId: "b1", name: "B1 Updated", obf }]);
+    await putBoards("set-1", [{ boardId: "b1", name: "B1 Updated", obf }]);
 
-    sets = await listBoardSets(db);
+    sets = await listBoardSets();
     expect(sets[0].boardCount).toBe(1);
   });
 
   test("counts multiple boards correctly", async () => {
-    const db = await openTestDB();
-    await upsertBoardSet(db, makeBoardSetInput());
+    await upsertBoardSet(makeBoardSetInput());
 
     const boards = [
       { boardId: "b1", name: "B1", obf: makeOBFBoard({ id: "b1" }) },
@@ -161,51 +139,45 @@ describe("putBoards and getBoard", () => {
       { boardId: "b3", name: "B3", obf: makeOBFBoard({ id: "b3" }) },
     ];
 
-    await putBoards(db, "set-1", boards);
+    await putBoards("set-1", boards);
 
-    const sets = await listBoardSets(db);
+    const sets = await listBoardSets();
     expect(sets[0].boardCount).toBe(3);
   });
 
   test("returns undefined for nonexistent board", async () => {
-    const db = await openTestDB();
-    await upsertBoardSet(db, makeBoardSetInput());
+    await upsertBoardSet(makeBoardSetInput());
 
-    const board = await getBoard(db, "set-1", "nonexistent");
+    const board = await getBoard("set-1", "nonexistent");
     expect(board).toBeUndefined();
   });
 
   test("stores boards even when boardset record does not exist", async () => {
-    const db = await openTestDB();
-
     const obf = makeOBFBoard({ id: "b1" });
-    await putBoards(db, "orphan-set", [{ boardId: "b1", name: "B1", obf }]);
+    await putBoards("orphan-set", [{ boardId: "b1", name: "B1", obf }]);
 
-    const board = await getBoard(db, "orphan-set", "b1");
+    const board = await getBoard("orphan-set", "b1");
     expect(board).toBeDefined();
     expect(board!.boardId).toBe("b1");
   });
 
   test("rejects empty setId", async () => {
-    const db = await openTestDB();
-
     await expect(
-      putBoards(db, "", [{ boardId: "b1", name: "B", obf: makeOBFBoard() }]),
+      putBoards("", [{ boardId: "b1", name: "B", obf: makeOBFBoard() }]),
     ).rejects.toThrow("Invalid setId");
   });
 });
 
 describe("putAssets and getAssetBlob", () => {
   test("stores and retrieves an asset blob", async () => {
-    const db = await openTestDB();
-    await upsertBoardSet(db, makeBoardSetInput());
+    await upsertBoardSet(makeBoardSetInput());
 
     const blob = new Blob(["hello"], { type: "text/plain" });
-    await putAssets(db, "set-1", [
+    await putAssets("set-1", [
       { path: "images/logo.png", blob, mime: "image/png" },
     ]);
 
-    const retrieved = await getAssetBlob(db, "set-1", "images/logo.png");
+    const retrieved = await getAssetBlob("set-1", "images/logo.png");
     expect(retrieved).toBeInstanceOf(Blob);
     expect(await retrieved!.text()).toBe("hello");
   });
@@ -217,33 +189,31 @@ describe("putAssets and getAssetBlob", () => {
   ])(
     "normalizes $description so the asset is retrievable by canonical path",
     async ({ rawPath }) => {
-      const db = await openTestDB();
-      await upsertBoardSet(db, makeBoardSetInput());
+      await upsertBoardSet(makeBoardSetInput());
 
       const blob = new Blob(["data"]);
-      await putAssets(db, "set-1", [{ path: rawPath, blob }]);
+      await putAssets("set-1", [{ path: rawPath, blob }]);
 
-      const retrieved = await getAssetBlob(db, "set-1", "images/photo.png");
+      const retrieved = await getAssetBlob("set-1", "images/photo.png");
       expect(retrieved).toBeInstanceOf(Blob);
       expect(await retrieved!.text()).toBe("data");
     },
   );
 
   test("returns undefined for nonexistent asset", async () => {
-    const db = await openTestDB();
-    await upsertBoardSet(db, makeBoardSetInput());
+    await upsertBoardSet(makeBoardSetInput());
 
-    const blob = await getAssetBlob(db, "set-1", "nope.png");
+    const blob = await getAssetBlob("set-1", "nope.png");
     expect(blob).toBeUndefined();
   });
 
   test("stores asset size from blob when not explicitly provided", async () => {
-    const db = await openTestDB();
-    await upsertBoardSet(db, makeBoardSetInput());
+    await upsertBoardSet(makeBoardSetInput());
 
     const blob = new Blob(["12345"]);
-    await putAssets(db, "set-1", [{ path: "file.bin", blob }]);
+    await putAssets("set-1", [{ path: "file.bin", blob }]);
 
+    const db = await getBoardsDB();
     const record = await db.get("assets", ["set-1", "file.bin"]);
     expect(record).toBeDefined();
     expect(record!.size).toBe(5);
@@ -252,36 +222,34 @@ describe("putAssets and getAssetBlob", () => {
 
 describe("updateBoardStrings", () => {
   test("adds localized strings to a board", async () => {
-    const db = await openTestDB();
-    await upsertBoardSet(db, makeBoardSetInput());
+    await upsertBoardSet(makeBoardSetInput());
 
     const obf = makeOBFBoard({ id: "b1" });
-    await putBoards(db, "set-1", [{ boardId: "b1", name: "B1", obf }]);
+    await putBoards("set-1", [{ boardId: "b1", name: "B1", obf }]);
 
-    await updateBoardStrings(db, "set-1", "b1", "es", {
+    await updateBoardStrings("set-1", "b1", "es", {
       hello: "hola",
       world: "mundo",
     });
 
-    const board = await getBoard(db, "set-1", "b1");
+    const board = await getBoard("set-1", "b1");
     expect(board!.obf.strings).toEqual({
       es: { hello: "hola", world: "mundo" },
     });
   });
 
   test("preserves existing locale strings when adding a new locale", async () => {
-    const db = await openTestDB();
-    await upsertBoardSet(db, makeBoardSetInput());
+    await upsertBoardSet(makeBoardSetInput());
 
     const obf = makeOBFBoard({
       id: "b1",
       strings: { fr: { hello: "bonjour" } },
     });
-    await putBoards(db, "set-1", [{ boardId: "b1", name: "B1", obf }]);
+    await putBoards("set-1", [{ boardId: "b1", name: "B1", obf }]);
 
-    await updateBoardStrings(db, "set-1", "b1", "es", { hello: "hola" });
+    await updateBoardStrings("set-1", "b1", "es", { hello: "hola" });
 
-    const board = await getBoard(db, "set-1", "b1");
+    const board = await getBoard("set-1", "b1");
     expect(board!.obf.strings).toEqual({
       fr: { hello: "bonjour" },
       es: { hello: "hola" },
@@ -289,134 +257,110 @@ describe("updateBoardStrings", () => {
   });
 
   test("replaces all strings when updating an existing locale", async () => {
-    const db = await openTestDB();
-    await upsertBoardSet(db, makeBoardSetInput());
+    await upsertBoardSet(makeBoardSetInput());
 
     const obf = makeOBFBoard({ id: "b1" });
-    await putBoards(db, "set-1", [{ boardId: "b1", name: "B1", obf }]);
+    await putBoards("set-1", [{ boardId: "b1", name: "B1", obf }]);
 
-    await updateBoardStrings(db, "set-1", "b1", "es", {
+    await updateBoardStrings("set-1", "b1", "es", {
       hello: "hola",
       bye: "adiós",
     });
-    await updateBoardStrings(db, "set-1", "b1", "es", { hello: "ey" });
+    await updateBoardStrings("set-1", "b1", "es", { hello: "ey" });
 
-    const board = await getBoard(db, "set-1", "b1");
+    const board = await getBoard("set-1", "b1");
     expect(board!.obf.strings).toEqual({ es: { hello: "ey" } });
   });
 
   test("throws when board does not exist", async () => {
-    const db = await openTestDB();
-    await upsertBoardSet(db, makeBoardSetInput());
+    await upsertBoardSet(makeBoardSetInput());
 
     await expect(
-      updateBoardStrings(db, "set-1", "nonexistent", "es", {}),
+      updateBoardStrings("set-1", "nonexistent", "es", {}),
     ).rejects.toThrow("Board not found");
   });
 });
 
 describe("deleteBoardSet", () => {
   test("removes the board set record", async () => {
-    const db = await openTestDB();
-    await upsertBoardSet(db, makeBoardSetInput());
+    await upsertBoardSet(makeBoardSetInput());
 
-    await deleteBoardSet(db, "set-1");
+    await deleteBoardSet("set-1");
 
-    const sets = await listBoardSets(db);
+    const sets = await listBoardSets();
     expect(sets).toHaveLength(0);
   });
 
   test("cascade-deletes all boards in the set", async () => {
-    const db = await openTestDB();
-    await upsertBoardSet(db, makeBoardSetInput());
+    await upsertBoardSet(makeBoardSetInput());
 
-    await putBoards(db, "set-1", [
+    await putBoards("set-1", [
       { boardId: "b1", name: "B1", obf: makeOBFBoard({ id: "b1" }) },
       { boardId: "b2", name: "B2", obf: makeOBFBoard({ id: "b2" }) },
     ]);
 
-    await deleteBoardSet(db, "set-1");
+    await deleteBoardSet("set-1");
 
-    expect(await getBoard(db, "set-1", "b1")).toBeUndefined();
-    expect(await getBoard(db, "set-1", "b2")).toBeUndefined();
+    expect(await getBoard("set-1", "b1")).toBeUndefined();
+    expect(await getBoard("set-1", "b2")).toBeUndefined();
   });
 
   test("cascade-deletes all assets in the set", async () => {
-    const db = await openTestDB();
-    await upsertBoardSet(db, makeBoardSetInput());
+    await upsertBoardSet(makeBoardSetInput());
 
-    await putAssets(db, "set-1", [
+    await putAssets("set-1", [
       { path: "img1.png", blob: new Blob(["a"]) },
       { path: "img2.png", blob: new Blob(["b"]) },
     ]);
 
-    await deleteBoardSet(db, "set-1");
+    await deleteBoardSet("set-1");
 
-    expect(await getAssetBlob(db, "set-1", "img1.png")).toBeUndefined();
-    expect(await getAssetBlob(db, "set-1", "img2.png")).toBeUndefined();
+    expect(await getAssetBlob("set-1", "img1.png")).toBeUndefined();
+    expect(await getAssetBlob("set-1", "img2.png")).toBeUndefined();
   });
 
   test("does not affect other board sets", async () => {
-    const db = await openTestDB();
-    await upsertBoardSet(db, makeBoardSetInput({ name: "Set 1" }));
-    await upsertBoardSet(
-      db,
-      makeBoardSetInput({ setId: "set-2", name: "Set 2" }),
-    );
+    await upsertBoardSet(makeBoardSetInput({ name: "Set 1" }));
+    await upsertBoardSet(makeBoardSetInput({ setId: "set-2", name: "Set 2" }));
 
-    await putBoards(db, "set-1", [
+    await putBoards("set-1", [
       { boardId: "b1", name: "B1", obf: makeOBFBoard({ id: "b1" }) },
     ]);
-    await putBoards(db, "set-2", [
+    await putBoards("set-2", [
       { boardId: "b2", name: "B2", obf: makeOBFBoard({ id: "b2" }) },
     ]);
 
-    await deleteBoardSet(db, "set-1");
+    await deleteBoardSet("set-1");
 
-    const sets = await listBoardSets(db);
+    const sets = await listBoardSets();
     expect(sets).toHaveLength(1);
     expect(sets[0].setId).toBe("set-2");
 
-    const board = await getBoard(db, "set-2", "b2");
+    const board = await getBoard("set-2", "b2");
     expect(board).toBeDefined();
   });
 
   test("rejects empty setId", async () => {
-    const db = await openTestDB();
-
-    await expect(deleteBoardSet(db, "")).rejects.toThrow("Invalid setId");
+    await expect(deleteBoardSet("")).rejects.toThrow("Invalid setId");
   });
 });
 
-describe("withBoardsDB", () => {
-  test("closes the database after the callback completes", async () => {
-    let capturedDb: BoardsDB | undefined;
+describe("getBoardsDB", () => {
+  test("reuses one connection across calls", async () => {
+    const [first, second] = await Promise.all([getBoardsDB(), getBoardsDB()]);
 
-    await withBoardsDB(async (db) => {
-      capturedDb = db;
-      await upsertBoardSet(
-        db,
-        makeBoardSetInput({ setId: "temp", name: "Temp" }),
-      );
-    });
-
-    expect(() => {
-      capturedDb!.transaction("boardSets", "readonly");
-    }).toThrow();
+    expect(first).toBe(second);
   });
 
-  test("closes the database even when the callback throws", async () => {
-    let capturedDb: BoardsDB | undefined;
+  test("reopens a fresh, usable connection after closeBoardsDB", async () => {
+    const first = await getBoardsDB();
+    await closeBoardsDB();
 
-    await expect(
-      withBoardsDB((db) => {
-        capturedDb = db;
-        throw new Error("boom");
-      }),
-    ).rejects.toThrow("boom");
+    const second = await getBoardsDB();
+    expect(second).not.toBe(first);
 
-    expect(() => {
-      capturedDb!.transaction("boardSets", "readonly");
-    }).toThrow();
+    await upsertBoardSet(makeBoardSetInput({ name: "Persisted" }));
+    const sets = await listBoardSets();
+    expect(sets.map((set) => set.name)).toContain("Persisted");
   });
 });

--- a/src/features/board/storage/db.ts
+++ b/src/features/board/storage/db.ts
@@ -100,8 +100,32 @@ function validateId(id: string, fieldName: string): void {
   }
 }
 
-export async function openBoardsDB(): Promise<BoardsDB> {
-  const db = await openDB<BoardsDBSchema>(DB_NAME, DB_VERSION, {
+let connection: Promise<BoardsDB> | null = null;
+
+// One long-lived connection per page: callers reach the store through these
+// functions, not a passed-in handle. A failed open clears the cache so the
+// next call retries rather than handing back the same rejected promise.
+export function getBoardsDB(): Promise<BoardsDB> {
+  connection ??= openConnection().catch((error: unknown) => {
+    connection = null;
+    throw error;
+  });
+
+  return connection;
+}
+
+export async function closeBoardsDB(): Promise<void> {
+  const pending = connection;
+  connection = null;
+  try {
+    (await pending)?.close();
+  } catch {
+    // Open never succeeded — nothing to close.
+  }
+}
+
+function openConnection(): Promise<BoardsDB> {
+  return openDB<BoardsDBSchema>(DB_NAME, DB_VERSION, {
     upgrade(db) {
       const boardSets = db.createObjectStore("boardSets", { keyPath: "setId" });
       boardSets.createIndex("byUpdatedAt", "updatedAt");
@@ -118,26 +142,13 @@ export async function openBoardsDB(): Promise<BoardsDB> {
       assets.createIndex("bySetIdAndMediaId", ["setId", "mediaId"]);
     },
   });
-
-  return db;
-}
-
-export async function withBoardsDB<T>(
-  operation: (db: BoardsDB) => Promise<T>,
-): Promise<T> {
-  const db = await openBoardsDB();
-  try {
-    return await operation(db);
-  } finally {
-    db.close();
-  }
 }
 
 export async function upsertBoardSet(
-  db: BoardsDB,
   input: UpsertBoardSetInput,
 ): Promise<void> {
   validateId(input.setId, "setId");
+  const db = await getBoardsDB();
   const tx = db.transaction("boardSets", "readwrite");
   const existing = await tx.store.get(input.setId);
 
@@ -160,15 +171,16 @@ export async function upsertBoardSet(
 }
 
 export async function getBoardSet(
-  db: BoardsDB,
   setId: string,
 ): Promise<BoardSetRecord | undefined> {
   validateId(setId, "setId");
+  const db = await getBoardsDB();
 
   return db.get("boardSets", setId);
 }
 
-export async function listBoardSets(db: BoardsDB): Promise<BoardSetRecord[]> {
+export async function listBoardSets(): Promise<BoardSetRecord[]> {
+  const db = await getBoardsDB();
   const tx = db.transaction("boardSets", "readonly");
   const index = tx.store.index("byUpdatedAt");
 
@@ -185,11 +197,9 @@ export async function listBoardSets(db: BoardsDB): Promise<BoardSetRecord[]> {
   return boardSets;
 }
 
-export async function deleteBoardSet(
-  db: BoardsDB,
-  setId: string,
-): Promise<void> {
+export async function deleteBoardSet(setId: string): Promise<void> {
   validateId(setId, "setId");
+  const db = await getBoardsDB();
   const tx = db.transaction(["boards", "assets", "boardSets"], "readwrite");
 
   // The [] upper bound exploits IDB key ordering — arrays sort after strings,
@@ -203,11 +213,11 @@ export async function deleteBoardSet(
 }
 
 export async function putBoards(
-  db: BoardsDB,
   setId: string,
   boards: UpsertBoardInput[],
 ): Promise<void> {
   validateId(setId, "setId");
+  const db = await getBoardsDB();
   const tx = db.transaction(["boards", "boardSets"], "readwrite");
   const boardStore = tx.objectStore("boards");
 
@@ -233,18 +243,17 @@ export async function putBoards(
 }
 
 export async function getBoard(
-  db: BoardsDB,
   setId: string,
   boardId: string,
 ): Promise<BoardRecord | undefined> {
   validateId(setId, "setId");
   validateId(boardId, "boardId");
+  const db = await getBoardsDB();
 
   return db.get("boards", [setId, boardId]);
 }
 
 export async function updateBoardStrings(
-  db: BoardsDB,
   setId: string,
   boardId: string,
   locale: string,
@@ -252,6 +261,7 @@ export async function updateBoardStrings(
 ): Promise<void> {
   validateId(setId, "setId");
   validateId(boardId, "boardId");
+  const db = await getBoardsDB();
   const tx = db.transaction("boards", "readwrite");
   const record = await tx.store.get([setId, boardId]);
 
@@ -269,11 +279,11 @@ export async function updateBoardStrings(
 }
 
 export async function putAssets(
-  db: BoardsDB,
   setId: string,
   assets: UpsertAssetInput[],
 ): Promise<void> {
   validateId(setId, "setId");
+  const db = await getBoardsDB();
   const tx = db.transaction(["assets", "boardSets"], "readwrite");
   const assetStore = tx.objectStore("assets");
 
@@ -301,11 +311,11 @@ export async function putAssets(
 }
 
 export async function getAssetBlob(
-  db: BoardsDB,
   setId: string,
   path: string,
 ): Promise<Blob | undefined> {
   validateId(setId, "setId");
+  const db = await getBoardsDB();
   const cleanPath = normalizePath(path);
   const asset = await db.get("assets", [setId, cleanPath]);
 

--- a/src/features/board/storage/queries.test.ts
+++ b/src/features/board/storage/queries.test.ts
@@ -1,7 +1,7 @@
 import type { OBFBoard } from "@shayc/open-board-format";
 import { beforeEach, describe, expect, test } from "vitest";
 import { invalidateBoardSets } from "./board-sets-store";
-import { putAssets, putBoards, upsertBoardSet, withBoardsDB } from "./db";
+import { putAssets, putBoards, upsertBoardSet } from "./db";
 import { BoardNotFoundError, hydrateBoard } from "./queries";
 import { resetBoardsDB } from "./test-helpers";
 
@@ -31,19 +31,17 @@ async function seedTestBoard(): Promise<void> {
     images: [{ id: "img-1", path: IMAGE_PATH, content_type: "image/png" }],
   };
 
-  await withBoardsDB(async (db) => {
-    await upsertBoardSet(db, {
-      setId: SET_ID,
-      name: "Loader Test",
-      rootBoardId: BOARD_ID,
-    });
-    await putBoards(db, SET_ID, [
-      { boardId: BOARD_ID, name: "Test Board", obf: obfBoard },
-    ]);
-    await putAssets(db, SET_ID, [
-      { path: IMAGE_PATH, blob: pngBlob, mime: "image/png" },
-    ]);
+  await upsertBoardSet({
+    setId: SET_ID,
+    name: "Loader Test",
+    rootBoardId: BOARD_ID,
   });
+  await putBoards(SET_ID, [
+    { boardId: BOARD_ID, name: "Test Board", obf: obfBoard },
+  ]);
+  await putAssets(SET_ID, [
+    { path: IMAGE_PATH, blob: pngBlob, mime: "image/png" },
+  ]);
 
   await invalidateBoardSets();
 }

--- a/src/features/board/storage/queries.ts
+++ b/src/features/board/storage/queries.ts
@@ -10,9 +10,7 @@ import {
   getAssetBlob,
   getBoard,
   updateBoardStrings,
-  withBoardsDB,
   type BoardSetRecord,
-  type BoardsDB,
 } from "./db";
 
 export class BoardNotFoundError extends Error {
@@ -30,7 +28,7 @@ let previousRegistry: ObjectUrlRegistry | null = null;
 export async function getBoardSet(
   setId: string,
 ): Promise<BoardSetRecord | undefined> {
-  return withBoardsDB((db) => dbGetBoardSet(db, setId));
+  return dbGetBoardSet(setId);
 }
 
 export async function persistBoardTranslations(
@@ -39,9 +37,7 @@ export async function persistBoardTranslations(
   locale: string,
   translations: Record<string, string>,
 ): Promise<void> {
-  await withBoardsDB((db) =>
-    updateBoardStrings(db, setId, boardId, locale, translations),
-  );
+  await updateBoardStrings(setId, boardId, locale, translations);
 }
 
 export async function hydrateBoard(
@@ -51,12 +47,9 @@ export async function hydrateBoard(
 ): Promise<Board> {
   const registry = createObjectUrlRegistry();
   try {
-    const board = await withBoardsDB(async (db) => {
-      const obf = await fetchOBFBoard(db, setId, boardId);
-      const hydrated = await hydrateOBFBoard(db, setId, obf, registry);
-
-      return obfToBoard(hydrated);
-    });
+    const obf = await fetchOBFBoard(setId, boardId);
+    const hydrated = await hydrateOBFBoard(setId, obf, registry);
+    const board = obfToBoard(hydrated);
 
     // Don't promote a superseded registry — it would orphan the live one.
     signal?.throwIfAborted();
@@ -73,11 +66,10 @@ export async function hydrateBoard(
 }
 
 async function fetchOBFBoard(
-  db: BoardsDB,
   setId: string,
   boardId: string,
 ): Promise<OBFBoard> {
-  const record = await getBoard(db, setId, boardId);
+  const record = await getBoard(setId, boardId);
   if (!record) {
     throw new BoardNotFoundError(setId, boardId);
   }
@@ -86,21 +78,19 @@ async function fetchOBFBoard(
 }
 
 async function hydrateOBFBoard(
-  db: BoardsDB,
   setId: string,
   board: OBFBoard,
   registry: ObjectUrlRegistry,
 ): Promise<OBFBoard> {
   const [images, sounds] = await Promise.all([
-    hydrateAssets(db, setId, board.images, registry),
-    hydrateAssets(db, setId, board.sounds, registry),
+    hydrateAssets(setId, board.images, registry),
+    hydrateAssets(setId, board.sounds, registry),
   ]);
 
   return { ...board, images, sounds };
 }
 
 async function hydrateAssets(
-  db: BoardsDB,
   setId: string,
   assets: OBFMedia[] | undefined,
   registry: ObjectUrlRegistry,
@@ -116,7 +106,7 @@ async function hydrateAssets(
       }
 
       try {
-        const blob = await getAssetBlob(db, setId, asset.path);
+        const blob = await getAssetBlob(setId, asset.path);
         const url = blob ? registry.create(blob) : null;
 
         return url ? { ...asset, data: url } : asset;

--- a/src/features/board/storage/test-helpers.ts
+++ b/src/features/board/storage/test-helpers.ts
@@ -1,10 +1,5 @@
 import { invalidateBoardSets } from "./board-sets-store";
-import {
-  openBoardsDB,
-  upsertBoardSet,
-  type BoardSetRecord,
-  type BoardsDB,
-} from "./db";
+import { getBoardsDB, upsertBoardSet, type BoardSetRecord } from "./db";
 
 const STORE_NAMES = ["boardSets", "boards", "assets"] as const;
 
@@ -13,7 +8,8 @@ export interface SeedBoardSet extends Partial<BoardSetRecord> {
   rootBoardId: string;
 }
 
-async function clearAllStores(db: BoardsDB): Promise<void> {
+export async function clearBoardsDB(): Promise<void> {
+  const db = await getBoardsDB();
   const tx = db.transaction(STORE_NAMES, "readwrite");
   for (const name of STORE_NAMES) {
     await tx.objectStore(name).clear();
@@ -23,31 +19,14 @@ async function clearAllStores(db: BoardsDB): Promise<void> {
 }
 
 export async function resetBoardsDB(): Promise<void> {
-  const db = await openBoardsDB();
-  try {
-    await clearAllStores(db);
-  } finally {
-    db.close();
-  }
-
+  await clearBoardsDB();
   await invalidateBoardSets();
 }
 
-export async function openCleanBoardsDB(): Promise<BoardsDB> {
-  const db = await openBoardsDB();
-  await clearAllStores(db);
-
-  return db;
-}
-
 export async function seedBoardSets(records: SeedBoardSet[]): Promise<void> {
-  const db = await openCleanBoardsDB();
-  try {
-    for (const record of records) {
-      await upsertBoardSet(db, { name: record.setId, ...record });
-    }
-  } finally {
-    db.close();
+  await clearBoardsDB();
+  for (const record of records) {
+    await upsertBoardSet({ name: record.setId, ...record });
   }
 
   await invalidateBoardSets();

--- a/src/features/board/testing.ts
+++ b/src/features/board/testing.ts
@@ -1,5 +1,4 @@
 export {
-  openCleanBoardsDB,
   resetBoardsDB,
   seedBoardSets,
   type SeedBoardSet,


### PR DESCRIPTION
## What

Replaces the open-close-per-operation model for the boards IndexedDB with **one cached connection per page**, and drops the `db` handle from every storage function and its callers.

Before, every operation opened a fresh connection and closed it (`withBoardsDB`/`openBoardsDB`), and callers threaded `db` through their own private helpers:

```ts
await withBoardsDB((db) => listBoardSets(db));
```

After, the module owns the connection and callers just call the function:

```ts
await listBoardSets();
```

## Why

- **DX:** removes `db`-parameter threading through `board-import` and `queries`; adding a new storage function no longer forces every caller to pass a handle. The idiomatic browser-IndexedDB shape (one long-lived connection) over open/close-per-op.
- **UX:** none intended — this is a pure refactor. (Minor: hot paths like `hydrateBoard` no longer pay an open/close per call, but it's imperceptible.)

## How it works

- `getBoardsDB()` lazily opens and caches one connection. A **failed open clears the cache** so the next call retries instead of handing back a permanently-rejected promise.
- `closeBoardsDB()` resets the cache *before* awaiting, so a rejected open can't wedge teardown. Used by test teardown.
- Test helpers route through the singleton: `openCleanBoardsDB` (returned a handle) → `clearBoardsDB()`; the per-call `try/finally` open/close boilerplate is gone.

## Safety

- **No behavior change.** Each function still opens its own transaction, so **atomicity is unchanged**.
- Full suite green (320 tests); the storage `db.test.ts` `withBoardsDB` block was replaced with `getBoardsDB` tests covering connection reuse and reopen-after-close.
- Net **−109 lines**, almost all boilerplate.

## Known limitation

The open-failure retry path has no regression test — triggering it means mocking `idb`'s `openDB` to reject-then-succeed, a fragile mock for a path that's rare in a single-tab, fixed-`DB_VERSION` app. Worth adding if `DB_VERSION` is ever bumped or multi-tab becomes a concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)