### PR TITLE
refactor(activation): return single-shape intents directly

### DIFF
--- a/src/features/board/activation/intent-resolver.ts
+++ b/src/features/board/activation/intent-resolver.ts
@@ -9,24 +9,18 @@ export type ButtonIntent =
   | { kind: "runAction"; action: BoardAction };
 
 export function resolveButtonIntent(button: BoardButton): ButtonIntent[] {
-  const intents: ButtonIntent[] = [];
-
   const targetBoardId = button.loadBoard?.id;
   if (targetBoardId) {
-    intents.push({ kind: "navigate", targetBoardId });
-
-    return intents;
+    return [{ kind: "navigate", targetBoardId }];
   }
 
   if (button.actions?.length) {
-    for (const action of button.actions) {
-      intents.push({ kind: "runAction", action });
-    }
-
-    return intents;
+    return button.actions.map((action) => ({ kind: "runAction", action }));
   }
 
-  intents.push({ kind: "compose", content: toPartContent(button) });
+  const intents: ButtonIntent[] = [
+    { kind: "compose", content: toPartContent(button) },
+  ];
 
   if (button.soundSrc) {
     intents.push({ kind: "playAudio", src: button.soundSrc });


### PR DESCRIPTION
## Summary

`resolveButtonIntent` opened a shared `intents` accumulator at the top, but the two early branches (navigate, run-actions) each pushed exactly one shape and returned immediately — only the compose path genuinely accumulates. This moves the accumulator to where accumulation actually happens.

- navigate branch returns `[{ kind: "navigate", ... }]` directly
- actions branch returns `button.actions.map(...)` directly
- `intents` is now seeded with the compose intent and grows only through the audio/speech fallthrough

Behavior is identical: branch order, early-return precedence, and the audio-vs-speech fallthrough are untouched. Net −6 lines.

## Test plan

- [x] `npm run lint` clean
- [x] `vitest run intent-resolver.test.ts` — 5/5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)