### PR TITLE
fix(suggestions): live shared context, debounce, and per-language AI

### DIFF
--- a/src/app/settings/ai-settings.tsx
+++ b/src/app/settings/ai-settings.tsx
@@ -8,11 +8,14 @@ import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
-import { useAISharedContext } from "@shared/hooks/use-ai-shared-context";
+import {
+  setAISharedContext,
+  useAISharedContext,
+} from "@shared/hooks/use-ai-shared-context";
 import { type BuiltInAIName, isSupported } from "@shayc/react-built-in-ai";
 
 export function AISettings() {
-  const [sharedContext, setSharedContext] = useAISharedContext();
+  const sharedContext = useAISharedContext();
 
   const capabilities: {
     apiName: BuiltInAIName;
@@ -45,7 +48,7 @@ export function AISettings() {
           placeholder={m.aiCustomInstructionsPlaceholder()}
           helperText={m.aiCustomInstructionsHelper()}
           value={sharedContext}
-          onChange={(e) => setSharedContext(e.target.value)}
+          onChange={(e) => setAISharedContext(e.target.value)}
         />
       )}
 

--- a/src/features/board/suggestions/use-suggestions.test.ts
+++ b/src/features/board/suggestions/use-suggestions.test.ts
@@ -1,18 +1,28 @@
+import { setAISharedContext } from "@shared/hooks/use-ai-shared-context";
+import { LanguageProvider } from "@shared/language/language-provider";
 import {
   makeProofreadResult,
   stubBuiltInAIUnsupported,
   stubProofreader,
   stubRewriter,
 } from "@shared/testing/built-in-ai";
-import { describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { renderHook } from "vitest-browser-react";
 import { useSuggestions } from "./use-suggestions";
 
+function renderSuggestions(text: string) {
+  return renderHook(() => useSuggestions(text), { wrapper: LanguageProvider });
+}
+
 describe("useSuggestions", () => {
+  beforeEach(() => {
+    setAISharedContext("");
+  });
+
   test("reports unsupported and stays empty when no Built-in AI is available", async () => {
     stubBuiltInAIUnsupported("Proofreader", "Rewriter");
 
-    const { result } = await renderHook(() => useSuggestions("want eat"));
+    const { result } = await renderSuggestions("want eat");
 
     await vi.waitFor(() => {
       expect(result.current.isSupported).toBe(false);
@@ -24,7 +34,7 @@ describe("useSuggestions", () => {
     stubProofreader();
     stubBuiltInAIUnsupported("Rewriter");
 
-    const { result } = await renderHook(() => useSuggestions("want eat"));
+    const { result } = await renderSuggestions("want eat");
 
     await vi.waitFor(() => {
       expect(result.current.isSupported).toBe(true);
@@ -37,7 +47,7 @@ describe("useSuggestions", () => {
     stubProofreader(() => makeProofreadResult("I want to eat."));
     stubRewriter(() => "I would like to eat.");
 
-    const { result } = await renderHook(() => useSuggestions("want eat"));
+    const { result } = await renderSuggestions("want eat");
 
     await vi.waitFor(() => {
       expect(result.current.phrases).toEqual([
@@ -51,7 +61,7 @@ describe("useSuggestions", () => {
     stubProofreader(() => makeProofreadResult("Hello."));
     stubRewriter(() => "Hello.");
 
-    const { result } = await renderHook(() => useSuggestions("helo"));
+    const { result } = await renderSuggestions("helo");
 
     await vi.waitFor(() => {
       expect(result.current.phrases).toEqual(["Hello."]);
@@ -62,7 +72,7 @@ describe("useSuggestions", () => {
     stubProofreader((input) => makeProofreadResult(input));
     stubRewriter(() => "Something different.");
 
-    const { result } = await renderHook(() => useSuggestions("unchanged"));
+    const { result } = await renderSuggestions("unchanged");
 
     await vi.waitFor(() => {
       expect(result.current.phrases).toEqual(["Something different."]);
@@ -76,7 +86,7 @@ describe("useSuggestions", () => {
     stubProofreader(() => makeProofreadResult(rejected));
     stubRewriter(() => accepted);
 
-    const { result } = await renderHook(() => useSuggestions("seed"));
+    const { result } = await renderSuggestions("seed");
 
     await vi.waitFor(() => {
       expect(result.current.phrases).toEqual([accepted]);
@@ -84,14 +94,11 @@ describe("useSuggestions", () => {
   });
 
   test("passes the persisted shared context to the rewriter", async () => {
-    localStorage.setItem(
-      "ai-shared-context",
-      JSON.stringify("Talk like a pirate"),
-    );
+    setAISharedContext("Talk like a pirate");
     const { create } = stubRewriter();
     stubBuiltInAIUnsupported("Proofreader");
 
-    await renderHook(() => useSuggestions("ahoy"));
+    await renderSuggestions("ahoy");
 
     await vi.waitFor(() => {
       expect(create.mock.calls.at(0)?.at(0)).toMatchObject({
@@ -103,11 +110,46 @@ describe("useSuggestions", () => {
     });
   });
 
+  test("provisions both engines with the message language", async () => {
+    const { create: createRewriter } = stubRewriter();
+    const { create: createProofreader } = stubProofreader();
+
+    await renderSuggestions("hello");
+
+    await vi.waitFor(() => {
+      expect(createRewriter.mock.calls.at(0)?.at(0)).toMatchObject({
+        expectedInputLanguages: ["en"],
+        expectedContextLanguages: ["en"],
+        outputLanguage: "en",
+      });
+      expect(createProofreader.mock.calls.at(0)?.at(0)).toMatchObject({
+        expectedInputLanguages: ["en"],
+      });
+    });
+  });
+
+  test("uses the selected language rather than English", async () => {
+    // LanguageProvider seeds its state from this key on mount.
+    localStorage.setItem("language", JSON.stringify("he"));
+    const { create } = stubRewriter();
+    stubBuiltInAIUnsupported("Proofreader");
+
+    await renderSuggestions("שלום");
+
+    await vi.waitFor(() => {
+      expect(create.mock.calls.at(0)?.at(0)).toMatchObject({
+        expectedInputLanguages: ["he"],
+        expectedContextLanguages: ["he"],
+        outputLanguage: "he",
+      });
+    });
+  });
+
   test("re-provisions the rewriter with the new tone when the tone changes", async () => {
     const { create } = stubRewriter((input) => `rewritten ${input}`);
     stubBuiltInAIUnsupported("Proofreader");
 
-    const { result } = await renderHook(() => useSuggestions("hi"));
+    const { result } = await renderSuggestions("hi");
 
     await vi.waitFor(() => {
       expect(create.mock.calls.at(0)?.at(0)).toMatchObject({ tone: "as-is" });
@@ -126,7 +168,7 @@ describe("useSuggestions", () => {
     stubRewriter(() => new Promise<string>((resolve) => pending.push(resolve)));
     stubBuiltInAIUnsupported("Proofreader");
 
-    const { result } = await renderHook(() => useSuggestions("hi"));
+    const { result } = await renderSuggestions("hi");
 
     await vi.waitFor(() => expect(pending).toHaveLength(1));
     pending[0]("casual hi");
@@ -159,7 +201,7 @@ describe("useSuggestions", () => {
 
     const { result, rerender } = await renderHook(
       ({ text }: { text: string } = { text: "old" }) => useSuggestions(text),
-      { initialProps: { text: "old" } },
+      { initialProps: { text: "old" }, wrapper: LanguageProvider },
     );
 
     await vi.waitFor(() => {
@@ -191,7 +233,7 @@ describe("useSuggestions", () => {
 
     const { result, rerender } = await renderHook(
       ({ text }: { text: string } = { text: "old" }) => useSuggestions(text),
-      { initialProps: { text: "old" } },
+      { initialProps: { text: "old" }, wrapper: LanguageProvider },
     );
 
     await vi.waitFor(() => {

--- a/src/features/board/suggestions/use-suggestions.ts
+++ b/src/features/board/suggestions/use-suggestions.ts
@@ -1,9 +1,13 @@
 import { useAISharedContext } from "@shared/hooks/use-ai-shared-context";
+import { useDebouncedValue } from "@shared/hooks/use-debounced-value";
+import { useLanguage } from "@shared/language/use-language";
 import { useProofreader, useRewriter } from "@shayc/react-built-in-ai";
 import { useState } from "react";
 import { toPhrases } from "./to-phrases";
 import type { SuggestionTone } from "./types";
 import { useFreshResult } from "./use-fresh-result";
+
+const SHARED_CONTEXT_DEBOUNCE_MS = 400;
 
 export interface UseSuggestionsReturn {
   isSupported: boolean;
@@ -15,15 +19,25 @@ export interface UseSuggestionsReturn {
 }
 
 export function useSuggestions(text: string): UseSuggestionsReturn {
-  const [sharedContext] = useAISharedContext();
+  const sharedContext = useAISharedContext();
+  const debouncedSharedContext = useDebouncedValue(
+    sharedContext,
+    SHARED_CONTEXT_DEBOUNCE_MS,
+  );
   const [tone, setTone] = useState<SuggestionTone>("as-is");
+  const { language } = useLanguage();
 
-  const proofreader = useProofreader();
+  const proofreader = useProofreader({
+    expectedInputLanguages: [language],
+  });
   const rewriter = useRewriter({
     tone,
-    sharedContext,
+    sharedContext: debouncedSharedContext,
     length: "shorter",
     format: "plain-text",
+    expectedInputLanguages: [language],
+    expectedContextLanguages: [language],
+    outputLanguage: language,
   });
 
   const isProofreaderSupported = proofreader.status !== "unsupported";
@@ -33,7 +47,7 @@ export function useSuggestions(text: string): UseSuggestionsReturn {
 
   const corrected = useFreshResult({
     enabled: hasText && proofreader.status === "ready",
-    deps: [text],
+    deps: [text, language],
     fetch: (signal) =>
       proofreader
         .proofread(text, { signal })
@@ -43,7 +57,7 @@ export function useSuggestions(text: string): UseSuggestionsReturn {
 
   const rewritten = useFreshResult({
     enabled: hasText && rewriter.status === "ready",
-    deps: [text, tone, sharedContext],
+    deps: [text, tone, debouncedSharedContext, language],
     fetch: (signal) =>
       rewriter.rewrite(text, { signal }).catch(() => undefined),
   });

--- a/src/shared/hooks/use-ai-shared-context.ts
+++ b/src/shared/hooks/use-ai-shared-context.ts
@@ -1,10 +1,14 @@
-import {
-  type UsePersistentStateReturn,
-  usePersistentState,
-} from "./use-persistent-state";
+import { createPersistedStore } from "@shared/utils/persisted-store";
+import { useSyncExternalStore } from "react";
 
-const STORAGE_KEY = "ai-shared-context";
+const store = createPersistedStore<string>("ai-shared-context", (raw) =>
+  typeof raw === "string" ? raw : "",
+);
 
-export function useAISharedContext(): UsePersistentStateReturn<string> {
-  return usePersistentState<string>(STORAGE_KEY, "");
+export function setAISharedContext(sharedContext: string): void {
+  store.setState(sharedContext);
+}
+
+export function useAISharedContext(): string {
+  return useSyncExternalStore(store.subscribe, store.getSnapshot);
 }

--- a/src/shared/hooks/use-debounced-value.test.ts
+++ b/src/shared/hooks/use-debounced-value.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+import { renderHook } from "vitest-browser-react";
+import { useDebouncedValue } from "./use-debounced-value";
+
+const DELAY = 50;
+
+describe("useDebouncedValue", () => {
+  test("returns the initial value immediately", async () => {
+    const { result } = await renderHook(() => useDebouncedValue("a", DELAY));
+
+    expect(result.current).toBe("a");
+  });
+
+  test("holds the previous value until the delay elapses, then updates", async () => {
+    const { result, rerender } = await renderHook(
+      ({ value }: { value: string } = { value: "a" }) =>
+        useDebouncedValue(value, DELAY),
+      { initialProps: { value: "a" } },
+    );
+
+    await rerender({ value: "b" });
+    expect(result.current).toBe("a");
+
+    await expect.poll(() => result.current).toBe("b");
+  });
+
+  test("collapses a burst of changes into the final value", async () => {
+    const { result, rerender } = await renderHook(
+      ({ value }: { value: string } = { value: "a" }) =>
+        useDebouncedValue(value, DELAY),
+      { initialProps: { value: "a" } },
+    );
+
+    await rerender({ value: "b" });
+    await rerender({ value: "c" });
+    expect(result.current).toBe("a");
+
+    await expect.poll(() => result.current).toBe("c");
+  });
+});

--- a/src/shared/hooks/use-debounced-value.ts
+++ b/src/shared/hooks/use-debounced-value.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from "react";
+
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => setDebounced(value), delayMs);
+
+    return () => clearTimeout(timeoutId);
+  }, [value, delayMs]);
+
+  return debounced;
+}


### PR DESCRIPTION
## Summary

Three related fixes to the AI suggestion bar, surfaced while chasing a "shared context doesn't update" bug.

### 1. Custom instructions now sync live
`ai-shared-context` was a per-instance `usePersistentState` (separate `useState` per call site), so a write in the settings drawer never reached the board's `useSuggestions` until a reload. It now uses a **`createPersistedStore` singleton + `useSyncExternalStore`**, matching the existing `playback-store`/`speech-store` pattern — one shared store, all consumers re-render on change. Exposes a named `setAISharedContext`; `usePersistentState` is left untouched for its other consumers.

### 2. Debounce the rewriter session
`sharedContext` is a **create-time** Rewriter option, so editing instructions over the mounted board recreated the on-device session on every keystroke. A small `useDebouncedValue` (400ms) feeds the debounced value to `useRewriter`, so the session rebuilds only after typing settles. (Sessions were always cleaned up correctly — this was churn, not a leak.)

### 3. Per-language suggestions
Both engines assumed English regardless of the board language. Now the current language is threaded in:
- **Rewriter** — `expectedInputLanguages`, `expectedContextLanguages`, `outputLanguage`
- **Proofreader** — `expectedInputLanguages` (English-only engine naturally goes unavailable for other languages)
- suggestions refetch when language changes

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `vitest run` — 331 pass, incl. new `useDebouncedValue` tests and two `useSuggestions` language tests (default `en` + non-English `he`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)