### PR TITLE
docs: restructure AGENTS.md style and architecture guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,28 +27,54 @@
 
 ## Testing Instructions
 
-- Structure: Colocate tests as `*.test.ts(x)`.
-- Runner: `npm test` runs Vitest browser mode via Playwright (real Chromium).
-- Utilities: Use `vitest-browser-react` for components and interactions.
-- Determinism: No sleeps; prefer real timers — use `vi.useFakeTimers()` only when advancing time deterministically.
-- Mocking: Render the full tree. Do not mock internals (child components, hooks, contexts, providers, utilities) or native web APIs.
-  - **Allowed stubs (closed list):** network (e.g., `fetch`, WebSocket), non-determinism (e.g., `Date.now`, `Math.random`), device output (e.g., `speechSynthesis`, `HTMLAudioElement.play`).
-  - **Method:** Prefer `vi.spyOn` over `vi.mock`.
-- Scope:
+- **Structure:** Colocate tests as `*.test.ts(x)`.
+- **Runner:** `npm test` runs Vitest browser mode via Playwright (real Chromium).
+- **Utilities:** Use `vitest-browser-react` for components and interactions.
+- **Determinism:** No sleeps; prefer real timers — use `vi.useFakeTimers()` only when advancing time deterministically.
+- **Mocking:** Render the full tree. Do not mock internals (child components, hooks, contexts, providers, utilities) or native web APIs.
+  - _Allowed stubs (closed list):_ network (`fetch`, WebSocket), non-determinism (`Date.now`, `Math.random`), device output (`speechSynthesis`, `HTMLAudioElement.play`).
+  - _Method:_ Prefer `vi.spyOn` over `vi.mock`.
+- **Scope:**
   - **Interactive:** Prove a behavior (interaction → observable result).
   - **Presentational:** Render-only assertions for accessibility, content, and visibility.
 
-## Code Style Guidelines
+## Code Style & Architecture Guidelines
 
-- TypeScript: Maintain strict type accuracy; avoid `any` unless unavoidable.
-- Linting: Fix underlying issues explicitly; do not use `eslint-disable` comments.
-- Imports: Prefer path aliases (`@app/*`, `@features/*`, `@shared/*`, `@pages/*`).
-- MUI: Import subpaths (e.g., `@mui/material/Button`) over package root to minimize bundle size.
-- React Compiler: Enabled by default; avoid `useMemo`/`useCallback` micro-optimizations.
-- Syntax: Use braces for `if` statements, even when the body is a single statement.
-- Logic: Prefer early returns over nested or chained ternary operators; extract complex JSX conditions into sub-components.
-- Comments: Prioritize self-documenting code; use inline comments only to explain "why", not "what".
-- Naming: Use meaningful variable names; avoid ambiguous abbreviations.
+> **Scope Note:** The formatting and structural design rules below apply strictly to new code or lines you are actively modifying. Do not apply them globally to untouched background files.
+
+### 1. Visual Layout & Density
+
+- **Paragraphs of Logic:** Group related statements together and use single blank lines to separate logical steps within a function.
+- **Line Breathing:** Break long, dense variable assignments or chained methods into multi-line blocks with consistent indentation.
+- **Explicit Braces:** Always use braces `{}` for `if` statements, even for single-line bodies.
+
+### 2. Branching & Flattening
+
+- **Structural Flattening:** Maximize scannability by using early returns and guard clauses. Keep the "happy path" flush against the left margin instead of nesting logic inside deep `if/else` blocks.
+- **Untangle Cleverness:** Eliminate hyper-dense one-liners and multi-layered nested ternaries. If a conditional operation requires deep evaluation, extract it into a descriptive local variable or a helper function.
+- **JSX Extraction:** Extract complex visual layout conditions or nested mapping loops out of the main return statement into standalone sub-components.
+
+### 3. Naming & Type Integrity
+
+- **Eradicate Vagueness:** Banish broad filler words (`data`, `info`, `manager`) and cryptic abbreviations (`usr`, `idx`, `amt`) unless they are standard loop counters.
+- **Strict Grammar:** Collections must be plural nouns (`activeUsers`). Booleans must pose a clear true/false question (`isFeatureEnabled`). Functions must start with strong, active verbs.
+- **The Silhouette Rule:** Avoid local variables within the same scope that differ by only a single character (`item` vs `items`) or introduce property stuttering (`suggestions.suggestions` should be `suggestions.phrases`).
+- **Omit Redundant Context:** Eliminate parent naming prefixes inside narrow scopes (e.g., inside a `User` type definition, use `name` instead of `userName`).
+- **Strict Typing:** Maintain strict type accuracy across the application. The `any` type is banned unless explicitly requested or handling raw external data edges.
+- **Lint Integrity:** Fix the underlying issue a lint rule flags; never silence it with an `eslint-disable` comment.
+
+### 4. Architecture & Dependencies
+
+- **The Iceberg Rule:** Match your function's level of abstraction. Encapsulate low-level mechanics (the mechanics of "how") inside descriptive helper utilities, leaving the main execution body as a clean, high-level summary of "what" is happening.
+- **Strict Need-to-Know:** Components and functions must only accept the exact leaf data they require to execute. Do not pass a whole `User` object if the component only renders `user.avatarUrl`.
+- **Shorten the Chain:** Avoid long chains of dot-notation (`order.customer.address.city`) that couple code tightly to deeply nested data shapes. Move derivations closer to the data source.
+- **Import Paths & Performance:** Use configured path aliases (`@app/*`, `@features/*`, `@shared/*`, `@pages/*`). Import MUI subpaths directly (e.g., `@mui/material/Button`) rather than from the package root to minimize bundle footprint.
+- **No Micro-Optimization:** The React Compiler is enabled; do not use `useMemo` or `useCallback` for micro-optimizations.
+
+### 5. Commentary & Language
+
+- **Context Over Code:** Delete comments that merely restate what the code execution does. Inline comments must strictly document non-obvious business requirements, edge cases, or technical "whys".
+- **Documentation Cleanliness:** Maintain correct grammar, punctuation, and capitalization across all inline comments.
 
 ## Workflow (Git/PR)
 
@@ -59,20 +85,20 @@
 
 ### Always
 
-- Keep changes scoped; avoid broad refactors or sweeping reformatting.
-- Verify changes: Run `npm run lint`, `npm test`, and `npm run build` before committing.
-- Consistency: Follow existing module boundaries and nearby-file patterns.
+- Keep changes closely scoped; avoid sweeping refactors or structural reformatting outside the task.
+- Verify changes by running `npm run lint`, `npm test`, and `npm run build` locally before pushing or marking a task complete.
+- Follow existing module boundaries and adjacent file design patterns.
 
 ### Ask First
 
-- Dependency updates (`package.json`, `package-lock.json`).
-- Infrastructure changes (CI, build tooling, lint/test config).
-- Data format modifications (OBF/OBZ import/export compatibility).
-- Architecture changes (Large UI rewrites, routing overhaul, cross-cutting refactors).
+- Modifying dependencies (`package.json`, `package-lock.json`).
+- Infrastructure modifications (CI configurations, build tooling, lint/test configs).
+- Data schema or breaking changes affecting import/export compatibility (OBF/OBZ formats).
+- Cross-cutting architectural updates (large UI rewrites, routing changes).
 
 ### Never
 
-- Commit secrets, tokens, or API keys.
-- Suppress linting, typechecking, or tests to force a passing build.
-- Manually edit generated output (`dist/`, `coverage/`).
-- Add telemetry, analytics, or data exfiltration without explicit approval.
+- Commit secrets, environment tokens, or private API keys.
+- Suppress linting directives, bypass typechecking, or drop tests to force a build through.
+- Manually edit or commit generated build artifacts (`dist/`, `coverage/`).
+- Introduce telemetry, analytics, tracking scripts, or any data-exfiltration path.


### PR DESCRIPTION
## Summary

Refresh `AGENTS.md` so the code-style guidance is actionable for coding agents, and tighten two safety rules that the restructure had weakened.

### Code Style & Architecture
- Regroup the flat style list into five themed sections with concrete examples (e.g. `data`/`info`/`manager` vagueness, `suggestions.suggestions → suggestions.phrases` stuttering, leaf-data-not-whole-`User`).
- Add a **Scope Note** limiting the rules to new or actively-modified code, so agents don't reformat untouched files.
- Add an **Architecture & Dependencies** section (abstraction altitude, strict need-to-know, shorten-the-chain).
- Drop brochure styling: removed the `(The X Edit)` header tags, unfused the braces rule from line-wrapping, and moved the React Compiler bullet out of *Branching & Flattening* into the performance group.

### Safety rules
- **Restore the unconditional `eslint-disable` ban** as *Lint Integrity* — the rewrite had left only the narrower "don't suppress to force a build" boundary.
- **Make the telemetry ban absolute** while keeping the `data-exfiltration` wording that the rewrite had dropped.

Docs-only change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)