### PR TITLE
fix(board): honest navigation predicate, consistent speech casing, single load gate

### DIFF
--- a/src/features/board/activation/intent-resolver.ts
+++ b/src/features/board/activation/intent-resolver.ts
@@ -1,5 +1,10 @@
 import type { MessagePartContent } from "../message/use-message";
-import { getSpokenText, type BoardAction, type BoardButton } from "../types";
+import {
+  getNavigationTargetId,
+  getSpokenText,
+  type BoardAction,
+  type BoardButton,
+} from "../types";
 
 export type ButtonIntent =
   | { kind: "navigate"; targetBoardId: string }
@@ -9,7 +14,7 @@ export type ButtonIntent =
   | { kind: "runAction"; action: BoardAction };
 
 export function resolveButtonIntent(button: BoardButton): ButtonIntent[] {
-  const targetBoardId = button.loadBoard?.id;
+  const targetBoardId = getNavigationTargetId(button);
   if (targetBoardId) {
     return [{ kind: "navigate", targetBoardId }];
   }
@@ -27,7 +32,7 @@ export function resolveButtonIntent(button: BoardButton): ButtonIntent[] {
   } else {
     const text = getSpokenText(button);
     if (text) {
-      intents.push({ kind: "speakText", text: text.toLowerCase() });
+      intents.push({ kind: "speakText", text });
     }
   }
 

--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -14,7 +14,7 @@ import { useBoardNavigation } from "./navigation/use-board-navigation";
 import { SuggestionBar } from "./suggestions/suggestion-bar";
 import { useSuggestions } from "./suggestions/use-suggestions";
 import { Tile } from "./tile/tile";
-import type { Board, BoardButton } from "./types";
+import { getNavigationTargetId, type Board, type BoardButton } from "./types";
 
 export interface BoardViewerProps {
   board: Board;
@@ -43,7 +43,7 @@ export function BoardViewer({ board }: BoardViewerProps) {
       imageSrc={button.imageSrc}
       backgroundColor={button.backgroundColor}
       borderColor={button.borderColor}
-      variant={button.loadBoard ? "folder" : undefined}
+      variant={getNavigationTargetId(button) ? "folder" : undefined}
       onClick={() => void activateButton(button)}
       {...props}
     />

--- a/src/features/board/message/use-message-playback.test.ts
+++ b/src/features/board/message/use-message-playback.test.ts
@@ -24,7 +24,7 @@ describe("useMessagePlayback", () => {
     await result.current.play();
 
     expect(speech.speak).toHaveBeenCalledTimes(1);
-    expect(speech.speak.mock.calls[0][0].text).toBe("I want");
+    expect(speech.speak.mock.calls[0][0].text).toBe("i want");
   });
 
   test("plays a sound part as audio rather than speaking it", async () => {
@@ -197,7 +197,7 @@ describe("useMessagePlayback", () => {
     const playPromise = result.current.play();
     await rerender();
 
-    fireBoundary?.(2); // "want" begins at offset 2 in "I want"
+    fireBoundary?.(2); // "want" begins at offset 2 in "i want"
     await rerender();
     expect(result.current.activePartId).toBe("2");
 

--- a/src/features/board/storage/board-sets-store.ts
+++ b/src/features/board/storage/board-sets-store.ts
@@ -38,10 +38,12 @@ async function loadBoardSets(): Promise<void> {
   }
 }
 
-function ensureLoaded(): void {
+function ensureLoaded(): Promise<void> {
   if (!hasLoaded && !pendingLoad) {
     pendingLoad = loadBoardSets();
   }
+
+  return pendingLoad ?? Promise.resolve();
 }
 
 export async function invalidateBoardSets(): Promise<void> {
@@ -56,23 +58,19 @@ export async function notifyBoardSetsChanged(): Promise<void> {
 
 export function subscribeBoardSets(listener: () => void): () => void {
   const unsubscribe = store.subscribe(listener);
-  ensureLoaded();
+  void ensureLoaded();
 
   return unsubscribe;
 }
 
 export function getBoardSetsSnapshot(): BoardSetsSnapshot {
-  ensureLoaded();
+  void ensureLoaded();
 
   return store.getSnapshot();
 }
 
 export async function getBoardSets(): Promise<BoardSetRecord[]> {
-  if (pendingLoad) {
-    await pendingLoad;
-  } else if (!hasLoaded) {
-    await loadBoardSets();
-  }
+  await ensureLoaded();
 
   return store.getSnapshot().boardSets;
 }

--- a/src/features/board/types.ts
+++ b/src/features/board/types.ts
@@ -57,5 +57,11 @@ export type BoardStrings = Record<string, Record<string, string>>;
 export function getSpokenText(
   button: Pick<BoardButton, "vocalization" | "label">,
 ): string | undefined {
-  return button.vocalization ?? button.label;
+  return (button.vocalization ?? button.label)?.toLowerCase();
+}
+
+export function getNavigationTargetId(
+  button: Pick<BoardButton, "loadBoard">,
+): string | undefined {
+  return button.loadBoard?.id;
 }


### PR DESCRIPTION
## Summary

Three small, independent fixes surfaced by a review of `src/features/board` (and refined through an adversarial second pass against `AGENTS.md`):

- **Honest folder affordance.** The folder corner-fold previously keyed off `button.loadBoard` truthiness while navigation keyed off `loadBoard?.id` — so a button referencing an unloadable board (external `url`/`data_url`, or an unresolved `path`) showed a folder but did nothing on tap. A new `getNavigationTargetId(button)` is the single source of truth, consumed by both the intent resolver and `BoardViewer`, so the icon and the route can no longer drift.
- **Consistent speech casing.** A single tap lowercased its spoken text; full-message playback did not — the same word could sound different, and a lone capital "I" was read as "Capital I" on playback. `getSpokenText` now lowercases at the one point every spoken string flows through. Display and AI suggestions are untouched (they use `label`).
- **Single load gate.** `getBoardSets`' cold path called `loadBoardSets()` without registering `pendingLoad`, leaving a window where a concurrent `ensureLoaded` could start a redundant IndexedDB listing. `ensureLoaded` now owns and returns its promise; `getBoardSets` awaits it.

## Verification

- `npm run lint` — clean
- `npm run build` (typecheck) — clean
- `npm test` — **331 passed (41 files)**; one assertion updated (`use-message-playback.test.ts`, `"I want"` → `"i want"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)