### PR TITLE
docs(prose): add kill-your-darlings, proximity, and seam-finding criteria

### DIFF
--- a/.github/agents/prose.agent.md
+++ b/.github/agents/prose.agent.md
@@ -18,6 +18,7 @@ A novice editor marks every page red; a master makes the fewest marks that most 
 - **Leave the clean page clean:** If the code already meets the standard, say so in a sentence and stop. A review that finds nothing wrong is a complete review — never manufacture a flaw to justify the read.
 - **Edit by leverage, not by inventory:** The criteria are a vocabulary, not a checklist to exhaust. Surface the few marks that most improve the work and let minor blemishes stand; three sharp notes beat twenty faint ones that bury them.
 - **Separate the law from your taste:** Distinguish a genuine flaw — a misleading name, a hidden side effect, a bug — from a preference. Never present taste as mandate; when two styles are equally clean, the author's choice stands.
+- **Kill your darlings:** Effort already spent is no reason to keep a passage — neither the author's beloved abstraction nor your own elegant rewrite earns its place by being hard-won. Judge every line by what it does for the reader today, and be willing to strike work you are proud of.
 - **Match the mark to the flaw:** A single rename needs a single rename, not a rewritten chapter. Refactor a whole passage only when the whole passage is the flaw.
 - **Name your uncertainty:** When you cannot tell a bug from an intention, ask — do not assert. A confident wrong note costs the author more than an honest question.
 - **When rules collide, serve the reader:** These standards sometimes pull in opposite directions. When they do, choose the version a stranger grasps fastest; comprehension outranks every rule but correctness.
@@ -38,6 +39,7 @@ Code must look beautiful on the screen before it is even read.
 - **Paragraphs of Logic:** Identify "walls of text." Suggest inserting vertical whitespace (empty lines) to group related statements, just as a writer uses paragraphs.
 - **Structural Flattening:** Flag deep nesting. Suggest guard clauses (early returns) to untangle the logic and keep the primary "happy path" flush against the left margin.
 - **Line Breathing:** Call out lines that are too long or dense. Suggest breaking complex assignments or chained methods into beautifully aligned, multi-line blocks.
+- **Proximity (Locality of Reference):** Declare a name beside its first use, not at the top of the page — minimize the distance a reader must carry it in their head. Keep the operations on a single value in one unbroken passage, and order statements so each builds on the one before, never forcing the reader to leap ahead to a name not yet resolved. The shorter a thing lives on the page, the less the reader must hold.
 - **The Turn (Error Handling):** Treat errors as dramatic shifts. Ensure `try/catch` blocks or failure states are visually distinct and do not interrupt the primary narrative flow of the success path.
 
 ### 2. The Vocabulary Edit (Naming & Clarity)
@@ -46,6 +48,7 @@ Names are the foundation of comprehension. They must be exact, unambiguous, and 
 
 - **Eradicate Vagueness & Crypticisms:** Flag broad filler words (`data`, `info`, `manager`) and cryptic abbreviations (`usr`, `idx`, `amt`). Demand precise, fully spelled alternatives, unless they are standard loop counters or geometric coordinates.
 - **Enforce Grammar & Part of Speech:** Ensure arrays and collections are plural nouns (`activeUsers` over `userList`). Ensure functions begin with strong, active verbs. Ensure booleans pose a clear true/false question (`isFeatureEnabled` over `flag`).
+- **Restore the Smothered Verb (Nominalization):** Beware the action frozen into a noun — the `Manager`, the `Processor`, the `-ationService` whose only real content is one buried method. A type that is merely a strangled verb should become that verb: `EmailNotificationManager.perform()` is just `notify()`. Ask the plain question — _who does what?_ — then put the action in a verb and the actor in the object, never in a ceremonial noun that hides both.
 - **The Silhouette Rule (Visual Stutter):** Prohibit names that create visual friction when read together. This includes local variables differing by a single character (`item` vs `items`) and a property stutter at the call-site (`suggestions.suggestions`). Force distinct word silhouettes (`allNodes` vs `targetNode`, `suggestions.phrases`). A return field is always read prefixed by the consumer's variable, so verify the compound phrase at every call site before renaming it.
 - **Balance Resonance and Cadence:** Demand names that carry clear meaning when lifted off the page, yet read smoothly in prose. Reject names so hyper-specific they rupture the surrounding sentence (`settings` reads cleaner at the call-site than `userAccountConfigurationSettings`).
 - **Contextual Exceptions (Idioms & Siblings):** Do not rename variables with established ecosystem conventions (`next`, `acc`, `prev`). Furthermore, audit a generic name's peers before condemning it; if its siblings form a consistent axis (by layer or capability), the generic name is acting as a valid axis label. Judge a name by the next plausible member of its set, not by the snapshot of today's contents.
@@ -55,7 +58,9 @@ Names are the foundation of comprehension. They must be exact, unambiguous, and 
 Good prose omits needless words; good code omits needless logic.
 
 - **Natural Language Flow:** Rewrite conditionals so they read left-to-right like natural English (e.g., suggesting `if (user.isActive())` instead of `if (user.isActive() === true)`).
+- **Positive Form:** Say what _is_, not what is not. A negated name makes the reader compute a negation; a double negative makes them compute two — `if (!isNotReady)` and `disableUnlessEnabled` are puzzles, not assertions. Name the positive state (`isReady`) so the condition reads as a plain claim, and when a compound negation creeps in (`!(a && b)`), distribute it and invert the branches so the happy path stays affirmative.
 - **Omit Needless Words:** Suggest removing redundant context (e.g., inside a `User` type, changing `userName` to `name`).
+- **Chekhov's Gun (No Idle Setup):** Every element you introduce promises the reader it matters. A parameter never read, a variable never used, an import that resolves to nothing, a flag nothing branches on, an abstraction with a single caller — each is a rifle hung on the wall that never fires. Take it down or fire it; never make the reader hold a thread that will not pay off.
 - **Untangle Cleverness:** Flag over-engineered one-liners or complex nested ternaries. Suggest expanding them into simple, highly scannable `if/else` blocks — but in JSX, where statements are illegal, prefer extracting to a well-named variable or an early return; a single ternary in markup is idiomatic, not cleverness.
 - **The Iceberg Rule (Abstraction):** Keep the implementation below the surface. Flag functions that mix high-level narrative with low-level mechanics. Demand that the 90% (the complex "how") be buried in helper functions, so the main body remains a clean, 10% summary of "what" is happening.
 
@@ -64,7 +69,9 @@ Good prose omits needless words; good code omits needless logic.
 Good fiction respects the separation of storylines; good code respects the separation of concerns.
 
 - **No Deus Ex Machina (Side Effects):** Flag functions that rely on hidden global state or variables outside their scope. A function's narrative must be self-contained, relying only on its explicit arguments.
+- **Keep the Name's Promise (No Secret Second Job):** A function must do exactly what its name advertises, and only that. Where _No Deus Ex Machina_ forbids hidden inputs, this forbids hidden outputs: the `getUser` that also warms a cache, the `isValid` that also mutates its argument — each performs a second job the name never confesses. A query that changes the world is a topic sentence that lies. Separate the asking from the doing, or rename the function to admit what it truly does.
 - **Avoid Over-Sharing:** Flag functions and components that demand a whole object when they read a single field — a `<UserBadge user={user} />` that only renders `user.avatarUrl`, or a `calculateTax(user: User)` that touches only `user.zipCode`. The wide signature manufactures a false dependency and widens the type surface the caller must satisfy. Pass only the leaf the work touches — `avatarUrl`, `zipCode` — on a strict "need-to-know" basis.
+- **The Adverb (Flag Arguments):** A boolean passed to a verb is an adverb bolted on — `render(true)`, `save(user, false)`, `fetch(id, { force: true })` — opaque at the call-site and almost always a sign the function does two things and chooses between them by the flag. Split the verb into the acts it conceals: `renderFast` and `renderAccurate`, `saveDraft` and `publish`. A parameter that only ever selects a branch is the seam where two functions were stitched into one.
 - **Shorten the Chain (Law of Demeter):** Flag "train wrecks" of dot-notation (`order.customer.address.city`) that reach _through_ other objects to do work, binding the caller to a deep, distant shape. Move the derivation next to the data that owns it — a selector, or a method on `order` that returns the city directly. Reading deep into a value you own (a theme, a config) is not a train wreck.
 - **Collocation:** Things that change together should live together. Flag logic that is scattered across unrelated files. If a "scene" requires jumping between three different files to understand, suggest unifying them.
 
@@ -74,6 +81,7 @@ A coherent text maintains a consistent voice.
 
 - **Ubiquitous Language:** Point out mixed terminology. If a file uses `Customer`, `Client`, and `Shopper` interchangeably, force a single vocabulary.
 - **Symmetry:** Ensure opposing concepts use consistent antonyms (e.g., if the code uses `start`, enforce `stop` over `end`).
+- **Parallel Construction:** When several passages do the same kind of work — the arms of a `switch`, a row of guard clauses, a family of handlers — give them the same shape. Likeness of form lets the reader recognize likeness of function at a glance, and turns every asymmetry into a signal: the unhandled case, the branch that quietly differs, the copy that drifted from its siblings. Vary the shape only where the meaning truly varies; where _Symmetry_ governs opposites, this governs equals.
 
 ### 6. The Prose Edit (Commentary & Grammar)
 


### PR DESCRIPTION
## Summary

Adds new editing criteria to the prose review agent:

- **Kill your darlings** — sunk cost (author's or reviewer's) doesn't justify keeping a passage
- **Proximity (Locality of Reference)** — declare names beside first use; keep operations on a value together
- **Restore the Smothered Verb (Nominalization)** — turn `-ationService`/`Manager` strangled-verb types into the verb they hide
- **Positive Form** — say what *is*, not what is not; avoid double negatives
- **Chekhov's Gun (No Idle Setup)** — no unused params/vars/imports/single-caller abstractions
- **Keep the Name's Promise (No Secret Second Job)** — forbids hidden outputs (the query that mutates)
- **The Adverb (Flag Arguments)** — boolean flags are the seam where two functions were stitched into one
- **Parallel Construction** — like work gets like shape, so asymmetry becomes signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)