### PR TITLE
refactor(import): one name for the path→id map

### DIFF
--- a/src/features/board/import/board-import.ts
+++ b/src/features/board/import/board-import.ts
@@ -76,14 +76,14 @@ function buildBoardPathIndex(manifest: OBFManifest): Map<string, string> {
 
 export function resolveLoadBoardPaths(
   obfBoard: OBFBoard,
-  boardIdByPath: Map<string, string>,
+  boardPathToId: Map<string, string>,
 ): OBFBoard {
   const buttons = obfBoard.buttons.map((obfButton) => {
     if (!obfButton.load_board?.path || obfButton.load_board.id) {
       return obfButton;
     }
 
-    const targetBoardId = boardIdByPath.get(obfButton.load_board.path);
+    const targetBoardId = boardPathToId.get(obfButton.load_board.path);
     if (!targetBoardId) {
       return obfButton;
     }


### PR DESCRIPTION
## What

`resolveLoadBoardPaths` named the path-keyed, id-valued map `boardIdByPath`, while its definition and every other use named it `boardPathToId`. The two read in opposite directions ("path → id" vs "id by path"), forcing a double-take to confirm they're the same value. Unify on `boardPathToId`.

Pure rename of one parameter and its single use — behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)