### PR TITLE
test(a11y): assert no axe-core violations in browser mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@vitejs/plugin-react": "^6.0.2",
         "@vitest/browser-playwright": "^4.1.8",
         "@vitest/coverage-v8": "^4.1.8",
+        "axe-core": "^4.12.0",
         "babel-plugin-react-compiler": "^1.0.0",
         "eslint": "^10.4.1",
         "eslint-config-prettier": "^10.1.8",
@@ -4368,6 +4369,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.0.tgz",
+      "integrity": "sha512-FTavr/7Ba0IptwGOPxnQvdyW2tAsdLBMTBXz7rKH6xJ2skpyxpBxyHkDdBs4lf69yRqYpkqCdfhnwS8YULGOmg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/babel-plugin-macros": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@vitejs/plugin-react": "^6.0.2",
     "@vitest/browser-playwright": "^4.1.8",
     "@vitest/coverage-v8": "^4.1.8",
+    "axe-core": "^4.12.0",
     "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "^10.4.1",
     "eslint-config-prettier": "^10.1.8",

--- a/src/features/board/board-viewer.test.tsx
+++ b/src/features/board/board-viewer.test.tsx
@@ -1,4 +1,5 @@
 import { AppProviders } from "@app/app-providers";
+import { expectNoA11yViolations } from "@shared/testing/axe";
 import { stubAudio, stubSpeech } from "@shared/testing/device-output";
 import type { OBFBoard } from "@shayc/open-board-format";
 import { MemoryRouter } from "react-router";
@@ -70,5 +71,11 @@ describe("BoardViewer", () => {
     await expect
       .element(screen.getByRole("grid", { name: "Communication board" }))
       .toBeVisible();
+  });
+
+  test("has no accessibility violations", async () => {
+    const screen = await renderBoardViewer(TWO_TILE_BOARD);
+
+    await expectNoA11yViolations(screen.container);
   });
 });

--- a/src/shared/testing/axe.ts
+++ b/src/shared/testing/axe.ts
@@ -11,7 +11,7 @@ export async function expectNoA11yViolations(
     const nodes = violation.nodes
       .map((node) => node.target.join(" "))
       .join("\n    ");
-    return `${violation.id} (${violation.impact}): ${violation.help}\n  ${violation.helpUrl}\n    ${nodes}`;
+    return `${violation.id} (${violation.impact ?? "unknown"}): ${violation.help}\n  ${violation.helpUrl}\n    ${nodes}`;
   });
 
   expect(violations.length, report.join("\n\n")).toBe(0);

--- a/src/shared/testing/axe.ts
+++ b/src/shared/testing/axe.ts
@@ -1,0 +1,18 @@
+import * as axe from "axe-core";
+import { expect } from "vitest";
+
+export async function expectNoA11yViolations(
+  target: Element,
+  options: axe.RunOptions = {},
+) {
+  const { violations } = await axe.run(target, options);
+
+  const report = violations.map((violation) => {
+    const nodes = violation.nodes
+      .map((node) => node.target.join(" "))
+      .join("\n    ");
+    return `${violation.id} (${violation.impact}): ${violation.help}\n  ${violation.helpUrl}\n    ${nodes}`;
+  });
+
+  expect(violations.length, report.join("\n\n")).toBe(0);
+}


### PR DESCRIPTION
## Summary
Adds axe-core accessibility assertions to the browser-mode test suite.

- Adds `axe-core` as a devDependency
- New reusable `expectNoA11yViolations(target, options?)` helper in `src/shared/testing/axe.ts`, scoped to the rendered subtree, that folds rule id, impact, help text, URL, and offending node selectors into the failure message
- Asserts `BoardViewer` renders with no violations

## Verification
- Lint, `tsc --noEmit`, and the `board-viewer` suite (4/4) all pass

## Follow-up
The helper is the real deliverable — broadening adoption to higher-risk surfaces (import flow, settings/AI dialogs, focus management) is worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)