### PR TITLE
test(a11y): scan composed message and suggestion bar states

### DIFF
--- a/src/features/board/board-viewer.test.tsx
+++ b/src/features/board/board-viewer.test.tsx
@@ -1,5 +1,6 @@
 import { AppProviders } from "@app/app-providers";
 import { expectNoA11yViolations } from "@shared/testing/axe";
+import { TEST_IMAGE_SRC } from "@shared/testing/fixtures";
 import { stubAudio, stubSpeech } from "@shared/testing/device-output";
 import type { OBFBoard } from "@shayc/open-board-format";
 import { MemoryRouter } from "react-router";
@@ -17,6 +18,21 @@ const TWO_TILE_BOARD: OBFBoard = {
     { id: "btn-2", label: "world" },
   ],
   grid: { rows: 1, columns: 2, order: [["btn-1", "btn-2"]] },
+};
+
+const PICTOGRAM_BOARD: OBFBoard = {
+  format: "open-board-0.1",
+  id: "pictogram-board",
+  locale: "en",
+  buttons: [
+    { id: "btn-1", label: "hello", image_id: "img-1" },
+    { id: "btn-2", label: "world", image_id: "img-2" },
+  ],
+  grid: { rows: 1, columns: 2, order: [["btn-1", "btn-2"]] },
+  images: [
+    { id: "img-1", data: TEST_IMAGE_SRC },
+    { id: "img-2", data: TEST_IMAGE_SRC },
+  ],
 };
 
 function renderBoardViewer(obfBoard: OBFBoard) {
@@ -75,6 +91,15 @@ describe("BoardViewer", () => {
 
   test("has no accessibility violations", async () => {
     const screen = await renderBoardViewer(TWO_TILE_BOARD);
+
+    await expectNoA11yViolations(screen.container);
+  });
+
+  test("has no accessibility violations with a composed message", async () => {
+    const screen = await renderBoardViewer(PICTOGRAM_BOARD);
+
+    await screen.getByRole("button", { name: "hello" }).click();
+    await screen.getByRole("button", { name: "world" }).click();
 
     await expectNoA11yViolations(screen.container);
   });

--- a/src/features/board/suggestions/suggestion-bar.test.tsx
+++ b/src/features/board/suggestions/suggestion-bar.test.tsx
@@ -1,3 +1,4 @@
+import { expectNoA11yViolations } from "@shared/testing/axe";
 import { describe, expect, test, vi } from "vitest";
 import { render } from "vitest-browser-react";
 import { SuggestionBar } from "./suggestion-bar";
@@ -88,5 +89,20 @@ describe("SuggestionBar", () => {
     await expect
       .element(screen.getByRole("button", { name: "direct tone" }))
       .not.toBeInTheDocument();
+  });
+
+  test("has no accessibility violations", async () => {
+    const handlers = createHandlers();
+
+    const screen = await render(
+      <SuggestionBar
+        suggestions={["Hello", "How are you?", "Thank you"]}
+        tone="as-is"
+        canChangeTone
+        {...handlers}
+      />,
+    );
+
+    await expectNoA11yViolations(screen.container);
   });
 });


### PR DESCRIPTION
## Summary
- Add an axe-core a11y scan of `BoardViewer` after composing a message from pictogram tiles, covering the composed-message bar state.
- Add an axe-core a11y scan of `SuggestionBar` in its rendered state with suggestions and tone-change enabled.

## Test plan
- `npm run test -- src/features/board/board-viewer.test.tsx src/features/board/suggestions/suggestion-bar.test.tsx` — 10 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)