### PR TITLE
chore: shorten GitHub link label and sync dark-mode shell color

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "يساعد {appName} الأشخاص الذين لا يستطيعون الاعتماد على الكلام على التواصل بسهولة وطبيعية أكبر. يستخدم الذكاء الاصطناعي على الجهاز لتصحيح القواعد، وضبط النبرة، وترجمة الرسائل فورًا وبخصوصية.",
   "aboutAcknowledgmentsHeading": "شكر وتقدير",
   "aboutAcknowledgments": "الفائز بـ {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. مبني على {#obf}Open Board Format{/obf} ويتضمّن مفردات Quick Core 24 من {#openaac}OpenAAC{/openaac}.",
-  "aboutViewSource": "عرض الكود المصدري على GitHub",
+  "aboutViewSource": "عرض على GitHub",
   "onboardingTagline": "تواصل بسهولة وطبيعية أكبر.",
   "onboardingSmartRewritingTitle": "إعادة صياغة ذكية",
   "onboardingSmartRewritingDescription": "حوّل العبارات القصيرة إلى جمل واضحة.",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} помага на хората, които не могат да разчитат на речта, да общуват по-лесно и по-естествено. Използва ИИ директно на устройството, за да коригира граматиката, да настройва тона и да превежда съобщенията мигновено и поверително.",
   "aboutAcknowledgmentsHeading": "Благодарности",
   "aboutAcknowledgments": "Победител в {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. Изградено върху {#obf}Open Board Format{/obf} и включва речника Quick Core 24 от {#openaac}OpenAAC{/openaac}.",
-  "aboutViewSource": "Преглед на изходния код в GitHub",
+  "aboutViewSource": "Преглед в GitHub",
   "onboardingTagline": "Общувайте по-лесно и по-естествено.",
   "onboardingSmartRewritingTitle": "Интелигентно преписване",
   "onboardingSmartRewritingDescription": "Превърнете кратки фрази в ясни изречения.",

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} এমন মানুষদের সাহায্য করে যারা কথার উপর নির্ভর করতে পারেন না, যাতে তাঁরা আরও সহজে ও স্বাভাবিকভাবে যোগাযোগ করতে পারেন। এটি ব্যাকরণ সংশোধন, টোন সমন্বয় এবং বার্তা তাৎক্ষণিকভাবে ও গোপনীয়ভাবে অনুবাদ করতে ডিভাইসে থাকা AI ব্যবহার করে।",
   "aboutAcknowledgmentsHeading": "কৃতজ্ঞতা স্বীকার",
   "aboutAcknowledgments": "{#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}-এর বিজয়ী। {#obf}Open Board Format{/obf}-এর উপর নির্মিত এবং এতে {#openaac}OpenAAC{/openaac}-এর Quick Core 24 শব্দভাণ্ডার অন্তর্ভুক্ত রয়েছে।",
-  "aboutViewSource": "GitHub-এ সোর্স কোড দেখুন",
+  "aboutViewSource": "GitHub-এ দেখুন",
   "onboardingTagline": "আরও সহজে ও স্বাভাবিকভাবে যোগাযোগ করুন।",
   "onboardingSmartRewritingTitle": "স্মার্ট পুনর্লিখন",
   "onboardingSmartRewritingDescription": "ছোট বাক্যাংশকে স্পষ্ট বাক্যে রূপান্তর করুন।",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} pomáhá lidem, kteří se nemohou spolehnout na řeč, komunikovat snáze a přirozeněji. Využívá AI přímo v zařízení k opravě gramatiky, úpravě tónu a okamžitému a soukromému překladu zpráv.",
   "aboutAcknowledgmentsHeading": "Poděkování",
   "aboutAcknowledgments": "Vítěz soutěže {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. Postaveno na formátu {#obf}Open Board Format{/obf} a obsahuje slovní zásobu Quick Core 24 od {#openaac}OpenAAC{/openaac}.",
-  "aboutViewSource": "Zobrazit zdrojový kód na GitHubu",
+  "aboutViewSource": "Zobrazit na GitHubu",
   "onboardingTagline": "Komunikujte snáze a přirozeněji.",
   "onboardingSmartRewritingTitle": "Chytrý přepis",
   "onboardingSmartRewritingDescription": "Proměňte krátké fráze v jasné věty.",

--- a/messages/da.json
+++ b/messages/da.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} hjælper mennesker, der ikke kan stole på tale, med at kommunikere lettere og mere naturligt. Appen bruger AI på enheden til at rette grammatik, justere tonen og oversætte beskeder med det samme og privat.",
   "aboutAcknowledgmentsHeading": "Tak til",
   "aboutAcknowledgments": "Vinder af {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. Bygget på {#obf}Open Board Format{/obf} og indeholder Quick Core 24-ordforrådet fra {#openaac}OpenAAC{/openaac}.",
-  "aboutViewSource": "Se kildekoden på GitHub",
+  "aboutViewSource": "Se på GitHub",
   "onboardingTagline": "Kommunikér lettere og mere naturligt.",
   "onboardingSmartRewritingTitle": "Smart omskrivning",
   "onboardingSmartRewritingDescription": "Forvandl korte sætninger til klare sætninger.",

--- a/messages/de.json
+++ b/messages/de.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} hilft Menschen, die sich nicht auf Sprache verlassen können, einfacher und natürlicher zu kommunizieren. Die App nutzt KI direkt auf dem Gerät, um Grammatik zu korrigieren, den Ton anzupassen und Nachrichten sofort und privat zu übersetzen.",
   "aboutAcknowledgmentsHeading": "Danksagungen",
   "aboutAcknowledgments": "Gewinner der {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. Entwickelt auf Basis des {#obf}Open Board Format{/obf} und enthält das Quick-Core-24-Vokabular von {#openaac}OpenAAC{/openaac}.",
-  "aboutViewSource": "Quellcode auf GitHub ansehen",
+  "aboutViewSource": "Auf GitHub ansehen",
   "onboardingTagline": "Kommuniziere einfacher und natürlicher.",
   "onboardingSmartRewritingTitle": "Intelligentes Umformulieren",
   "onboardingSmartRewritingDescription": "Verwandle kurze Wendungen in klare Sätze.",

--- a/messages/el.json
+++ b/messages/el.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "Το {appName} βοηθά τους ανθρώπους που δεν μπορούν να βασιστούν στην ομιλία να επικοινωνούν πιο εύκολα και φυσικά. Χρησιμοποιεί AI στη συσκευή για να διορθώνει τη γραμματική, να προσαρμόζει τον τόνο και να μεταφράζει μηνύματα άμεσα και ιδιωτικά.",
   "aboutAcknowledgmentsHeading": "Ευχαριστίες",
   "aboutAcknowledgments": "Νικητής του {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. Βασισμένο στο {#obf}Open Board Format{/obf} και περιλαμβάνει το λεξιλόγιο Quick Core 24 του {#openaac}OpenAAC{/openaac}.",
-  "aboutViewSource": "Προβολή πηγαίου κώδικα στο GitHub",
+  "aboutViewSource": "Προβολή στο GitHub",
   "onboardingTagline": "Επικοινωνήστε πιο εύκολα και φυσικά.",
   "onboardingSmartRewritingTitle": "Έξυπνη αναδιατύπωση",
   "onboardingSmartRewritingDescription": "Μετατρέψτε σύντομες φράσεις σε σαφείς προτάσεις.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} helps people who can't rely on speech communicate more easily and naturally. It uses on-device AI to correct grammar, adjust tone, and translate messages instantly and privately.",
   "aboutAcknowledgmentsHeading": "Acknowledgments",
   "aboutAcknowledgments": "Winner of the {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. Built on the {#obf}Open Board Format{/obf} and includes {#openaac}OpenAAC{/openaac}'s Quick Core 24 vocabulary.",
-  "aboutViewSource": "View source code on GitHub",
+  "aboutViewSource": "View on GitHub",
   "onboardingTagline": "Communicate more easily and naturally.",
   "onboardingSmartRewritingTitle": "Smart rewriting",
   "onboardingSmartRewritingDescription": "Turn short phrases into clear sentences.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} ayuda a las personas que no pueden depender del habla a comunicarse de forma más fácil y natural. Utiliza IA en el dispositivo para corregir la gramática, ajustar el tono y traducir mensajes de forma instantánea y privada.",
   "aboutAcknowledgmentsHeading": "Agradecimientos",
   "aboutAcknowledgments": "Ganador del {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. Desarrollado sobre el {#obf}Open Board Format{/obf} e incluye el vocabulario Quick Core 24 de {#openaac}OpenAAC{/openaac}.",
-  "aboutViewSource": "Ver el código fuente en GitHub",
+  "aboutViewSource": "Ver en GitHub",
   "onboardingTagline": "Comunícate de forma más fácil y natural.",
   "onboardingSmartRewritingTitle": "Reescritura inteligente",
   "onboardingSmartRewritingDescription": "Convierte frases cortas en oraciones claras.",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} auttaa ihmisiä, jotka eivät voi luottaa puheeseen, kommunikoimaan helpommin ja luonnollisemmin. Se käyttää laitteessa toimivaa tekoälyä kieliopin korjaamiseen, sävyn säätämiseen ja viestien kääntämiseen välittömästi ja yksityisesti.",
   "aboutAcknowledgmentsHeading": "Kiitokset",
   "aboutAcknowledgments": "Kilpailun {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge} voittaja. Rakennettu {#obf}Open Board Format{/obf} -muodon päälle ja sisältää {#openaac}OpenAAC{/openaac}:n Quick Core 24 -sanaston.",
-  "aboutViewSource": "Näytä lähdekoodi GitHubissa",
+  "aboutViewSource": "Näytä GitHubissa",
   "onboardingTagline": "Kommunikoi helpommin ja luonnollisemmin.",
   "onboardingSmartRewritingTitle": "Älykäs uudelleenkirjoitus",
   "onboardingSmartRewritingDescription": "Muunna lyhyet ilmaukset selkeiksi lauseiksi.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} aide les personnes qui ne peuvent pas compter sur la parole à communiquer plus facilement et naturellement. L'application utilise une IA exécutée sur l'appareil pour corriger la grammaire, ajuster le ton et traduire les messages instantanément et en toute confidentialité.",
   "aboutAcknowledgmentsHeading": "Remerciements",
   "aboutAcknowledgments": "Lauréat du {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. Développé sur le {#obf}Open Board Format{/obf} et inclut le vocabulaire Quick Core 24 d'{#openaac}OpenAAC{/openaac}.",
-  "aboutViewSource": "Voir le code source sur GitHub",
+  "aboutViewSource": "Voir sur GitHub",
   "onboardingTagline": "Communiquez plus facilement et naturellement.",
   "onboardingSmartRewritingTitle": "Réécriture intelligente",
   "onboardingSmartRewritingDescription": "Transformez des phrases courtes en phrases claires.",

--- a/messages/he.json
+++ b/messages/he.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} מסייע לאנשים שאינם יכולים להסתמך על דיבור לתקשר בצורה קלה וטבעית יותר. המערכת משתמשת בבינה מלאכותית המופעלת ישירות על המכשיר (On-device AI) כדי לתקן שגיאות דקדוק, להתאים את טון הדיבור ולתרגם הודעות באופן מיידי ובפרטיות מלאה.",
   "aboutAcknowledgmentsHeading": "תודות והערכה",
   "aboutAcknowledgments": "הזוכה באתגר {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. פותח על בסיס פורמט {#obf}Open Board Format{/obf} וכולל את אוצר המילים Quick Core 24 של {#openaac}OpenAAC{/openaac}.",
-  "aboutViewSource": "הצגת קוד המקור ב-GitHub",
+  "aboutViewSource": "צפה ב-GitHub",
   "onboardingTagline": "לתקשר בקלות ובאופן טבעי.",
   "onboardingSmartRewritingTitle": "שכתוב חכם",
   "onboardingSmartRewritingDescription": "הפיכת ביטויים קצרים למשפטים מלאים וברורים.",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} उन लोगों की मदद करता है जो बोलने पर निर्भर नहीं रह सकते, ताकि वे अधिक आसानी और स्वाभाविक रूप से संवाद कर सकें। यह व्याकरण सुधारने, टोन समायोजित करने और संदेशों का तुरंत व निजी रूप से अनुवाद करने के लिए डिवाइस पर मौजूद AI का उपयोग करता है।",
   "aboutAcknowledgmentsHeading": "आभार",
   "aboutAcknowledgments": "{#challenge}Google Chrome Built-in AI Challenge 2025{/challenge} का विजेता। {#obf}Open Board Format{/obf} पर निर्मित और इसमें {#openaac}OpenAAC{/openaac} की Quick Core 24 शब्दावली शामिल है।",
-  "aboutViewSource": "GitHub पर सोर्स कोड देखें",
+  "aboutViewSource": "GitHub पर देखें",
   "onboardingTagline": "अधिक आसानी और स्वाभाविक रूप से संवाद करें।",
   "onboardingSmartRewritingTitle": "स्मार्ट पुनर्लेखन",
   "onboardingSmartRewritingDescription": "छोटे वाक्यांशों को स्पष्ट वाक्यों में बदलें।",

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} pomaže osobama koje se ne mogu osloniti na govor da komuniciraju lakše i prirodnije. Koristi umjetnu inteligenciju na uređaju za ispravljanje gramatike, prilagodbu tona te trenutačan i privatan prijevod poruka.",
   "aboutAcknowledgmentsHeading": "Zahvale",
   "aboutAcknowledgments": "Pobjednik natjecanja {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. Izgrađeno na formatu {#obf}Open Board Format{/obf} i uključuje rječnik Quick Core 24 organizacije {#openaac}OpenAAC{/openaac}.",
-  "aboutViewSource": "Pogledaj izvorni kôd na GitHubu",
+  "aboutViewSource": "Pogledaj na GitHubu",
   "onboardingTagline": "Komunicirajte lakše i prirodnije.",
   "onboardingSmartRewritingTitle": "Pametno preoblikovanje",
   "onboardingSmartRewritingDescription": "Pretvorite kratke izraze u jasne rečenice.",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "A(z) {appName} segít azoknak, akik nem támaszkodhatnak a beszédre, hogy könnyebben és természetesebben kommunikáljanak. Az eszközön futó MI-t használja a nyelvtan javítására, a hangnem beállítására, valamint az üzenetek azonnali és privát fordítására.",
   "aboutAcknowledgmentsHeading": "Köszönetnyilvánítás",
   "aboutAcknowledgments": "A(z) {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge} győztese. A(z) {#obf}Open Board Format{/obf} alapra épül, és tartalmazza a(z) {#openaac}OpenAAC{/openaac} Quick Core 24 szókészletét.",
-  "aboutViewSource": "Forráskód megtekintése a GitHubon",
+  "aboutViewSource": "Megtekintés a GitHubon",
   "onboardingTagline": "Kommunikálj könnyebben és természetesebben.",
   "onboardingSmartRewritingTitle": "Okos átfogalmazás",
   "onboardingSmartRewritingDescription": "Alakítsd a rövid kifejezéseket világos mondatokká.",

--- a/messages/id.json
+++ b/messages/id.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} membantu orang yang tidak dapat mengandalkan ucapan untuk berkomunikasi dengan lebih mudah dan alami. Aplikasi ini menggunakan AI di perangkat untuk mengoreksi tata bahasa, menyesuaikan nada, dan menerjemahkan pesan secara instan dan pribadi.",
   "aboutAcknowledgmentsHeading": "Ucapan terima kasih",
   "aboutAcknowledgments": "Pemenang {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. Dibuat di atas {#obf}Open Board Format{/obf} dan menyertakan kosakata Quick Core 24 dari {#openaac}OpenAAC{/openaac}.",
-  "aboutViewSource": "Lihat kode sumber di GitHub",
+  "aboutViewSource": "Lihat di GitHub",
   "onboardingTagline": "Berkomunikasi dengan lebih mudah dan alami.",
   "onboardingSmartRewritingTitle": "Penulisan ulang cerdas",
   "onboardingSmartRewritingDescription": "Ubah frasa singkat menjadi kalimat yang jelas.",

--- a/messages/it.json
+++ b/messages/it.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} aiuta le persone che non possono affidarsi alla parola a comunicare in modo più facile e naturale. Utilizza un'IA eseguita sul dispositivo per correggere la grammatica, regolare il tono e tradurre i messaggi in modo istantaneo e privato.",
   "aboutAcknowledgmentsHeading": "Ringraziamenti",
   "aboutAcknowledgments": "Vincitore del {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. Sviluppato sull'{#obf}Open Board Format{/obf} e include il vocabolario Quick Core 24 di {#openaac}OpenAAC{/openaac}.",
-  "aboutViewSource": "Visualizza il codice sorgente su GitHub",
+  "aboutViewSource": "Visualizza su GitHub",
   "onboardingTagline": "Comunica in modo più facile e naturale.",
   "onboardingSmartRewritingTitle": "Riscrittura intelligente",
   "onboardingSmartRewritingDescription": "Trasforma frasi brevi in frasi chiare.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} は、発話に頼れない人々がより簡単に自然にコミュニケーションできるよう支援します。デバイス上の AI を使用して、文法を修正し、トーンを調整し、メッセージを即座に、プライベートに翻訳します。",
   "aboutAcknowledgmentsHeading": "謝辞",
   "aboutAcknowledgments": "{#challenge}Google Chrome Built-in AI Challenge 2025{/challenge} の受賞作品です。{#obf}Open Board Format{/obf} を基盤として構築され、{#openaac}OpenAAC{/openaac} の Quick Core 24 語彙を含んでいます。",
-  "aboutViewSource": "GitHub でソースコードを見る",
+  "aboutViewSource": "GitHub で見る",
   "onboardingTagline": "より簡単に、より自然にコミュニケーション。",
   "onboardingSmartRewritingTitle": "スマートリライト",
   "onboardingSmartRewritingDescription": "短いフレーズを明確な文に変換します。",

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "ಮಾತಿನ ಮೇಲೆ ಅವಲಂಬಿತರಾಗಲಾಗದ ಜನರು ಹೆಚ್ಚು ಸುಲಭವಾಗಿ ಮತ್ತು ಸಹಜವಾಗಿ ಸಂವಹನ ನಡೆಸಲು {appName} ಸಹಾಯ ಮಾಡುತ್ತದೆ. ವ್ಯಾಕರಣವನ್ನು ಸರಿಪಡಿಸಲು, ಧಾಟಿಯನ್ನು ಹೊಂದಿಸಲು ಮತ್ತು ಸಂದೇಶಗಳನ್ನು ತಕ್ಷಣವೇ ಹಾಗೂ ಖಾಸಗಿಯಾಗಿ ಅನುವಾದಿಸಲು ಇದು ಸಾಧನದಲ್ಲಿನ AI ಅನ್ನು ಬಳಸುತ್ತದೆ.",
   "aboutAcknowledgmentsHeading": "ಕೃತಜ್ಞತೆಗಳು",
   "aboutAcknowledgments": "{#challenge}Google Chrome Built-in AI Challenge 2025{/challenge} ನ ವಿಜೇತ. {#obf}Open Board Format{/obf} ಮೇಲೆ ನಿರ್ಮಿಸಲಾಗಿದೆ ಮತ್ತು {#openaac}OpenAAC{/openaac} ನ Quick Core 24 ಶಬ್ದಕೋಶವನ್ನು ಒಳಗೊಂಡಿದೆ.",
-  "aboutViewSource": "GitHub ನಲ್ಲಿ ಮೂಲ ಕೋಡ್ ವೀಕ್ಷಿಸಿ",
+  "aboutViewSource": "GitHub ನಲ್ಲಿ ವೀಕ್ಷಿಸಿ",
   "onboardingTagline": "ಹೆಚ್ಚು ಸುಲಭವಾಗಿ ಮತ್ತು ಸಹಜವಾಗಿ ಸಂವಹನ ನಡೆಸಿ.",
   "onboardingSmartRewritingTitle": "ಸ್ಮಾರ್ಟ್ ಮರುಬರವಣಿಗೆ",
   "onboardingSmartRewritingDescription": "ಚಿಕ್ಕ ನುಡಿಗಟ್ಟುಗಳನ್ನು ಸ್ಪಷ್ಟ ವಾಕ್ಯಗಳಾಗಿ ಪರಿವರ್ತಿಸಿ.",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName}은(는) 말에 의존할 수 없는 사람들이 더 쉽고 자연스럽게 의사소통할 수 있도록 돕습니다. 기기 내 AI를 사용해 문법을 교정하고, 어조를 조정하며, 메시지를 즉시 비공개로 번역합니다.",
   "aboutAcknowledgmentsHeading": "감사의 말",
   "aboutAcknowledgments": "{#challenge}Google Chrome Built-in AI Challenge 2025{/challenge} 수상작입니다. {#obf}Open Board Format{/obf}을 기반으로 제작되었으며 {#openaac}OpenAAC{/openaac}의 Quick Core 24 어휘를 포함합니다.",
-  "aboutViewSource": "GitHub에서 소스 코드 보기",
+  "aboutViewSource": "GitHub에서 보기",
   "onboardingTagline": "더 쉽고 자연스럽게 의사소통하세요.",
   "onboardingSmartRewritingTitle": "스마트 다시 쓰기",
   "onboardingSmartRewritingDescription": "짧은 문구를 명확한 문장으로 바꿉니다.",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} helpt mensen die niet op spraak kunnen vertrouwen om gemakkelijker en natuurlijker te communiceren. De app gebruikt AI op het apparaat om grammatica te corrigeren, de toon aan te passen en berichten direct en privé te vertalen.",
   "aboutAcknowledgmentsHeading": "Met dank aan",
   "aboutAcknowledgments": "Winnaar van de {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. Gebouwd op het {#obf}Open Board Format{/obf} en bevat de Quick Core 24-woordenschat van {#openaac}OpenAAC{/openaac}.",
-  "aboutViewSource": "Broncode bekijken op GitHub",
+  "aboutViewSource": "Bekijken op GitHub",
   "onboardingTagline": "Communiceer gemakkelijker en natuurlijker.",
   "onboardingSmartRewritingTitle": "Slim herschrijven",
   "onboardingSmartRewritingDescription": "Zet korte zinnen om in heldere zinnen.",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} pomaga osobom, które nie mogą polegać na mowie, komunikować się łatwiej i bardziej naturalnie. Wykorzystuje AI działającą na urządzeniu, aby poprawiać gramatykę, dostosowywać ton i tłumaczyć wiadomości natychmiast i prywatnie.",
   "aboutAcknowledgmentsHeading": "Podziękowania",
   "aboutAcknowledgments": "Zwycięzca {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. Zbudowano na podstawie {#obf}Open Board Format{/obf} i zawiera słownictwo Quick Core 24 od {#openaac}OpenAAC{/openaac}.",
-  "aboutViewSource": "Zobacz kod źródłowy na GitHub",
+  "aboutViewSource": "Zobacz na GitHubie",
   "onboardingTagline": "Komunikuj się łatwiej i bardziej naturalnie.",
   "onboardingSmartRewritingTitle": "Inteligentne przeredagowanie",
   "onboardingSmartRewritingDescription": "Zamień krótkie frazy w jasne zdania.",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "O {appName} ajuda pessoas que não podem depender da fala a se comunicarem de forma mais fácil e natural. Ele usa IA no dispositivo para corrigir a gramática, ajustar o tom e traduzir mensagens de forma instantânea e privada.",
   "aboutAcknowledgmentsHeading": "Agradecimentos",
   "aboutAcknowledgments": "Vencedor do {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. Desenvolvido sobre o {#obf}Open Board Format{/obf} e inclui o vocabulário Quick Core 24 do {#openaac}OpenAAC{/openaac}.",
-  "aboutViewSource": "Ver o código-fonte no GitHub",
+  "aboutViewSource": "Ver no GitHub",
   "onboardingTagline": "Comunique-se de forma mais fácil e natural.",
   "onboardingSmartRewritingTitle": "Reescrita inteligente",
   "onboardingSmartRewritingDescription": "Transforme frases curtas em frases claras.",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} ajută persoanele care nu se pot baza pe vorbire să comunice mai ușor și mai natural. Folosește AI pe dispozitiv pentru a corecta gramatica, a ajusta tonul și a traduce mesajele instantaneu și privat.",
   "aboutAcknowledgmentsHeading": "Mulțumiri",
   "aboutAcknowledgments": "Câștigător al {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. Construit pe {#obf}Open Board Format{/obf} și include vocabularul Quick Core 24 de la {#openaac}OpenAAC{/openaac}.",
-  "aboutViewSource": "Vezi codul sursă pe GitHub",
+  "aboutViewSource": "Vezi pe GitHub",
   "onboardingTagline": "Comunică mai ușor și mai natural.",
   "onboardingSmartRewritingTitle": "Rescriere inteligentă",
   "onboardingSmartRewritingDescription": "Transformă expresiile scurte în propoziții clare.",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} помогает людям, которые не могут полагаться на речь, общаться легче и естественнее. Приложение использует ИИ прямо на устройстве, чтобы исправлять грамматику, корректировать тон и мгновенно и конфиденциально переводить сообщения.",
   "aboutAcknowledgmentsHeading": "Благодарности",
   "aboutAcknowledgments": "Победитель {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. Создано на основе {#obf}Open Board Format{/obf} и включает словарь Quick Core 24 от {#openaac}OpenAAC{/openaac}.",
-  "aboutViewSource": "Посмотреть исходный код на GitHub",
+  "aboutViewSource": "Посмотреть на GitHub",
   "onboardingTagline": "Общайтесь легче и естественнее.",
   "onboardingSmartRewritingTitle": "Умное перефразирование",
   "onboardingSmartRewritingDescription": "Превращайте короткие фразы в понятные предложения.",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} pomáha ľuďom, ktorí sa nemôžu spoľahnúť na reč, komunikovať jednoduchšie a prirodzenejšie. Využíva AI priamo v zariadení na opravu gramatiky, úpravu tónu a okamžitý a súkromný preklad správ.",
   "aboutAcknowledgmentsHeading": "Poďakovanie",
   "aboutAcknowledgments": "Víťaz súťaže {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. Postavené na formáte {#obf}Open Board Format{/obf} a obsahuje slovnú zásobu Quick Core 24 od {#openaac}OpenAAC{/openaac}.",
-  "aboutViewSource": "Zobraziť zdrojový kód na GitHube",
+  "aboutViewSource": "Zobraziť na GitHube",
   "onboardingTagline": "Komunikujte jednoduchšie a prirodzenejšie.",
   "onboardingSmartRewritingTitle": "Inteligentný prepis",
   "onboardingSmartRewritingDescription": "Premeňte krátke frázy na jasné vety.",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} pomaga ljudem, ki se ne morejo zanašati na govor, da komunicirajo lažje in bolj naravno. Uporablja UI v napravi za popravljanje slovnice, prilagajanje tona ter takojšnje in zasebno prevajanje sporočil.",
   "aboutAcknowledgmentsHeading": "Zahvale",
   "aboutAcknowledgments": "Zmagovalec natečaja {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. Zgrajeno na formatu {#obf}Open Board Format{/obf} in vključuje besedišče Quick Core 24 organizacije {#openaac}OpenAAC{/openaac}.",
-  "aboutViewSource": "Ogled izvorne kode na GitHubu",
+  "aboutViewSource": "Ogled na GitHubu",
   "onboardingTagline": "Komunicirajte lažje in bolj naravno.",
   "onboardingSmartRewritingTitle": "Pametno preoblikovanje",
   "onboardingSmartRewritingDescription": "Kratke fraze spremenite v jasne stavke.",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} hjälper personer som inte kan förlita sig på tal att kommunicera enklare och mer naturligt. Appen använder AI på enheten för att korrigera grammatik, justera tonen och översätta meddelanden direkt och privat.",
   "aboutAcknowledgmentsHeading": "Tack till",
   "aboutAcknowledgments": "Vinnare av {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. Byggd på {#obf}Open Board Format{/obf} och innehåller Quick Core 24-vokabulären från {#openaac}OpenAAC{/openaac}.",
-  "aboutViewSource": "Visa källkoden på GitHub",
+  "aboutViewSource": "Visa på GitHub",
   "onboardingTagline": "Kommunicera enklare och mer naturligt.",
   "onboardingSmartRewritingTitle": "Smart omskrivning",
   "onboardingSmartRewritingDescription": "Omvandla korta fraser till tydliga meningar.",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} பேச்சை நம்பியிருக்க முடியாதவர்கள் எளிதாகவும் இயல்பாகவும் தொடர்புகொள்ள உதவுகிறது. இது இலக்கணத்தைச் சரிசெய்யவும், தொனியைச் சீரமைக்கவும், செய்திகளை உடனடியாகவும் தனிப்பட்ட முறையிலும் மொழிபெயர்க்கவும் சாதனத்தில் உள்ள AI ஐப் பயன்படுத்துகிறது.",
   "aboutAcknowledgmentsHeading": "நன்றியுரை",
   "aboutAcknowledgments": "{#challenge}Google Chrome Built-in AI Challenge 2025{/challenge} இன் வெற்றியாளர். {#obf}Open Board Format{/obf} மீது உருவாக்கப்பட்டது, மேலும் {#openaac}OpenAAC{/openaac} இன் Quick Core 24 சொற்களஞ்சியத்தை உள்ளடக்கியது.",
-  "aboutViewSource": "GitHub இல் மூலக் குறியீட்டைப் பார்",
+  "aboutViewSource": "GitHub இல் பார்க்க",
   "onboardingTagline": "எளிதாகவும் இயல்பாகவும் தொடர்புகொள்ளுங்கள்.",
   "onboardingSmartRewritingTitle": "ஸ்மார்ட் மறுஎழுத்து",
   "onboardingSmartRewritingDescription": "குறுகிய சொற்றொடர்களைத் தெளிவான வாக்கியங்களாக மாற்றுங்கள்.",

--- a/messages/te.json
+++ b/messages/te.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "మాట్లాడటంపై ఆధారపడలేని వ్యక్తులు మరింత సులభంగా, సహజంగా సంభాషించడానికి {appName} సహాయపడుతుంది. వ్యాకరణాన్ని సరిచేయడానికి, టోన్‌ను సర్దుబాటు చేయడానికి, సందేశాలను తక్షణమే, గోప్యంగా అనువదించడానికి ఇది పరికరంలోని AIని ఉపయోగిస్తుంది.",
   "aboutAcknowledgmentsHeading": "కృతజ్ఞతలు",
   "aboutAcknowledgments": "{#challenge}Google Chrome Built-in AI Challenge 2025{/challenge} విజేత. {#obf}Open Board Format{/obf}పై నిర్మించబడింది మరియు {#openaac}OpenAAC{/openaac} యొక్క Quick Core 24 పదజాలాన్ని కలిగి ఉంది.",
-  "aboutViewSource": "GitHubలో సోర్స్ కోడ్‌ను చూడండి",
+  "aboutViewSource": "GitHubలో చూడండి",
   "onboardingTagline": "మరింత సులభంగా, సహజంగా సంభాషించండి.",
   "onboardingSmartRewritingTitle": "స్మార్ట్ రీరైటింగ్",
   "onboardingSmartRewritingDescription": "చిన్న పదబంధాలను స్పష్టమైన వాక్యాలుగా మార్చండి.",

--- a/messages/th.json
+++ b/messages/th.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} ช่วยให้ผู้ที่ไม่สามารถพึ่งพาการพูดสื่อสารได้ง่ายและเป็นธรรมชาติมากขึ้น โดยใช้ AI บนอุปกรณ์เพื่อแก้ไขไวยากรณ์ ปรับโทน และแปลข้อความได้ทันทีและเป็นส่วนตัว",
   "aboutAcknowledgmentsHeading": "กิตติกรรมประกาศ",
   "aboutAcknowledgments": "ผู้ชนะ {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge} พัฒนาบน {#obf}Open Board Format{/obf} และมีคลังคำศัพท์ Quick Core 24 ของ {#openaac}OpenAAC{/openaac}",
-  "aboutViewSource": "ดูซอร์สโค้ดบน GitHub",
+  "aboutViewSource": "ดูบน GitHub",
   "onboardingTagline": "สื่อสารได้ง่ายและเป็นธรรมชาติมากขึ้น",
   "onboardingSmartRewritingTitle": "การเขียนใหม่อัจฉริยะ",
   "onboardingSmartRewritingDescription": "เปลี่ยนวลีสั้นๆ ให้เป็นประโยคที่ชัดเจน",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName}, konuşmaya güvenemeyen kişilerin daha kolay ve doğal bir şekilde iletişim kurmasına yardımcı olur. Dil bilgisini düzeltmek, tonu ayarlamak ve mesajları anında ve gizli biçimde çevirmek için cihaz üzerinde çalışan yapay zekayı kullanır.",
   "aboutAcknowledgmentsHeading": "Teşekkürler",
   "aboutAcknowledgments": "{#challenge}Google Chrome Built-in AI Challenge 2025{/challenge} kazananı. {#obf}Open Board Format{/obf} üzerine geliştirildi ve {#openaac}OpenAAC{/openaac} tarafından sunulan Quick Core 24 sözcük dağarcığını içerir.",
-  "aboutViewSource": "Kaynak kodu GitHub'da görüntüle",
+  "aboutViewSource": "GitHub'da görüntüle",
   "onboardingTagline": "Daha kolay ve doğal iletişim kurun.",
   "onboardingSmartRewritingTitle": "Akıllı yeniden yazma",
   "onboardingSmartRewritingDescription": "Kısa ifadeleri açık cümlelere dönüştürün.",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} допомагає людям, які не можуть покладатися на мовлення, спілкуватися легше та природніше. Застосунок використовує ШІ безпосередньо на пристрої, щоб виправляти граматику, коригувати тон і миттєво та конфіденційно перекладати повідомлення.",
   "aboutAcknowledgmentsHeading": "Подяки",
   "aboutAcknowledgments": "Переможець {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. Створено на основі {#obf}Open Board Format{/obf} і містить словник Quick Core 24 від {#openaac}OpenAAC{/openaac}.",
-  "aboutViewSource": "Переглянути вихідний код на GitHub",
+  "aboutViewSource": "Переглянути на GitHub",
   "onboardingTagline": "Спілкуйтеся легше та природніше.",
   "onboardingSmartRewritingTitle": "Розумне переписування",
   "onboardingSmartRewritingDescription": "Перетворюйте короткі фрази на зрозумілі речення.",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} giúp những người không thể dựa vào lời nói giao tiếp dễ dàng và tự nhiên hơn. Ứng dụng sử dụng AI trên thiết bị để sửa ngữ pháp, điều chỉnh giọng điệu và dịch tin nhắn ngay lập tức và riêng tư.",
   "aboutAcknowledgmentsHeading": "Lời cảm ơn",
   "aboutAcknowledgments": "Người chiến thắng {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. Được xây dựng trên {#obf}Open Board Format{/obf} và bao gồm bộ từ vựng Quick Core 24 của {#openaac}OpenAAC{/openaac}.",
-  "aboutViewSource": "Xem mã nguồn trên GitHub",
+  "aboutViewSource": "Xem trên GitHub",
   "onboardingTagline": "Giao tiếp dễ dàng và tự nhiên hơn.",
   "onboardingSmartRewritingTitle": "Viết lại thông minh",
   "onboardingSmartRewritingDescription": "Biến những cụm từ ngắn thành câu rõ ràng.",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -93,7 +93,7 @@
   "aboutAppDescription": "{appName} 帮助无法依靠言语的人更轻松、更自然地沟通。它使用设备端 AI 来纠正语法、调整语气，并即时、私密地翻译消息。",
   "aboutAcknowledgmentsHeading": "致谢",
   "aboutAcknowledgments": "{#challenge}Google Chrome Built-in AI Challenge 2025{/challenge} 的获奖作品。基于 {#obf}Open Board Format{/obf} 构建，并包含 {#openaac}OpenAAC{/openaac} 的 Quick Core 24 词汇表。",
-  "aboutViewSource": "在 GitHub 上查看源代码",
+  "aboutViewSource": "在 GitHub 上查看",
   "onboardingTagline": "更轻松、更自然地沟通。",
   "onboardingSmartRewritingTitle": "智能改写",
   "onboardingSmartRewritingDescription": "将简短的短语转化为清晰的句子。",

--- a/src/shared/components/external-link.tsx
+++ b/src/shared/components/external-link.tsx
@@ -3,8 +3,8 @@ import Link, { type LinkProps } from "@mui/material/Link";
 export function ExternalLink(props: Omit<LinkProps, "target" | "rel">) {
   return (
     <Link
-      underline="hover"
       {...props}
+      underline="always"
       target="_blank"
       rel="noopener noreferrer"
     />

--- a/src/shared/theme/theme-colors.ts
+++ b/src/shared/theme/theme-colors.ts
@@ -1,6 +1,6 @@
 // SHELL paints the bars and chrome; CONTENT is the reading surface.
 export const SHELL_LIGHT = "#ffffff";
-export const SHELL_DARK = "#222222";
+export const SHELL_DARK = "#121212";
 
 export const CONTENT_LIGHT = "#ffffff";
 export const CONTENT_DARK = "#121212";


### PR DESCRIPTION
## Summary
- Shorten the About-page source link from "View source code on GitHub" to "View on GitHub" across all 35 locales, and force the external link to always show its underline.
- Sync the dark-mode shell color (`SHELL_DARK`) to the content background (`#121212`), mirroring light mode where shell and content are both `#ffffff`.

## Test plan
- Visual check in dark mode: header/drawer now share the content background, separated only by the AppBar divider.
- About page link reads "View on GitHub" and is underlined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)