### PR TITLE
docs(readme): drop rot-prone model names from AI stack line

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ npm run build           # Typecheck + production build
 ## Technical stack
 
 - **UI:** React 19 (with the React Compiler), TypeScript, Material UI, React Router
-- **AI:** Gemini Nano (Chrome) / Phi-4 Mini (Edge), via browser-native APIs
+- **AI:** Proofreader, Rewriter & Translator APIs (browser-native, on-device)
 - **Speech:** Web Speech API
 - **Storage:** IndexedDB (offline-first PWA shell)
 - **Data:** open-board-format (OBF/OBZ file parsing)


### PR DESCRIPTION
Replaces `Gemini Nano (Chrome) / Phi-4 Mini (Edge)` in the Technical stack with the stable API surface — `Proofreader, Rewriter & Translator APIs (browser-native, on-device)`.

**Why:** browsers swap their on-device models over time (e.g. Edge's local model is changing), so naming specific models dates the README and undercuts a portfolio piece. The API names are standards-track and stable, and the new line is parallel to its sibling stack bullets (named tech first, qualifier in parens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)