### PR TITLE
test(suggestions): assert tone changes don't re-invoke the proofreader

### DIFF
--- a/src/features/board/suggestions/use-suggestions.test.ts
+++ b/src/features/board/suggestions/use-suggestions.test.ts
@@ -162,6 +162,28 @@ describe("useSuggestions", () => {
     });
   });
 
+  test("changing tone re-invokes only the rewriter, leaving the proofreader untouched", async () => {
+    const { proofread, create: createProofreader } = stubProofreader();
+    const { create: createRewriter } = stubRewriter();
+
+    const { result } = await renderSuggestions("want eat");
+
+    await vi.waitFor(() => {
+      expect(proofread).toHaveBeenCalledTimes(1);
+    });
+    expect(createProofreader).toHaveBeenCalledTimes(1);
+
+    result.current.setTone("more-formal");
+
+    await vi.waitFor(() => {
+      const tones = createRewriter.mock.calls.map((call) => call.at(0)?.tone);
+      expect(tones).toContain("more-formal");
+    });
+
+    expect(proofread).toHaveBeenCalledTimes(1);
+    expect(createProofreader).toHaveBeenCalledTimes(1);
+  });
+
   test("drops the stale rewrite when the tone changes, until the new tone resolves", async () => {
     const pending: ((rewritten: string) => void)[] = [];
     stubRewriter(() => new Promise<string>((resolve) => pending.push(resolve)));


### PR DESCRIPTION
Adds a test locking in that tone is a rewriter-only concern: changing the tone re-provisions the rewriter for the new tone but leaves the proofreader neither re-run (`proofread`) nor rebuilt (`create`).

**Why:** the proofreader's and rewriter's `useLatestAsync` blocks are structurally parallel and adjacent. The proofreader's `deps` deliberately exclude `tone`; a copy-paste that added it would fire a redundant on-device proofread on every tone toggle (wasted inference, flickering suggestions). No existing test covered this — the sibling tone test disables the proofreader, so it can't catch a leak.

Standalone rather than merged into the existing tone test, for test independence (single reason to fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)