### PR TITLE
Audit follow-ups: doc-link fix, hydration abort (O2), persisted-store debounce (O3)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,7 @@ Built-in AI is a leaf-level enhancement, not the architecture: when available, i
 
 The codebase is **feature-sliced**. The single feature today is `board`. Layers and import rules:
 
-- `@app/*` — app shell, providers, routing, top-level dialogs/drawers.
+- `@app/*` — app shell, routing, top-level dialogs/drawers.
 - `@features/*` — self-contained feature modules. May import from `@shared/*`. Must **not** import from `@app/*` or from each other.
 - `@pages/*` — route components. Compose features and shared UI.
 - `@shared/*` — cross-cutting code (Built-in AI hooks, speech, language, snackbar, theme, utilities). No knowledge of features.
@@ -54,7 +54,7 @@ LanguageProvider              // selected language + Paraglide locale
 
 Order is load-bearing: `ThemeProvider` reads `direction` from `useLanguage()` to pick the LTR or RTL emotion cache and theme. Speech is not a provider — it lives in a module-level store (§6). `LanguageProvider` keeps that store in sync via `useVoiceLanguageSync`, which auto-selects a default voice for the active language whenever the current voice doesn't match. It also synchronizes Paraglide's runtime locale during render so the first paint after a language change is already translated.
 
-**See:** [src/app/app-router.tsx](../src/app/app-router.tsx), [src/app/loaders/](../src/app/loaders/), [src/app/layouts/app-shell.tsx](../src/app/layouts/app-shell.tsx), [src/app/app-providers.tsx](../src/app/app-providers.tsx), [src/shared/language/language-provider.tsx](../src/shared/language/language-provider.tsx).
+**See:** [src/app/app-router.tsx](../src/app/app-router.tsx), [src/app/loaders/](../src/app/loaders/), [src/app/layouts/app-shell.tsx](../src/app/layouts/app-shell.tsx), [src/shared/providers/app-providers.tsx](../src/shared/providers/app-providers.tsx), [src/shared/language/language-provider.tsx](../src/shared/language/language-provider.tsx).
 
 ## 4. Loading a board
 

--- a/src/features/board/storage/board-hydration.ts
+++ b/src/features/board/storage/board-hydration.ts
@@ -25,10 +25,12 @@ export async function hydrateBoard(
   const registry = createObjectUrlRegistry();
   try {
     const obf = await fetchOBFBoard(setId, boardId);
+
+    signal?.throwIfAborted();
+
     const hydrated = await hydrateOBFBoard(setId, obf, registry);
     const board = obfToBoard(hydrated);
 
-    // Don't promote a superseded registry — it would orphan the live one.
     signal?.throwIfAborted();
 
     const previous = previousRegistry;

--- a/src/shared/playback/playback-store.test.ts
+++ b/src/shared/playback/playback-store.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { renderHook } from "vitest-browser-react";
 import {
   parsePlaybackConfig,
@@ -36,8 +36,10 @@ describe("playback-store", () => {
     await rerender();
 
     expect(result.current.highlightActivePart).toBe(true);
-    expect(localStorage.getItem("playback-config")).toBe(
-      JSON.stringify({ highlightActivePart: true }),
+    await vi.waitFor(() =>
+      expect(localStorage.getItem("playback-config")).toBe(
+        JSON.stringify({ highlightActivePart: true }),
+      ),
     );
   });
 });

--- a/src/shared/utils/debounce.test.ts
+++ b/src/shared/utils/debounce.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test, vi } from "vitest";
+import { debounce } from "./debounce";
+
+describe("debounce", () => {
+  test("delays the call until the wait elapses", () => {
+    vi.useFakeTimers();
+    try {
+      const fn = vi.fn();
+      const debounced = debounce(fn, 200);
+
+      debounced();
+      expect(fn).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(200);
+      expect(fn).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("coalesces rapid calls into one, using the latest arguments", () => {
+    vi.useFakeTimers();
+    try {
+      const fn = vi.fn<(value: string) => void>();
+      const debounced = debounce(fn, 200);
+
+      debounced("a");
+      debounced("b");
+      debounced("c");
+      vi.advanceTimersByTime(200);
+
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(fn).toHaveBeenCalledWith("c");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("restarts the wait on each call", () => {
+    vi.useFakeTimers();
+    try {
+      const fn = vi.fn();
+      const debounced = debounce(fn, 200);
+
+      debounced();
+      vi.advanceTimersByTime(150);
+      debounced();
+      vi.advanceTimersByTime(150);
+      expect(fn).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(50);
+      expect(fn).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/shared/utils/debounce.ts
+++ b/src/shared/utils/debounce.ts
@@ -1,0 +1,11 @@
+export function debounce<Args extends unknown[]>(
+  fn: (...args: Args) => void,
+  delayMs: number,
+): (...args: Args) => void {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  return (...args: Args) => {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => fn(...args), delayMs);
+  };
+}

--- a/src/shared/utils/persisted-store.test.ts
+++ b/src/shared/utils/persisted-store.test.ts
@@ -54,26 +54,4 @@ describe("createPersistedStore", () => {
       vi.useRealTimers();
     }
   });
-
-  test("coalesces a burst of setStates into a single write", () => {
-    vi.useFakeTimers();
-    try {
-      const store = createPersistedStore("counter", parseCounter);
-      const setItem = vi.spyOn(Storage.prototype, "setItem");
-
-      store.setState({ count: 1 });
-      store.setState({ count: 2 });
-      store.setState({ count: 3 });
-      vi.runAllTimers();
-
-      expect(setItem).toHaveBeenCalledTimes(1);
-      expect(localStorage.getItem("counter")).toBe(
-        JSON.stringify({ count: 3 }),
-      );
-
-      setItem.mockRestore();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
 });

--- a/src/shared/utils/persisted-store.test.ts
+++ b/src/shared/utils/persisted-store.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { createPersistedStore } from "./persisted-store";
 
 interface Counter {
@@ -38,11 +38,42 @@ describe("createPersistedStore", () => {
     expect(store.getSnapshot()).toEqual({ count: 0 });
   });
 
-  test("writes the snapshot back to localStorage on setState", () => {
-    const store = createPersistedStore("counter", parseCounter);
+  test("writes the snapshot back to localStorage after a debounce", () => {
+    vi.useFakeTimers();
+    try {
+      const store = createPersistedStore("counter", parseCounter);
 
-    store.setState({ count: 9 });
+      store.setState({ count: 9 });
+      expect(localStorage.getItem("counter")).toBeNull();
 
-    expect(localStorage.getItem("counter")).toBe(JSON.stringify({ count: 9 }));
+      vi.runAllTimers();
+      expect(localStorage.getItem("counter")).toBe(
+        JSON.stringify({ count: 9 }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("coalesces a burst of setStates into a single write", () => {
+    vi.useFakeTimers();
+    try {
+      const store = createPersistedStore("counter", parseCounter);
+      const setItem = vi.spyOn(Storage.prototype, "setItem");
+
+      store.setState({ count: 1 });
+      store.setState({ count: 2 });
+      store.setState({ count: 3 });
+      vi.runAllTimers();
+
+      expect(setItem).toHaveBeenCalledTimes(1);
+      expect(localStorage.getItem("counter")).toBe(
+        JSON.stringify({ count: 3 }),
+      );
+
+      setItem.mockRestore();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/shared/utils/persisted-store.ts
+++ b/src/shared/utils/persisted-store.ts
@@ -1,3 +1,4 @@
+import { debounce } from "./debounce";
 import { createExternalStore, type ExternalStore } from "./external-store";
 
 const PERSIST_DEBOUNCE_MS = 200;
@@ -18,17 +19,15 @@ export function createPersistedStore<T>(
 
   const store = createExternalStore<T>(load());
 
-  let writeTimer: ReturnType<typeof setTimeout> | undefined;
-  store.subscribe(() => {
-    clearTimeout(writeTimer);
-    writeTimer = setTimeout(() => {
-      try {
-        localStorage.setItem(storageKey, JSON.stringify(store.getSnapshot()));
-      } catch {
-        // Storage failures (quota, private mode) shouldn't break the in-memory store.
-      }
-    }, PERSIST_DEBOUNCE_MS);
-  });
+  const persist = () => {
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(store.getSnapshot()));
+    } catch {
+      // Storage failures (quota, private mode) shouldn't break the in-memory store.
+    }
+  };
+
+  store.subscribe(debounce(persist, PERSIST_DEBOUNCE_MS));
 
   return store;
 }

--- a/src/shared/utils/persisted-store.ts
+++ b/src/shared/utils/persisted-store.ts
@@ -1,5 +1,7 @@
 import { createExternalStore, type ExternalStore } from "./external-store";
 
+const PERSIST_DEBOUNCE_MS = 200;
+
 export function createPersistedStore<T>(
   storageKey: string,
   parse: (raw: unknown) => T,
@@ -16,12 +18,16 @@ export function createPersistedStore<T>(
 
   const store = createExternalStore<T>(load());
 
+  let writeTimer: ReturnType<typeof setTimeout> | undefined;
   store.subscribe(() => {
-    try {
-      localStorage.setItem(storageKey, JSON.stringify(store.getSnapshot()));
-    } catch {
-      // Storage failures (quota, private mode) shouldn't break the in-memory store.
-    }
+    clearTimeout(writeTimer);
+    writeTimer = setTimeout(() => {
+      try {
+        localStorage.setItem(storageKey, JSON.stringify(store.getSnapshot()));
+      } catch {
+        // Storage failures (quota, private mode) shouldn't break the in-memory store.
+      }
+    }, PERSIST_DEBOUNCE_MS);
   });
 
   return store;


### PR DESCRIPTION
Follow-ups after the loader-based translation rework. Three small, independent changes.

## Commits
- **docs(architecture)** — `app-providers` moved to `@shared/providers`; fixed the stale §3 link (was `../src/app/app-providers.tsx`) and dropped "providers" from the `@app` layer description in §2.
- **perf(hydration) — O2** — `hydrateBoard` now checks `request.signal` right after the OBF fetch, so a superseded rapid navigation skips the per-asset IndexedDB reads + `URL.createObjectURL` instead of doing the full hydration before the existing end-of-function abort check. Helps INP on the rapid-tap navigation an AAC grid exercises hardest.
- **perf(persisted-store) — O3** — debounce the `localStorage` write. The in-memory store still updates synchronously (slider/preview/consumers stay live); only the disk write is coalesced, so a settings slider drag does one write instead of a dozen. Tests advance timers / `waitFor` the deferred write.

## Deliberately skipped after re-validation
- **O6** (`documentElement.lang`) — **not done on purpose.** With translation now in the loader, board content *is* rendered in the selected `language`, so `lang = language` correctly labels the dominant content. The previously-proposed "fall back to `baseLocale`" would mislabel the translated board as English to assistive tech — a net regression.

## Verification
- `eslint .` clean
- `tsc -b && vite build` passes
- **full test suite green** (incl. new persisted-store debounce/coalesce tests)

Remaining audit items (O1, O4, O5, O7, O8, O9) stay optional/measure-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)