### PR TITLE
refactor(board): move BoardButton accessors out of types.ts

### DIFF
--- a/src/features/board/activation/intent-resolver.ts
+++ b/src/features/board/activation/intent-resolver.ts
@@ -1,10 +1,6 @@
 import type { MessagePartContent } from "../message/use-message";
-import {
-  getNavigationTargetId,
-  getSpokenText,
-  type BoardAction,
-  type BoardButton,
-} from "../types";
+import { getNavigationTargetId, getSpokenText } from "../board-button";
+import type { BoardAction, BoardButton } from "../types";
 
 export type ButtonIntent =
   | { kind: "navigate"; targetBoardId: string }

--- a/src/features/board/board-button.ts
+++ b/src/features/board/board-button.ts
@@ -1,0 +1,13 @@
+import type { BoardButton } from "./types";
+
+export function getSpokenText(
+  button: Pick<BoardButton, "vocalization" | "label">,
+): string | undefined {
+  return (button.vocalization ?? button.label)?.toLowerCase();
+}
+
+export function getNavigationTargetId(
+  button: Pick<BoardButton, "loadBoard">,
+): string | undefined {
+  return button.loadBoard?.id;
+}

--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -14,7 +14,8 @@ import { useBoardNavigation } from "./navigation/use-board-navigation";
 import { SuggestionBar } from "./suggestions/suggestion-bar";
 import { useSuggestions } from "./suggestions/use-suggestions";
 import { Tile } from "./tile/tile";
-import { getNavigationTargetId, type Board, type BoardButton } from "./types";
+import { getNavigationTargetId } from "./board-button";
+import type { Board, BoardButton } from "./types";
 
 export interface BoardViewerProps {
   board: Board;

--- a/src/features/board/message/use-message-playback.ts
+++ b/src/features/board/message/use-message-playback.ts
@@ -1,7 +1,7 @@
 import { playAudio } from "@shared/audio/play-audio";
 import { speak } from "@shared/speech/speech-store";
 import { useRef, useState } from "react";
-import { getSpokenText } from "../types";
+import { getSpokenText } from "../board-button";
 import {
   createPartTracker,
   type PartTracker,

--- a/src/features/board/types.ts
+++ b/src/features/board/types.ts
@@ -53,15 +53,3 @@ export interface BoardLicense {
 }
 
 export type BoardStrings = Record<string, Record<string, string>>;
-
-export function getSpokenText(
-  button: Pick<BoardButton, "vocalization" | "label">,
-): string | undefined {
-  return (button.vocalization ?? button.label)?.toLowerCase();
-}
-
-export function getNavigationTargetId(
-  button: Pick<BoardButton, "loadBoard">,
-): string | undefined {
-  return button.loadBoard?.id;
-}


### PR DESCRIPTION
## What

`getSpokenText` and `getNavigationTargetId` are runtime derivations over a `BoardButton`, not type declarations — but they lived in `types.ts`, which advertises "declarations only." This moves them to a new feature-root module `board-button.ts`.

| | Before | After |
|---|---|---|
| `getSpokenText` / `getNavigationTargetId` | `types.ts` | `board-button.ts` |
| `types.ts` | types + 2 functions | types only |

## Why `board-button.ts` at the feature root
- Both are pure "derive X from a button" accessors — one cohesive concept, kept together.
- Consumers span three places (`board-viewer.tsx`, `activation/intent-resolver.ts`, `message/use-message-playback.ts`). A feature-root module is reachable by all symmetrically, so no subfolder owns logic the others depend on.
- Pairs with `types.ts`: shapes there, button-derived values here.

## Changes
- New `board-button.ts` with both functions.
- `types.ts` reduced to declarations.
- Three import sites updated — each splits the function import (`./board-button`) from the type imports (`./types`). Not exported from the barrel, so no external surface changed.

## Verification
- `tsc --noEmit` clean, lint clean.
- 39 tests pass across activation / message / board-viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)