### PR TITLE
refactor(board): descriptionHTML -> descriptionHtml for casing consistency

### DIFF
--- a/src/features/board/obf/obf-to-board.test.ts
+++ b/src/features/board/obf/obf-to-board.test.ts
@@ -26,7 +26,7 @@ describe("obfToBoard", () => {
   });
 
   describe("board fields", () => {
-    test("maps optional top-level fields (locale, descriptionHTML)", () => {
+    test("maps optional top-level fields (locale, descriptionHtml)", () => {
       const obfBoard: OBFBoard = {
         format: "open-board-0.1",
         id: "board-top-level",
@@ -44,7 +44,7 @@ describe("obfToBoard", () => {
       const board = obfToBoard(obfBoard);
 
       expect(board.locale).toBe("en-US");
-      expect(board.descriptionHTML).toBe("<p>Board description</p>");
+      expect(board.descriptionHtml).toBe("<p>Board description</p>");
     });
 
     test("normalizes the locale to BCP-47 casing on import", () => {

--- a/src/features/board/obf/obf-to-board.ts
+++ b/src/features/board/obf/obf-to-board.ts
@@ -26,7 +26,7 @@ export function obfToBoard(obfBoard: OBFBoard): Board {
     id: obfBoard.id,
     name: obfBoard.name,
     locale: obfBoard.locale ? normalizeLocale(obfBoard.locale) : undefined,
-    descriptionHTML: obfBoard.description_html,
+    descriptionHtml: obfBoard.description_html,
     buttons: obfBoard.buttons.map((obfButton) =>
       transformButton(obfButton, imageSourceById, soundSourceById),
     ),

--- a/src/features/board/types.ts
+++ b/src/features/board/types.ts
@@ -4,7 +4,7 @@ export interface Board {
   locale?: string;
   grid: BoardGrid;
   buttons: BoardButton[];
-  descriptionHTML?: string;
+  descriptionHtml?: string;
   license?: BoardLicense;
   strings?: BoardStrings;
 }


### PR DESCRIPTION
## What

Renames the `Board.descriptionHTML` field to `descriptionHtml` so its acronym casing matches the sibling fields `dataUrl`, `sourceUrl`, `authorUrl`, `copyrightNoticeUrl` (acronyms-as-words style).

Neither casing is forced by OBF — both `descriptionHTML` and `dataUrl` map from snake_case OBF fields (`description_html`, `data_url`) — so the all-caps `HTML` was just an inconsistent one-off.

## Changes
- `types.ts` — field rename.
- `obf-to-board.ts` — assignment rename.
- `obf-to-board.test.ts` — test name + assertion.

Not exported from the barrel; no external surface changed.

## Verification
- No `descriptionHTML` references remain.
- `tsc --noEmit` clean, lint clean, 17 obf tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)