### PR TITLE
fix(translation): replace await using for Safari compatibility

### DIFF
--- a/src/features/board/translation/resolve-translated-board.ts
+++ b/src/features/board/translation/resolve-translated-board.ts
@@ -20,18 +20,22 @@ export async function resolveTranslatedBoard(
   }
 
   try {
-    await using translator = await createTranslator({
+    const translator = await createTranslator({
       sourceLanguage: getBoardLanguage(board),
       targetLanguage: language,
       signal,
     });
 
-    const phrases = collectTranslatableStrings(board);
-    const translations = await translatePhrases(phrases, translator, signal);
+    try {
+      const phrases = collectTranslatableStrings(board);
+      const translations = await translatePhrases(phrases, translator, signal);
 
-    void persistTranslations(setId, board.id, language, translations);
+      void persistTranslations(setId, board.id, language, translations);
 
-    return applyTranslations(board, translations);
+      return applyTranslations(board, translations);
+    } finally {
+      translator.destroy();
+    }
   } catch {
     // Translator unavailable or aborted — render the source board; its
     // pictograms carry the meaning until a translation lands.


### PR DESCRIPTION
## Problem

Safari crashed on board load with `SyntaxError: Unexpected identifier 'translator'` (works in Chrome & Firefox).

The cause was `await using translator = …` in `resolve-translated-board.ts` — the explicit-resource-management syntax. Chrome and Firefox support it natively, but Safari doesn't, and esbuild passed it through untranspiled (Vite's transform target is `esnext`; the `ES2025` in tsconfig only governs type-checking, not the transform).

## Fix

Dispose the translator explicitly via try/finally + `destroy()` instead of relying on `await using`. `createTranslator` returns `Translator & AsyncDisposable`, and `Translator.destroy()` performs the same cleanup `Symbol.asyncDispose` was doing — just in syntax every browser parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)