### PR TITLE
fix(import): widen file picker accept for iOS Safari

### DIFF
--- a/src/features/board/import/use-import-board-files.ts
+++ b/src/features/board/import/use-import-board-files.ts
@@ -3,7 +3,8 @@ import { useSnackbar } from "@shared/snackbar/use-snackbar";
 import { openFiles } from "@shared/utils/file-picker";
 import { importBoardFiles } from "./board-import";
 
-const BOARD_FILE_ACCEPT = ".obz,.obf,application/zip,application/json";
+const BOARD_FILE_ACCEPT =
+  ".obz,.obf,.zip,.json,application/zip,application/json,application/octet-stream";
 
 export interface UseImportBoardFilesReturn {
   pickAndImportBoardFiles: () => Promise<void>;


### PR DESCRIPTION
## What

Widen the `accept` filter on the board-import file picker so `.obz`/`.obf` files stay selectable in iOS Safari's Files picker.

## Why

iOS Safari matches `accept` against the file's UTType-derived MIME and greys out anything it doesn't recognize — a long-standing WebKit bug. `.obz`/`.obf` have no registered UTType, so an extension-only `accept` can leave board files unselectable on iPad (where AAC users actually are). Adding `.zip`/`.json` plus broad MIME fallbacks (incl. `application/octet-stream`) keeps them tappable.

`accept` is only a UX hint — the importer still validates by parsing file content, branching on the `.obz` extension, so a wrong pick just throws a snackbar rather than corrupting anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)