### PR TITLE
feat(play-button): gray out Fab while playing

### DIFF
--- a/src/features/board/message/play-button.tsx
+++ b/src/features/board/message/play-button.tsx
@@ -25,7 +25,7 @@ export function PlayButton({
     <Tooltip title={playButtonLabel}>
       <Box sx={{ alignSelf: "center" }}>
         <Fab
-          color="primary"
+          color={isPlaying ? "default" : "primary"}
           disabled={disabled}
           aria-label={playButtonLabel}
           onClick={isPlaying ? onStopClick : onPlayClick}


### PR DESCRIPTION
## Summary
- Switch the play button's Fab color to MUI's theme `"default"` (grey) while playing, reverting to `"primary"` when stopped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)