### PR TITLE
chore(i18n): translate drag-and-drop overlay string

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "أفلت ملفات اللوحات لاستيرادها",
   "libraryInfo": "معلومات",
   "libraryDelete": "حذف",
   "libraryCancel": "إلغاء",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "Пуснете файловете с дъски за импортиране",
   "libraryInfo": "Информация",
   "libraryDelete": "Изтриване",
   "libraryCancel": "Отказ",

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "আমদানি করতে বোর্ড ফাইল ছাড়ুন",
   "libraryInfo": "তথ্য",
   "libraryDelete": "মুছুন",
   "libraryCancel": "বাতিল করুন",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "Přetáhněte sem soubory tabulek pro import",
   "libraryInfo": "Informace",
   "libraryDelete": "Smazat",
   "libraryCancel": "Zrušit",

--- a/messages/da.json
+++ b/messages/da.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "Slip tavlefiler for at importere",
   "libraryInfo": "Info",
   "libraryDelete": "Slet",
   "libraryCancel": "Annullér",

--- a/messages/de.json
+++ b/messages/de.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "Tafeldateien zum Importieren ablegen",
   "libraryInfo": "Info",
   "libraryDelete": "Löschen",
   "libraryCancel": "Abbrechen",

--- a/messages/el.json
+++ b/messages/el.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "Αφήστε αρχεία πινάκων για εισαγωγή",
   "libraryInfo": "Πληροφορίες",
   "libraryDelete": "Διαγραφή",
   "libraryCancel": "Άκυρο",

--- a/messages/es.json
+++ b/messages/es.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "Suelta archivos de tableros para importar",
   "libraryInfo": "Información",
   "libraryDelete": "Eliminar",
   "libraryCancel": "Cancelar",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "Pudota taulutiedostot tuodaksesi",
   "libraryInfo": "Tiedot",
   "libraryDelete": "Poista",
   "libraryCancel": "Peruuta",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "Déposez des fichiers de tableaux pour les importer",
   "libraryInfo": "Infos",
   "libraryDelete": "Supprimer",
   "libraryCancel": "Annuler",

--- a/messages/he.json
+++ b/messages/he.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "שחרר קובצי לוחות כדי לייבא",
   "libraryInfo": "פרטים",
   "libraryDelete": "מחיקה",
   "libraryCancel": "ביטול",

--- a/messages/he.json
+++ b/messages/he.json
@@ -38,7 +38,7 @@
       }
     }
   ],
-  "libraryDropToImport": "שחרר קובצי לוחות כדי לייבא",
+  "libraryDropToImport": "גרור לוחות לכאן כדי לייבא",
   "libraryInfo": "פרטים",
   "libraryDelete": "מחיקה",
   "libraryCancel": "ביטול",
@@ -65,7 +65,7 @@
   "themeDark": "כהה",
   "languageLabel": "שפה",
   "languageDownloading": "הורדת שפה...",
-  "languageDownloadProgress": "{progress}% הושלם...",
+  "languageDownloadProgress": "הושלמו {progress}%...",
   "speechVoice": "קול",
   "speechRate": "קצב דיבור",
   "speechPitch": "גובה צליל",
@@ -83,7 +83,7 @@
   "navBack": "חזרה",
   "navHome": "לעמוד הבית",
   "messageBackspace": "מחיקה",
-  "messageBackspaceLongPressHint": "לחיצה ארוכה למחיקת ההודעה.",
+  "messageBackspaceLongPressHint": "לחיצה ארוכה לניקוי ההודעה.",
   "messagePlay": "השמעת הודעה",
   "messageStop": "עצירה",
   "toneSelection": "בחירת סגנון",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "आयात करने के लिए बोर्ड फ़ाइलें छोड़ें",
   "libraryInfo": "जानकारी",
   "libraryDelete": "हटाएँ",
   "libraryCancel": "रद्द करें",

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "Ispustite datoteke ploča za uvoz",
   "libraryInfo": "Informacije",
   "libraryDelete": "Izbriši",
   "libraryCancel": "Odustani",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "Ejtsd ide a táblafájlokat az importáláshoz",
   "libraryInfo": "Információ",
   "libraryDelete": "Törlés",
   "libraryCancel": "Mégse",

--- a/messages/id.json
+++ b/messages/id.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "Lepaskan berkas papan untuk mengimpor",
   "libraryInfo": "Info",
   "libraryDelete": "Hapus",
   "libraryCancel": "Batal",

--- a/messages/it.json
+++ b/messages/it.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "Rilascia i file delle tabelle per importare",
   "libraryInfo": "Informazioni",
   "libraryDelete": "Elimina",
   "libraryCancel": "Annulla",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "ボードファイルをドロップしてインポート",
   "libraryInfo": "情報",
   "libraryDelete": "削除",
   "libraryCancel": "キャンセル",

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "ಆಮದು ಮಾಡಲು ಬೋರ್ಡ್ ಫೈಲ್‌ಗಳನ್ನು ಬಿಡಿ",
   "libraryInfo": "ಮಾಹಿತಿ",
   "libraryDelete": "ಅಳಿಸಿ",
   "libraryCancel": "ರದ್ದುಮಾಡಿ",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "가져오려면 보드 파일을 놓으세요",
   "libraryInfo": "정보",
   "libraryDelete": "삭제",
   "libraryCancel": "취소",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "Zet bordbestanden neer om te importeren",
   "libraryInfo": "Info",
   "libraryDelete": "Verwijderen",
   "libraryCancel": "Annuleren",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "Upuść pliki tablic, aby zaimportować",
   "libraryInfo": "Informacje",
   "libraryDelete": "Usuń",
   "libraryCancel": "Anuluj",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "Solte arquivos de pranchas para importar",
   "libraryInfo": "Informações",
   "libraryDelete": "Excluir",
   "libraryCancel": "Cancelar",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "Plasează fișierele de table pentru a le importa",
   "libraryInfo": "Informații",
   "libraryDelete": "Șterge",
   "libraryCancel": "Anulează",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "Отпустите файлы досок для импорта",
   "libraryInfo": "Сведения",
   "libraryDelete": "Удалить",
   "libraryCancel": "Отмена",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "Pustite súbory tabuliek na import",
   "libraryInfo": "Informácie",
   "libraryDelete": "Odstrániť",
   "libraryCancel": "Zrušiť",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "Spustite datoteke tabel za uvoz",
   "libraryInfo": "Informacije",
   "libraryDelete": "Izbriši",
   "libraryCancel": "Prekliči",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "Släpp tavelfiler för att importera",
   "libraryInfo": "Info",
   "libraryDelete": "Ta bort",
   "libraryCancel": "Avbryt",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "இறக்குமதி செய்ய பலகை கோப்புகளை விடுங்கள்",
   "libraryInfo": "தகவல்",
   "libraryDelete": "நீக்கு",
   "libraryCancel": "ரத்துசெய்",

--- a/messages/te.json
+++ b/messages/te.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "దిగుమతి చేయడానికి బోర్డు ఫైళ్లను వదలండి",
   "libraryInfo": "సమాచారం",
   "libraryDelete": "తొలగించు",
   "libraryCancel": "రద్దు చేయి",

--- a/messages/th.json
+++ b/messages/th.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "วางไฟล์บอร์ดเพื่อนำเข้า",
   "libraryInfo": "ข้อมูล",
   "libraryDelete": "ลบ",
   "libraryCancel": "ยกเลิก",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "İçe aktarmak için pano dosyalarını bırakın",
   "libraryInfo": "Bilgi",
   "libraryDelete": "Sil",
   "libraryCancel": "İptal",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "Відпустіть файли дошок для імпорту",
   "libraryInfo": "Інформація",
   "libraryDelete": "Видалити",
   "libraryCancel": "Скасувати",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "Thả tệp bảng để nhập",
   "libraryInfo": "Thông tin",
   "libraryDelete": "Xóa",
   "libraryCancel": "Hủy",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -38,6 +38,7 @@
       }
     }
   ],
+  "libraryDropToImport": "拖放沟通板文件以导入",
   "libraryInfo": "信息",
   "libraryDelete": "删除",
   "libraryCancel": "取消",


### PR DESCRIPTION
## Summary

Follow-up to #507. The drag-and-drop overlay string `libraryDropToImport` ("Drop board files to import") was added in **English only**, so the other 34 locales fell back to `en`. This adds it to every locale, reusing each one's existing term for "board" (e.g. de `Tafeln`, fr `tableaux`, he `לוחות`, zh `沟通板`).

One line added per file; Paraglide compiles cleanly; all 35 JSON files validate.

## Hebrew (native review)

The `he` string went through native-speaker review (the app owner), which corrected the overlay string and turned up two pre-existing nits — all three fixed in this PR:

| Key | Before | After |
| --- | --- | --- |
| `libraryDropToImport` | _(new)_ | `גרור לוחות לכאן כדי לייבא` |
| `languageDownloadProgress` | `{progress}% הושלם...` | `הושלמו {progress}%...` (percent is plural-masculine; don't lead an RTL string with a variable) |
| `messageBackspaceLongPressHint` | `...למחיקת ההודעה.` | `...לניקוי ההודעה.` (`ניקוי`/clear vs the backspace's `מחיקה`/delete) |

## Translations

AI-produced, anchored to each locale's existing import/board terminology. **Please review the languages you read.**

| Locale | `libraryDropToImport` |
| --- | --- |
| ar | أفلت ملفات اللوحات لاستيرادها |
| bg | Пуснете файловете с дъски за импортиране |
| bn | আমদানি করতে বোর্ড ফাইল ছাড়ুন |
| cs | Přetáhněte sem soubory tabulek pro import |
| da | Slip tavlefiler for at importere |
| de | Tafeldateien zum Importieren ablegen |
| el | Αφήστε αρχεία πινάκων για εισαγωγή |
| es | Suelta archivos de tableros para importar |
| fi | Pudota taulutiedostot tuodaksesi |
| fr | Déposez des fichiers de tableaux pour les importer |
| he | גרור לוחות לכאן כדי לייבא |
| hi | आयात करने के लिए बोर्ड फ़ाइलें छोड़ें |
| hr | Ispustite datoteke ploča za uvoz |
| hu | Ejtsd ide a táblafájlokat az importáláshoz |
| id | Lepaskan berkas papan untuk mengimpor |
| it | Rilascia i file delle tabelle per importare |
| ja | ボードファイルをドロップしてインポート |
| kn | ಆಮದು ಮಾಡಲು ಬೋರ್ಡ್ ಫೈಲ್‌ಗಳನ್ನು ಬಿಡಿ |
| ko | 가져오려면 보드 파일을 놓으세요 |
| nl | Zet bordbestanden neer om te importeren |
| pl | Upuść pliki tablic, aby zaimportować |
| pt | Solte arquivos de pranchas para importar |
| ro | Plasează fișierele de table pentru a le importa |
| ru | Отпустите файлы досок для импорта |
| sk | Pustite súbory tabuliek na import |
| sl | Spustite datoteke tabel za uvoz |
| sv | Släpp tavelfiler för att importera |
| ta | இறக்குமதி செய்ய பலகை கோப்புகளை விடுங்கள் |
| te | దిగుమతి చేయడానికి బోర్డు ఫైళ్లను వదలండి |
| th | วางไฟล์บอร์ดเพื่อนำเข้า |
| tr | İçe aktarmak için pano dosyalarını bırakın |
| uk | Відпустіть файли дошок для імпорту |
| vi | Thả tệp bảng để nhập |
| zh | 拖放沟通板文件以导入 |

## Test plan

- All 35 `messages/*.json` parse as valid JSON.
- `paraglide-js compile` succeeds.
- Diff is one inserted line per locale, plus the three `he` corrections above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)