### PR TITLE
feat(import): open board files via PWA file handlers

### DIFF
--- a/src/app/layouts/app-shell.tsx
+++ b/src/app/layouts/app-shell.tsx
@@ -3,7 +3,11 @@ import { MenuDrawer } from "@app/menu/menu-drawer";
 import { OnboardingDialog } from "@app/onboarding/onboarding-dialog";
 import { useOnboarding } from "@app/onboarding/use-onboarding";
 import { SettingsDrawer } from "@app/settings/settings-drawer";
-import { BoardFileDropOverlay, useBoardFileDrop } from "@features/board";
+import {
+  BoardFileDropOverlay,
+  useBoardFileDrop,
+  useFileHandlerLaunch,
+} from "@features/board";
 import Box from "@mui/material/Box";
 import { useRevalidateOnLanguageChange } from "@shared/language/use-revalidate-on-language-change";
 import { useState } from "react";
@@ -15,6 +19,7 @@ export function AppShell() {
   const onboarding = useOnboarding();
   const fileDrop = useBoardFileDrop();
 
+  useFileHandlerLaunch();
   useRevalidateOnLanguageChange();
 
   return (

--- a/src/features/board/import/launch-queue.d.ts
+++ b/src/features/board/import/launch-queue.d.ts
@@ -1,0 +1,11 @@
+interface LaunchParams {
+  readonly files: readonly FileSystemFileHandle[];
+}
+
+interface LaunchQueue {
+  setConsumer(consumer: (params: LaunchParams) => void): void;
+}
+
+interface Window {
+  readonly launchQueue?: LaunchQueue;
+}

--- a/src/features/board/import/use-file-handler-launch.test.tsx
+++ b/src/features/board/import/use-file-handler-launch.test.tsx
@@ -1,0 +1,84 @@
+import { AppProviders } from "@shared/providers/app-providers";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { listBoardSets } from "../storage/boards-db";
+import { resetBoardsDB } from "../storage/test-helpers";
+import { useFileHandlerLaunch } from "./use-file-handler-launch";
+
+const SAMPLE_BOARDS_DIR = "/src/shared/testing/sample-boards";
+const OBF_FIXTURE = "lots-of-stuff.obf";
+const IMPORTED_SET_ID = "lots-of-stuff";
+
+function LaunchHarness() {
+  useFileHandlerLaunch();
+
+  return null;
+}
+
+function stubLaunchQueue() {
+  let consumer: ((params: LaunchParams) => void) | undefined;
+
+  vi.stubGlobal("launchQueue", {
+    setConsumer: (next: (params: LaunchParams) => void) => {
+      consumer = next;
+    },
+  });
+
+  return (...files: FileSystemFileHandle[]) => consumer?.({ files });
+}
+
+function fileHandle(file: File): FileSystemFileHandle {
+  return { getFile: () => Promise.resolve(file) } as FileSystemFileHandle;
+}
+
+async function loadFixtureFile(name: string): Promise<File> {
+  const response = await fetch(`${SAMPLE_BOARDS_DIR}/${name}`);
+
+  if (!response.ok) {
+    throw new Error(`Failed to load test fixture: ${response.status}`);
+  }
+
+  const blob = await response.blob();
+
+  return new File([blob], name, {
+    type: blob.type || "application/octet-stream",
+  });
+}
+
+async function renderLaunchHandler() {
+  await render(
+    <AppProviders>
+      <LaunchHarness />
+    </AppProviders>,
+  );
+}
+
+describe("useFileHandlerLaunch", () => {
+  beforeEach(async () => {
+    await resetBoardsDB();
+  });
+
+  test("does nothing when the browser has no launch queue", async () => {
+    vi.stubGlobal("launchQueue", undefined);
+
+    await renderLaunchHandler();
+
+    expect(await listBoardSets()).toHaveLength(0);
+  });
+
+  test("resolves file handles and imports only the board files", async () => {
+    const launch = stubLaunchQueue();
+    await renderLaunchHandler();
+
+    launch(
+      fileHandle(new File([""], "notes.txt")),
+      fileHandle(await loadFixtureFile(OBF_FIXTURE)),
+    );
+
+    await vi.waitFor(async () => {
+      const boardSets = await listBoardSets();
+      expect(boardSets).toHaveLength(1);
+      expect(boardSets[0]?.setId).toBe(IMPORTED_SET_ID);
+    });
+  });
+});

--- a/src/features/board/import/use-file-handler-launch.ts
+++ b/src/features/board/import/use-file-handler-launch.ts
@@ -1,0 +1,20 @@
+import { useEffect } from "react";
+import { isBoardFile } from "./board-file-types";
+import { useImportBoardFiles } from "./use-import-board-files";
+
+export function useFileHandlerLaunch(): void {
+  const { importBoardFiles } = useImportBoardFiles();
+
+  useEffect(() => {
+    const queue = window.launchQueue;
+    if (!queue) {
+      return;
+    }
+
+    queue.setConsumer(({ files }) => {
+      void Promise.all(files.map((handle) => handle.getFile())).then((opened) =>
+        importBoardFiles(opened.filter(isBoardFile)),
+      );
+    });
+  }, [importBoardFiles]);
+}

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -7,6 +7,7 @@ export { BoardViewer } from "./board-viewer";
 export { BoardFileDropOverlay } from "./import/board-file-drop-overlay";
 export { importBoardFromUrl } from "./import/import-from-url";
 export { useBoardFileDrop } from "./import/use-board-file-drop";
+export { useFileHandlerLaunch } from "./import/use-file-handler-launch";
 export { useImportBoardFiles } from "./import/use-import-board-files";
 export {
   BOARD_PATTERN,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,6 +45,15 @@ export default defineConfig({
           "AAC Board AI helps people who can't speak communicate naturally with Built-in AI — proofreading, rephrasing, and translating safely on their device.",
         start_url: "/",
         display: "standalone",
+        file_handlers: [
+          {
+            action: "/",
+            accept: {
+              "application/zip": [".obz", ".zip"],
+              "application/json": [".obf", ".json"],
+            },
+          },
+        ],
         theme_color: SHELL_DARK,
         background_color: CONTENT_DARK,
         icons: [


### PR DESCRIPTION
## What

Lets users open a board file from the OS (e.g. double-click an `.obf`/`.obz` in macOS Finder) and have it imported into the app.

## How

- **Manifest** — adds a `file_handlers` entry registering `.obz/.zip` (ZIP) and `.obf/.json` (JSON) with the OS at install time.
- **`useFileHandlerLaunch`** — consumes `window.launchQueue`, resolves the delivered `FileSystemFileHandle`s to `File`s, filters via the existing `isBoardFile`, and hands off to the existing `importBoardFiles` pipeline (snackbars + storage for free).
- Wired into `AppShell` next to `useBoardFileDrop`.

## Scope

Chromium desktop only (Chrome/Edge), consistent with the app's Built-in AI baseline. Safari/Firefox don't support file handling; the hook is a no-op where `launchQueue` is absent, so it's pure progressive enhancement. Requires the PWA to be installed.

## Tests

- Imports only board files from a mixed launch (verifies handle resolution + filter; fails if the filter is removed).
- No-op when `launchQueue` is unavailable (mutation-verified to fail if the guard is removed).

Verified: `tsc`, lint, browser tests, and a build confirming `file_handlers` lands in the emitted manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)