### PR TITLE
feat(import): open the board immediately after import

### DIFF
--- a/src/app/loaders/board-set-index-loader.ts
+++ b/src/app/loaders/board-set-index-loader.ts
@@ -1,4 +1,4 @@
-import { boardPath, getBoardSet } from "@features/board";
+import { boardSetPath, getBoardSet } from "@features/board";
 import { m } from "@paraglide/messages.js";
 import { data, redirect, type LoaderFunctionArgs } from "react-router";
 
@@ -12,5 +12,5 @@ export async function boardSetIndexLoader({
     throw data(m.errorBoardSetNotFound(), { status: 404 });
   }
 
-  return redirect(boardPath({ setId, boardId: set.rootBoardId }));
+  return redirect(boardSetPath(set));
 }

--- a/src/app/loaders/root-index-loader.ts
+++ b/src/app/loaders/root-index-loader.ts
@@ -1,4 +1,8 @@
-import { boardPath, getBoardSets, importBoardFromUrl } from "@features/board";
+import {
+  boardSetPath,
+  getBoardSets,
+  importBoardFromUrl,
+} from "@features/board";
 import { redirect, type LoaderFunctionArgs } from "react-router";
 
 const DEFAULT_BOARD_URL = `${import.meta.env.BASE_URL}quick-core-24.obz`;
@@ -7,19 +11,15 @@ async function resolveInitialRedirectPath(
   boardUrl: string | null,
 ): Promise<string> {
   if (boardUrl) {
-    const { setId, boardId } = await importBoardFromUrl(boardUrl);
-
-    return boardPath({ setId, boardId });
+    return boardSetPath(await importBoardFromUrl(boardUrl));
   }
 
   const [existing] = await getBoardSets();
   if (existing) {
-    return boardPath({ setId: existing.setId, boardId: existing.rootBoardId });
+    return boardSetPath(existing);
   }
 
-  const { setId, boardId } = await importBoardFromUrl(DEFAULT_BOARD_URL);
-
-  return boardPath({ setId, boardId });
+  return boardSetPath(await importBoardFromUrl(DEFAULT_BOARD_URL));
 }
 
 export async function rootIndexLoader({

--- a/src/features/board/import/board-import.test.ts
+++ b/src/features/board/import/board-import.test.ts
@@ -46,7 +46,7 @@ describe("importFilesAsBoardSets", () => {
     expect(importResults).toEqual([
       {
         setId: IMPORTED_SET_ID,
-        boardId: board.id,
+        rootBoardId: board.id,
       },
     ]);
 
@@ -106,7 +106,7 @@ describe("importFilesAsBoardSets", () => {
     expect(importResults).toEqual([
       {
         setId: IMPORTED_SET_ID,
-        boardId: rootBoardId,
+        rootBoardId,
       },
     ]);
 

--- a/src/features/board/import/board-import.ts
+++ b/src/features/board/import/board-import.ts
@@ -17,7 +17,7 @@ import { putAssets, putBoards, upsertBoardSet } from "../storage/boards-db";
 
 export interface ImportResult {
   setId: string;
-  boardId: string;
+  rootBoardId: string;
 }
 
 export async function importBoardFiles(
@@ -70,7 +70,7 @@ async function importOBZArchive(
     await putAssets(setId, assetInputs);
   }
 
-  return { setId, boardId: rootBoardId };
+  return { setId, rootBoardId };
 }
 
 function buildBoardPathToId(manifest: OBFManifest): Map<string, string> {
@@ -179,7 +179,7 @@ async function importOBFBoard(
     },
   ]);
 
-  return { setId, boardId: board.id };
+  return { setId, rootBoardId: board.id };
 }
 
 function deriveSetId(filename: string): string {

--- a/src/features/board/import/use-board-file-drop.test.tsx
+++ b/src/features/board/import/use-board-file-drop.test.tsx
@@ -1,4 +1,5 @@
 import { AppProviders } from "@shared/providers/app-providers";
+import { MemoryRouter, useLocation } from "react-router";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { render } from "vitest-browser-react";
 import { listBoardSets } from "../storage/boards-db";
@@ -13,20 +14,25 @@ function DropHarness() {
   const { isDraggingFiles, dropHandlers } = useBoardFileDrop();
 
   return (
-    <div data-testid="zone" {...dropHandlers}>
-      {isDraggingFiles ? "active" : "idle"}
-    </div>
+    <>
+      <div data-testid="zone" {...dropHandlers}>
+        {isDraggingFiles ? "active" : "idle"}
+      </div>
+      <div data-testid="path">{useLocation().pathname}</div>
+    </>
   );
 }
 
 async function renderDropZone() {
   const screen = await render(
     <AppProviders>
-      <DropHarness />
+      <MemoryRouter>
+        <DropHarness />
+      </MemoryRouter>
     </AppProviders>,
   );
 
-  return screen.getByTestId("zone").element();
+  return { screen, zone: screen.getByTestId("zone").element() };
 }
 
 function dataTransferWithFiles(...files: File[]): DataTransfer {
@@ -75,7 +81,7 @@ describe("useBoardFileDrop", () => {
   });
 
   test("shows the overlay while files are dragged over and hides it on drop", async () => {
-    const zone = await renderDropZone();
+    const { zone } = await renderDropZone();
     const dataTransfer = dataTransferWithFiles(new File([""], "notes.txt"));
 
     fireDrag(zone, "dragenter", dataTransfer);
@@ -86,7 +92,7 @@ describe("useBoardFileDrop", () => {
   });
 
   test("ignores drags that carry no files", async () => {
-    const zone = await renderDropZone();
+    const { zone } = await renderDropZone();
     const dataTransfer = new DataTransfer();
     dataTransfer.setData("text/plain", "hello");
 
@@ -96,7 +102,7 @@ describe("useBoardFileDrop", () => {
   });
 
   test("stays visible while crossing nested elements (no flicker)", async () => {
-    const zone = await renderDropZone();
+    const { zone } = await renderDropZone();
     const dataTransfer = dataTransferWithFiles(new File([""], "notes.txt"));
     const insideApp = zone;
 
@@ -112,7 +118,7 @@ describe("useBoardFileDrop", () => {
   });
 
   test("hides immediately when the drag leaves the window", async () => {
-    const zone = await renderDropZone();
+    const { zone } = await renderDropZone();
     const dataTransfer = dataTransferWithFiles(new File([""], "notes.txt"));
     const leftWindow = null;
 
@@ -124,8 +130,8 @@ describe("useBoardFileDrop", () => {
     await expect.element(zone).toHaveTextContent("idle");
   });
 
-  test("imports a dropped board file", async () => {
-    const zone = await renderDropZone();
+  test("imports a dropped board file and opens it", async () => {
+    const { zone, screen } = await renderDropZone();
     const boardFile = await loadFixtureFile(OBF_FIXTURE);
 
     fireDrag(zone, "drop", dataTransferWithFiles(boardFile));
@@ -135,5 +141,9 @@ describe("useBoardFileDrop", () => {
       expect(boardSets).toHaveLength(1);
       expect(boardSets[0]?.setId).toBe(IMPORTED_SET_ID);
     });
+
+    await expect
+      .element(screen.getByTestId("path"))
+      .toHaveTextContent(`/sets/${IMPORTED_SET_ID}/boards/`);
   });
 });

--- a/src/features/board/import/use-board-file-drop.ts
+++ b/src/features/board/import/use-board-file-drop.ts
@@ -19,7 +19,7 @@ function containsFiles(event: DragEvent<HTMLElement>): boolean {
 }
 
 export function useBoardFileDrop(): UseBoardFileDropReturn {
-  const { importBoardFiles } = useImportBoardFiles();
+  const { importAndOpenBoardFiles } = useImportBoardFiles();
   const [isDraggingFiles, setIsDraggingFiles] = useState(false);
   const dragDepth = useRef(0);
 
@@ -67,7 +67,7 @@ export function useBoardFileDrop(): UseBoardFileDropReturn {
     clearDrag();
 
     const files = Array.from(event.dataTransfer.files).filter(isBoardFile);
-    void importBoardFiles(files);
+    void importAndOpenBoardFiles(files);
   }
 
   return {

--- a/src/features/board/import/use-file-handler-launch.test.tsx
+++ b/src/features/board/import/use-file-handler-launch.test.tsx
@@ -1,4 +1,5 @@
 import { AppProviders } from "@shared/providers/app-providers";
+import { MemoryRouter, useLocation } from "react-router";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { render } from "vitest-browser-react";
 import { listBoardSets } from "../storage/boards-db";
@@ -12,7 +13,7 @@ const IMPORTED_SET_ID = "lots-of-stuff";
 function LaunchHarness() {
   useFileHandlerLaunch();
 
-  return null;
+  return <div data-testid="path">{useLocation().pathname}</div>;
 }
 
 function stubLaunchQueue() {
@@ -45,10 +46,12 @@ async function loadFixtureFile(name: string): Promise<File> {
   });
 }
 
-async function renderLaunchHandler() {
-  await render(
+function renderLaunchHandler() {
+  return render(
     <AppProviders>
-      <LaunchHarness />
+      <MemoryRouter>
+        <LaunchHarness />
+      </MemoryRouter>
     </AppProviders>,
   );
 }
@@ -61,14 +64,15 @@ describe("useFileHandlerLaunch", () => {
   test("does nothing when the browser has no launch queue", async () => {
     vi.stubGlobal("launchQueue", undefined);
 
-    await renderLaunchHandler();
+    const screen = await renderLaunchHandler();
 
     expect(await listBoardSets()).toHaveLength(0);
+    await expect.element(screen.getByTestId("path")).toHaveTextContent(/^\/$/);
   });
 
-  test("resolves file handles and imports only the board files", async () => {
+  test("imports only the board files and opens the result", async () => {
     const launch = stubLaunchQueue();
-    await renderLaunchHandler();
+    const screen = await renderLaunchHandler();
 
     launch(
       fileHandle(new File([""], "notes.txt")),
@@ -80,5 +84,9 @@ describe("useFileHandlerLaunch", () => {
       expect(boardSets).toHaveLength(1);
       expect(boardSets[0]?.setId).toBe(IMPORTED_SET_ID);
     });
+
+    await expect
+      .element(screen.getByTestId("path"))
+      .toHaveTextContent(`/sets/${IMPORTED_SET_ID}/boards/`);
   });
 });

--- a/src/features/board/import/use-file-handler-launch.ts
+++ b/src/features/board/import/use-file-handler-launch.ts
@@ -3,7 +3,7 @@ import { isBoardFile } from "./board-file-types";
 import { useImportBoardFiles } from "./use-import-board-files";
 
 export function useFileHandlerLaunch(): void {
-  const { importBoardFiles } = useImportBoardFiles();
+  const { importAndOpenBoardFiles } = useImportBoardFiles();
 
   useEffect(() => {
     const queue = window.launchQueue;
@@ -13,8 +13,8 @@ export function useFileHandlerLaunch(): void {
 
     queue.setConsumer(({ files }) => {
       void Promise.all(files.map((handle) => handle.getFile())).then((opened) =>
-        importBoardFiles(opened.filter(isBoardFile)),
+        importAndOpenBoardFiles(opened.filter(isBoardFile)),
       );
     });
-  }, [importBoardFiles]);
+  }, [importAndOpenBoardFiles]);
 }

--- a/src/features/board/import/use-import-board-files.ts
+++ b/src/features/board/import/use-import-board-files.ts
@@ -1,20 +1,27 @@
 import { m } from "@paraglide/messages.js";
 import { useSnackbar } from "@shared/snackbar/use-snackbar";
 import { openFiles } from "@shared/utils/file-picker";
+import { useNavigate } from "react-router";
+import { boardSetPath } from "../navigation/board-paths";
 import { BOARD_FILE_ACCEPT } from "./board-file-types";
-import { importBoardFiles as importBoardFilesToStorage } from "./board-import";
+import {
+  importBoardFiles as importBoardFilesToStorage,
+  type ImportResult,
+} from "./board-import";
 
 export interface UseImportBoardFilesReturn {
   pickAndImportBoardFiles: () => Promise<void>;
-  importBoardFiles: (files: File[]) => Promise<void>;
+  importBoardFiles: (files: File[]) => Promise<ImportResult[]>;
+  importAndOpenBoardFiles: (files: File[]) => Promise<void>;
 }
 
 export function useImportBoardFiles(): UseImportBoardFilesReturn {
   const { showSnackbar } = useSnackbar();
+  const navigate = useNavigate();
 
-  async function importBoardFiles(files: File[]) {
+  async function importBoardFiles(files: File[]): Promise<ImportResult[]> {
     if (files.length === 0) {
-      return;
+      return [];
     }
 
     const count = files.length;
@@ -24,12 +31,14 @@ export function useImportBoardFiles(): UseImportBoardFilesReturn {
     });
 
     try {
-      await importBoardFilesToStorage(files);
+      const results = await importBoardFilesToStorage(files);
 
       showSnackbar({
         message: m.libraryImportedBoards({ count }),
         severity: "success",
       });
+
+      return results;
     } catch (error) {
       showSnackbar({
         message: m.libraryImportFailedBoards({ count }),
@@ -37,6 +46,15 @@ export function useImportBoardFiles(): UseImportBoardFilesReturn {
       });
 
       throw error;
+    }
+  }
+
+  async function importAndOpenBoardFiles(files: File[]) {
+    const results = await importBoardFiles(files);
+
+    if (results.length === 1) {
+      const [result] = results;
+      void navigate(boardSetPath(result));
     }
   }
 
@@ -49,5 +67,9 @@ export function useImportBoardFiles(): UseImportBoardFilesReturn {
     await importBoardFiles(files);
   }
 
-  return { pickAndImportBoardFiles, importBoardFiles };
+  return {
+    pickAndImportBoardFiles,
+    importBoardFiles,
+    importAndOpenBoardFiles,
+  };
 }

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -13,6 +13,7 @@ export {
   BOARD_PATTERN,
   BOARD_SET_PATTERN,
   boardPath,
+  boardSetPath,
 } from "./navigation/board-paths";
 export { BoardNotFoundError, hydrateBoard } from "./storage/board-hydration";
 export { getBoardSet } from "./storage/boards-db";

--- a/src/features/board/navigation/board-paths.ts
+++ b/src/features/board/navigation/board-paths.ts
@@ -15,3 +15,13 @@ export function boardPath({
     boardId,
   });
 }
+
+export function boardSetPath({
+  setId,
+  rootBoardId,
+}: {
+  setId: string;
+  rootBoardId: string;
+}): string {
+  return boardPath({ setId, boardId: rootBoardId });
+}

--- a/src/features/board/navigation/use-board-navigation.ts
+++ b/src/features/board/navigation/use-board-navigation.ts
@@ -1,6 +1,6 @@
 import { useLocation, useNavigate, useParams } from "react-router";
 import { useBoardSets } from "../board-sets/use-board-sets";
-import { boardPath } from "./board-paths";
+import { boardPath, boardSetPath } from "./board-paths";
 
 export interface BoardRouteParams {
   [key: string]: string;
@@ -67,7 +67,7 @@ export function useBoardNavigation(): UseBoardNavigationReturn {
       return;
     }
 
-    void navigate(boardPath({ setId, boardId: rootBoardId }), {
+    void navigate(boardSetPath({ setId, rootBoardId }), {
       state: { backStack: [] },
       replace: true,
     });

--- a/src/pages/library-page.tsx
+++ b/src/pages/library-page.tsx
@@ -4,7 +4,7 @@ import {
   BoardSetDeleteDialog,
   BoardSetInfoDialog,
   BoardSetList,
-  boardPath,
+  boardSetPath,
   deleteBoardSet,
   useBoardSets,
   useImportBoardFiles,
@@ -31,12 +31,7 @@ export const Component = function LibraryPage() {
   const [infoTarget, setInfoTarget] = useState<BoardSetRecord | null>(null);
 
   function handleSelect(boardSet: BoardSetRecord) {
-    void navigate(
-      boardPath({
-        setId: boardSet.setId,
-        boardId: boardSet.rootBoardId,
-      }),
-    );
+    void navigate(boardSetPath(boardSet));
   }
 
   async function handleDelete() {


### PR DESCRIPTION
## What

Dropping a board file, or opening one via the OS file handler, now navigates straight to the imported board instead of importing silently into the library. A single board → opens it; multiple files → import and stay put (no ambiguous pick).

## How

- `useImportBoardFiles` gains **`importAndOpenBoardFiles`**; drop and file-handler launch use it. `importBoardFiles` now returns the `ImportResult[]` it previously discarded.
- Extract **`boardSetPath({ setId, rootBoardId })`** — "open a set at its root" — replacing the repeated `boardPath({ setId, boardId: rootBoardId })` across both loaders, the library page, and board navigation. `boardPath` now means strictly "a specific board."
- Rename **`ImportResult.boardId` → `rootBoardId`** so the type states what it is; call sites collapse to `boardSetPath(result)`.

## Tests

- Drop and launch tests assert navigation to `/sets/<id>/boards/…` (both mutation-verified: reverting the wiring or disabling navigation fails them).
- Guard test: no-op when `launchQueue` is absent.
- Behavior is identical for existing flows — `boardSetPath` emits byte-identical paths, so loader/navigation tests passed unchanged.

Verified: tsc, lint, full suite (371 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)