### PR TITLE
chore: bump version to 1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aac-board-ai",
   "private": true,
-  "version": "1.8.2",
+  "version": "1.9.0",
   "license": "MIT",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Minor release. Since v1.8.2 the app gained four user-facing features, which by semver (and this repo's convention that patch releases carry no `feat:`) warrant a minor bump:

- `feat(import): drag-and-drop board file import` (#507)
- `feat(import): open board files via PWA file handlers` (#509)
- `feat(import): open the board immediately after import` (#510)
- `feat(play-button): gray out Fab while playing` (#501)

Plus fixes/refactors (#502–#506). Tag `v1.9.0` to follow on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)