### PR TITLE
chore: sync package-lock version to 1.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aac-board-ai",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aac-board-ai",
-      "version": "1.8.2",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.14.0",


### PR DESCRIPTION
Keeps `package-lock.json`'s root version in lockstep with `package.json` (1.9.0), rather than waiting for the next deps commit to sync it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)