### PR TITLE
refactor: remove dead code and align with conventions

### DIFF
--- a/src/app/settings/ai-settings.tsx
+++ b/src/app/settings/ai-settings.tsx
@@ -48,7 +48,7 @@ export function AISettings() {
           placeholder={m.aiCustomInstructionsPlaceholder()}
           helperText={m.aiCustomInstructionsHelper()}
           value={sharedContext}
-          onChange={(e) => setAISharedContext(e.target.value)}
+          onChange={(event) => setAISharedContext(event.target.value)}
         />
       )}
 

--- a/src/features/board/import/board-import.test.ts
+++ b/src/features/board/import/board-import.test.ts
@@ -7,7 +7,7 @@ import {
   listBoardSets,
 } from "../storage/boards-db";
 import { resetBoardsDB } from "../storage/test-helpers";
-import { importFilesAsBoardSets, resolveLoadBoardPaths } from "./board-import";
+import { importBoardFiles, resolveLoadBoardPaths } from "./board-import";
 
 const SAMPLE_BOARDS_DIR = "/src/shared/testing/sample-boards";
 const OBZ_FIXTURE = "lots-of-stuff.obz";
@@ -32,7 +32,7 @@ async function loadFixtureFile(name: string): Promise<File> {
   });
 }
 
-describe("importFilesAsBoardSets", () => {
+describe("importBoardFiles", () => {
   beforeEach(async () => {
     await resetBoardsDB();
   });
@@ -41,7 +41,7 @@ describe("importFilesAsBoardSets", () => {
     const fixtureFile = await loadFixtureFile(OBF_FIXTURE);
     const board = await loadOBF(fixtureFile);
 
-    const importResults = await importFilesAsBoardSets(fixtureFile);
+    const importResults = await importBoardFiles(fixtureFile);
 
     expect(importResults).toEqual([
       {
@@ -101,7 +101,7 @@ describe("importFilesAsBoardSets", () => {
     assertDefined(sampleAssetEntry);
     const [sampleAssetPath, sampleAssetBytes] = sampleAssetEntry;
 
-    const importResults = await importFilesAsBoardSets(fixtureFile);
+    const importResults = await importBoardFiles(fixtureFile);
 
     expect(importResults).toEqual([
       {
@@ -170,7 +170,7 @@ describe("importFilesAsBoardSets", () => {
       type: "application/zip",
     });
 
-    const importResults = await importFilesAsBoardSets(zipNamedFile);
+    const importResults = await importBoardFiles(zipNamedFile);
 
     expect(importResults).toHaveLength(1);
     expect(importResults[0].setId).toBe(IMPORTED_SET_ID);

--- a/src/features/board/import/board-import.ts
+++ b/src/features/board/import/board-import.ts
@@ -23,15 +23,6 @@ export interface ImportResult {
 export async function importBoardFiles(
   files: File | File[],
 ): Promise<ImportResult[]> {
-  const results = await importFilesAsBoardSets(files);
-  await notifyBoardSetsChanged();
-
-  return results;
-}
-
-export async function importFilesAsBoardSets(
-  files: File | File[],
-): Promise<ImportResult[]> {
   const fileList = Array.isArray(files) ? files : [files];
   const results: ImportResult[] = [];
 
@@ -45,6 +36,8 @@ export async function importFilesAsBoardSets(
         : await importOBFBoard(loaded.board, setId, file.name),
     );
   }
+
+  await notifyBoardSetsChanged();
 
   return results;
 }

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -12,13 +12,11 @@ export { useImportBoardFiles } from "./import/use-import-board-files";
 export {
   BOARD_PATTERN,
   BOARD_SET_PATTERN,
-  boardPath,
   boardSetPath,
 } from "./navigation/board-paths";
 export { BoardNotFoundError, hydrateBoard } from "./storage/board-hydration";
 export { getBoardSet } from "./storage/boards-db";
 export { resolveTranslatedBoard } from "./translation/resolve-translated-board";
 
-export type { BoardRouteParams } from "./navigation/use-board-navigation";
 export type { BoardSetRecord } from "./storage/boards-db";
 export type { Board } from "./types";

--- a/src/features/board/storage/boards-db.ts
+++ b/src/features/board/storage/boards-db.ts
@@ -26,7 +26,6 @@ export interface BoardRecord {
 export interface AssetRecord {
   setId: string;
   path: string;
-  mediaId?: string;
   blob: Blob;
   mime?: string;
   size?: number;
@@ -55,7 +54,6 @@ export interface UpsertAssetInput {
   blob: Blob;
   mime?: string;
   size?: number;
-  mediaId?: string;
 }
 
 export interface BoardsDBSchema extends DBSchema {
@@ -72,7 +70,7 @@ export interface BoardsDBSchema extends DBSchema {
   assets: {
     key: [string, string];
     value: AssetRecord;
-    indexes: { bySetId: string; bySetIdAndMediaId: [string, string] };
+    indexes: { bySetId: string };
   };
 }
 
@@ -136,7 +134,6 @@ function openConnection(): Promise<BoardsDB> {
         keyPath: ["setId", "path"],
       });
       assets.createIndex("bySetId", "setId");
-      assets.createIndex("bySetIdAndMediaId", ["setId", "mediaId"]);
     },
   });
 }
@@ -289,7 +286,6 @@ export async function putAssets(
     await assetStore.put({
       setId,
       path: cleanPath,
-      mediaId: asset.mediaId,
       blob: asset.blob,
       mime: asset.mime,
       size: asset.size ?? asset.blob.size,

--- a/src/pages/library-page.tsx
+++ b/src/pages/library-page.tsx
@@ -48,11 +48,12 @@ export const Component = function LibraryPage() {
         message: m.libraryDeleted({ name }),
         severity: "success",
       });
-    } catch {
+    } catch (error) {
       showSnackbar({
         message: m.libraryDeleteFailed({ name }),
         severity: "error",
       });
+      throw error;
     }
   }
 

--- a/src/shared/snackbar/snackbar-provider.tsx
+++ b/src/shared/snackbar/snackbar-provider.tsx
@@ -122,6 +122,7 @@ export function SnackbarProvider({ children }: SnackbarProviderProps) {
       >
         <Alert
           severity={state.current?.severity ?? DEFAULT_SNACKBAR_SEVERITY}
+          action={state.current?.action}
           onClose={handleClose}
           sx={{ width: "100%" }}
         >


### PR DESCRIPTION
Cleanup pass from a project cleanliness review. No user-facing behavior change except the snackbar `action` option now actually renders.

## Changes
- **storage:** drop unused `mediaId` field + `bySetIdAndMediaId` index — it was always `undefined` at the only write site and never queried.
- **import:** collapse the test-only `importFilesAsBoardSets` into `importBoardFiles` so `notifyBoardSetsChanged` can't be bypassed by a second public entry point; tests now exercise the real path.
- **library:** rethrow after the delete-failure snackbar to match the codebase-wide catch → `showSnackbar` → `throw` convention (mirrors the import flow).
- **snackbar:** wire the `action` option into `<Alert action={...}>` so it's a real affordance instead of a silently-dropped option. No behavior change for existing callers (none pass `action`).
- **board:** drop dead barrel re-exports (`boardPath`, `BoardRouteParams`) — both are imported directly from their defining modules.
- **ai-settings:** rename `onChange` param `e` → `event` for consistency with sibling settings panels.

## Verification
- `npm run lint` — clean
- `tsc -b` — clean
- Affected tests pass (import, message buttons, board-viewer, boards-db)

🤖 Generated with [Claude Code](https://claude.com/claude-code)