### PR TITLE
fix(board): OBF action precedence, board-sets snapshot purity, narrow activation deps

### DIFF
--- a/src/features/board/activation/button-activation.ts
+++ b/src/features/board/activation/button-activation.ts
@@ -7,9 +7,12 @@ import type { BoardAction, BoardButton } from "../types";
 import { resolveButtonIntent } from "./button-intent-resolver";
 
 export interface ButtonActivationOptions {
-  message: UseMessageReturn;
-  playback: UseMessagePlaybackReturn;
-  navigation: UseBoardNavigationReturn;
+  message: Pick<
+    UseMessageReturn,
+    "addPart" | "appendText" | "addSpace" | "removeLastPart" | "clear"
+  >;
+  playback: Pick<UseMessagePlaybackReturn, "play">;
+  navigation: Pick<UseBoardNavigationReturn, "goToBoard" | "goHome">;
 }
 
 export interface ButtonActivation {

--- a/src/features/board/board-sets/board-sets-store.ts
+++ b/src/features/board/board-sets/board-sets-store.ts
@@ -68,8 +68,6 @@ export function subscribeBoardSets(listener: () => void): () => void {
 }
 
 export function getBoardSetsSnapshot(): BoardSetsSnapshot {
-  void ensureLoaded();
-
   return store.getSnapshot();
 }
 

--- a/src/features/board/obf/obf-to-board.test.ts
+++ b/src/features/board/obf/obf-to-board.test.ts
@@ -227,7 +227,7 @@ describe("obfToBoard", () => {
       expect(board.buttons[0]?.actions).toEqual([]);
     });
 
-    test("merges action + actions in order", () => {
+    test("uses actions and ignores the action fallback when both are present", () => {
       const obfBoard: OBFBoard = {
         format: "open-board-0.1",
         id: "board-2",
@@ -248,10 +248,21 @@ describe("obfToBoard", () => {
 
       const board = obfToBoard(obfBoard);
       expect(board.buttons[0]?.actions).toEqual([
-        { kind: "speak" },
         { kind: "space" },
         { kind: "clear" },
       ]);
+    });
+
+    test("falls back to the single action when actions is absent", () => {
+      const obfBoard: OBFBoard = {
+        format: "open-board-0.1",
+        id: "board-2-fallback",
+        buttons: [{ id: "btn-1", label: "Speak", action: ":speak" }],
+        grid: { rows: 1, columns: 1, order: [["btn-1"]] },
+      };
+
+      const board = obfToBoard(obfBoard);
+      expect(board.buttons[0]?.actions).toEqual([{ kind: "speak" }]);
     });
 
     test("parses spell actions and drops unknown ones", () => {

--- a/src/features/board/obf/obf-to-board.ts
+++ b/src/features/board/obf/obf-to-board.ts
@@ -86,10 +86,10 @@ function transformButton(
 }
 
 function collectActions(obfButton: OBFButton): BoardAction[] {
-  const raw = [obfButton.action, ...(obfButton.actions ?? [])];
+  const raw = obfButton.actions ?? (obfButton.action ? [obfButton.action] : []);
 
   return raw.flatMap((value) => {
-    const action = value ? parseAction(value) : null;
+    const action = parseAction(value);
 
     return action ? [action] : [];
   });


### PR DESCRIPTION
Three follow-ups from an adversarial review of the board feature.

## Fixes

1. **OBF `action`/`actions` precedence** (`obf-to-board.ts`) — `collectActions` concatenated `action` + `actions`, so a button with both ran the single-action fallback *plus* the full list (e.g. the spec's own `action:":clear"`/`actions:[":clear",":home"]` example cleared twice). Per the OBF spec, `action` is a single-action fallback for apps that don't support `actions`; when both are present, `actions` wins. Test flipped to assert precedence + added the fallback-path case.

2. **`board-sets` snapshot purity** (`board-sets-store.ts`) — `getBoardSetsSnapshot` called `ensureLoaded()`, violating `useSyncExternalStore`'s purity contract. On a persistent IDB failure this spun a `render → load → error(setState) → render` loop. The load is now driven solely by `subscribeBoardSets`; the snapshot getter is side-effect-free. Verified the only callers are `useBoardSets` (sync) and `getBoardSets` (async, awaits `ensureLoaded` directly).

3. **Narrow `createButtonActivation` deps** (`button-activation.ts`) — it took whole hook-return bags while its sibling `useBoardKeyboard` narrows via `Pick`. Now narrowed to exactly the methods used, matching the convention.

## Verification

- `tsc -b` clean, `eslint .` clean
- Full suite green (372 tests / 49 files) prior to commit; affected tests (`obf-to-board`, `button-activation`) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)