### PR TITLE
refactor(language): single validated language store

### DIFF
--- a/src/features/board/suggestions/to-phrases.ts
+++ b/src/features/board/suggestions/to-phrases.ts
@@ -4,17 +4,25 @@ function isClean(phrase: string): boolean {
   return !UNDERSCORED_WORD.test(phrase) && !phrase.includes('"');
 }
 
+function normalize(phrase: string): string {
+  return phrase.trim().toLowerCase();
+}
+
 export function toPhrases(
   text: string,
   candidates: readonly (string | undefined)[],
 ): string[] {
-  const phrases = new Set<string>();
+  const seen = new Set<string>([normalize(text)]);
 
-  for (const candidate of candidates) {
-    if (candidate && candidate !== text && isClean(candidate)) {
-      phrases.add(candidate);
+  return candidates.filter((candidate): candidate is string => {
+    if (!candidate || !isClean(candidate)) {
+      return false;
     }
-  }
-
-  return [...phrases];
+    const key = normalize(candidate);
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
 }

--- a/src/features/board/suggestions/use-suggestions.test.ts
+++ b/src/features/board/suggestions/use-suggestions.test.ts
@@ -73,6 +73,17 @@ describe("useSuggestions", () => {
     });
   });
 
+  test("dedupes proofread and rewrite outputs that differ only in case", async () => {
+    stubProofreader(() => makeProofreadResult("My movies"));
+    stubRewriter(() => "my movies");
+
+    const { result } = await renderSuggestions("movies");
+
+    await vi.waitFor(() => {
+      expect(result.current.phrases).toEqual(["My movies"]);
+    });
+  });
+
   test("drops a candidate that is identical to the original text", async () => {
     stubProofreader((input) => makeProofreadResult(input));
     stubRewriter(() => "Something different.");

--- a/src/features/board/suggestions/use-suggestions.test.ts
+++ b/src/features/board/suggestions/use-suggestions.test.ts
@@ -1,6 +1,10 @@
 import { setAISharedContext } from "@shared/hooks/use-ai-shared-context";
 import { LanguageProvider } from "@shared/language/language-provider";
 import {
+  DEFAULT_LANGUAGE,
+  setStoredLanguage,
+} from "@shared/language/stored-language";
+import {
   makeProofreadResult,
   stubBuiltInAIUnsupported,
   stubProofreader,
@@ -17,6 +21,7 @@ function renderSuggestions(text: string) {
 describe("useSuggestions", () => {
   beforeEach(() => {
     setAISharedContext("");
+    setStoredLanguage(DEFAULT_LANGUAGE);
   });
 
   test("reports unsupported and stays empty when no Built-in AI is available", async () => {
@@ -129,7 +134,7 @@ describe("useSuggestions", () => {
   });
 
   test("uses the selected language rather than English", async () => {
-    localStorage.setItem("language", JSON.stringify("he"));
+    setStoredLanguage("he");
     const { create } = stubRewriter();
     stubBuiltInAIUnsupported("Proofreader");
 

--- a/src/shared/language/language-provider.tsx
+++ b/src/shared/language/language-provider.tsx
@@ -1,10 +1,9 @@
 import { baseLocale, isLocale, setLocale } from "@paraglide/runtime";
-import { usePersistentState } from "@shared/hooks/use-persistent-state";
 import { useVoiceLanguageSync } from "@shared/speech/use-voice-language-sync";
 import { getTextDirection } from "@shared/utils/locale";
 import { useLayoutEffect, type ReactNode } from "react";
 import { LanguageContext, type LanguageContextValue } from "./language-context";
-import { DEFAULT_LANGUAGE, LANGUAGE_STORAGE_KEY } from "./stored-language";
+import { setStoredLanguage, useStoredLanguage } from "./stored-language";
 import { useAvailableLanguages } from "./use-available-languages";
 
 export interface LanguageProviderProps {
@@ -12,10 +11,7 @@ export interface LanguageProviderProps {
 }
 
 export function LanguageProvider({ children }: LanguageProviderProps) {
-  const [language, setLanguage] = usePersistentState<string>(
-    LANGUAGE_STORAGE_KEY,
-    DEFAULT_LANGUAGE,
-  );
+  const language = useStoredLanguage();
   const languages = useAvailableLanguages();
   const direction = getTextDirection(language);
 
@@ -31,7 +27,7 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
 
   const contextValue: LanguageContextValue = {
     language,
-    setLanguage,
+    setLanguage: setStoredLanguage,
     languages,
     direction,
   };

--- a/src/shared/language/stored-language.test.ts
+++ b/src/shared/language/stored-language.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import {
+  DEFAULT_LANGUAGE,
+  getStoredLanguage,
+  parseStoredLanguage,
+  setStoredLanguage,
+} from "./stored-language";
+
+describe("parseStoredLanguage", () => {
+  test("passes a non-empty string through unchanged", () => {
+    expect(parseStoredLanguage("he")).toBe("he");
+  });
+
+  test("falls back to the default for a non-string value", () => {
+    expect(parseStoredLanguage({ not: "a string" })).toBe(DEFAULT_LANGUAGE);
+    expect(parseStoredLanguage(undefined)).toBe(DEFAULT_LANGUAGE);
+    expect(parseStoredLanguage(42)).toBe(DEFAULT_LANGUAGE);
+  });
+
+  test("falls back to the default for an empty string", () => {
+    expect(parseStoredLanguage("")).toBe(DEFAULT_LANGUAGE);
+  });
+});
+
+describe("stored-language store", () => {
+  beforeEach(() => {
+    setStoredLanguage(DEFAULT_LANGUAGE);
+  });
+
+  test("setStoredLanguage exposes the new value as the live snapshot", () => {
+    setStoredLanguage("fr");
+
+    expect(getStoredLanguage()).toBe("fr");
+  });
+});

--- a/src/shared/language/stored-language.ts
+++ b/src/shared/language/stored-language.ts
@@ -1,12 +1,26 @@
+import { createPersistedStore } from "@shared/utils/persisted-store";
+import { useSyncExternalStore } from "react";
+
 export const LANGUAGE_STORAGE_KEY = "language";
 export const DEFAULT_LANGUAGE = "en";
 
-export function getStoredLanguage(): string {
-  try {
-    const stored = localStorage.getItem(LANGUAGE_STORAGE_KEY);
+export function parseStoredLanguage(raw: unknown): string {
+  return typeof raw === "string" && raw !== "" ? raw : DEFAULT_LANGUAGE;
+}
 
-    return stored ? (JSON.parse(stored) as string) : DEFAULT_LANGUAGE;
-  } catch {
-    return DEFAULT_LANGUAGE;
-  }
+const store = createPersistedStore<string>(
+  LANGUAGE_STORAGE_KEY,
+  parseStoredLanguage,
+);
+
+export function getStoredLanguage(): string {
+  return store.getSnapshot();
+}
+
+export function setStoredLanguage(language: string): void {
+  store.setState(language);
+}
+
+export function useStoredLanguage(): string {
+  return useSyncExternalStore(store.subscribe, store.getSnapshot);
 }


### PR DESCRIPTION
Part of #515 — item 1 (persistence triplication). Implements the issue's recommended **Option A**.

## What
Collapse the load-bearing `language` key's write and read onto a single validated `createPersistedStore`, mirroring the existing `ai-shared-context` precedent.

- **[stored-language.ts](src/shared/language/stored-language.ts)** — now owns load/validate/persist/read/subscribe and exposes `getStoredLanguage()` (live in-memory snapshot), `setStoredLanguage()`, and a `useStoredLanguage()` hook.
- **[language-provider.tsx](src/shared/language/language-provider.tsx)** — drops `usePersistentState` for the store; `setLanguage` is now the stable module-level setter.
- **Validator, not a cast** — replaces `JSON.parse(...) as string` with a non-empty-string check. Per the issue's trap, this is deliberately **not** `isLocale`: the selected language is a TTS/board language that may have no shipped UI translation, so an `isLocale` gate would silently reset valid non-UI languages.

## Why it matters
**Eliminates a real race, not just a structural tidy.** On a language change, the board loader read `language` from localStorage, which lagged the in-memory value (the persist ran in a deferred/now-debounced effect) while `useRevalidateOnLanguageChange` fired the loader off the in-memory change. Because child effects run before parent effects, the revalidation's loader read could observe the **pre-write** value and re-translate the board into the *previous* language. `setStoredLanguage` now updates the in-memory store synchronously, and the loader reads that same snapshot — the read can't outrun the write.

Secondary: the `as string` type lie is gone (corrupt storage now falls back to the default instead of propagating a non-string into `setLocale`/Intl), and two coincidentally-agreeing write/read paths become one contract that can't desync.

## Tradeoff (intentional)
Persistence is now debounced 200ms (vs. the old immediate effect write), matching the `ai-shared-context` store. The only loss is change-then-kill-tab within 200ms; language changes keep the user in-app, so the debounce always flushes in practice.

## Scope note
`usePersistentState` survives — `useOnboarding` (a boolean) is now its only consumer, as the issue's follow-up notes.

## Also in this PR — suggestions dedup fix
Bundled an unrelated bugfix on the same branch: proofreader and rewriter outputs that differ only in case (e.g. "My movies" vs "my movies") both surfaced as separate suggestion chips.

- **[to-phrases.ts](src/features/board/suggestions/to-phrases.ts)** — dedupe on a normalized (trimmed, lower-cased) key while preserving the first candidate's display casing, and seed the seen-set with the input `text` so a candidate matching the input by case alone is dropped. Reworked from a `Set`-plus-loop into an order-preserving `filter` with a type guard.

## Tests
- New [stored-language.test.ts](src/shared/language/stored-language.test.ts): validator (string passthrough; non-string/empty → default) + live-snapshot setter. The validator is an exported pure function because the store is a module singleton that loads once at import (browser-mode `vi.resetModules()` doesn't re-evaluate it).
- Updated [use-suggestions.test.ts](src/features/board/suggestions/use-suggestions.test.ts): it set the language by poking `localStorage` and relied on the old mount-time read; now uses the public `setStoredLanguage` setter, plus a `beforeEach` singleton reset (parallel to the existing `setAISharedContext("")`). Also adds a case-insensitive dedup case for the fix above.

Full suite green (50 files, 377 tests), `tsc --noEmit` and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
