### PR TITLE
refactor: stop exporting internal-only symbols

### DIFF
--- a/src/features/board/storage/boards-db.ts
+++ b/src/features/board/storage/boards-db.ts
@@ -56,7 +56,7 @@ export interface UpsertAssetInput {
   size?: number;
 }
 
-export interface BoardsDBSchema extends DBSchema {
+interface BoardsDBSchema extends DBSchema {
   boardSets: {
     key: string;
     value: BoardSetRecord;

--- a/src/features/board/testing.ts
+++ b/src/features/board/testing.ts
@@ -1,5 +1,1 @@
-export {
-  resetBoardsDB,
-  seedBoardSets,
-  type SeedBoardSet,
-} from "./storage/test-helpers";
+export { resetBoardsDB, seedBoardSets } from "./storage/test-helpers";

--- a/src/shared/language/language-store.ts
+++ b/src/shared/language/language-store.ts
@@ -1,7 +1,7 @@
 import { createPersistedStore } from "@shared/utils/persisted-store";
 import { useSyncExternalStore } from "react";
 
-export const LANGUAGE_STORAGE_KEY = "language";
+const LANGUAGE_STORAGE_KEY = "language";
 export const DEFAULT_LANGUAGE = "en";
 
 export function parseStoredLanguage(raw: unknown): string {


### PR DESCRIPTION
## What

Tightens three over-exported symbols flagged by a dead-surface review. All three were exported but had no cross-module consumer.

- `LANGUAGE_STORAGE_KEY` — used only inside `language-store.ts`; the store (`getStoredLanguage`/`setStoredLanguage`/`useStoredLanguage`) is the intended gateway, so the key stays internal.
- `BoardsDBSchema` — used only inside `boards-db.ts` (the `BoardsDB` type and the `openDB` generic); the module encapsulates IndexedDB behind typed accessors.
- `SeedBoardSet` — removed from the `board/testing` barrel re-export; never imported through it. Still exported from `storage/test-helpers`, where it's `seedBoardSets`' param type.

## Notes

Symbols with plausible reuse or symmetry value (`BOARD_FILE_EXTENSIONS`, `BoardRouteParams`, `Cell`, `BoardFileDropHandlers`, `AssetRecord`) were intentionally left exported. `launch-queue.d.ts` and the `vite.config.ts`-consumed theme colors are tooling false positives, not dead.

Verified: `tsc -b` clean, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)