### PR TITLE
perf(storage): batch IndexedDB writes and bulk-read board sets

### DIFF
--- a/src/features/board/storage/boards-db.ts
+++ b/src/features/board/storage/boards-db.ts
@@ -135,6 +135,9 @@ function openConnection(): Promise<BoardsDB> {
       });
       assets.createIndex("bySetId", "setId");
     },
+    terminated() {
+      connection = null;
+    },
   });
 }
 
@@ -178,17 +181,11 @@ export async function listBoardSets(): Promise<BoardSetRecord[]> {
   const tx = db.transaction("boardSets", "readonly");
   const index = tx.store.index("byUpdatedAt");
 
-  const boardSets: BoardSetRecord[] = [];
-  let cursor = await index.openCursor(undefined, "prev");
-
-  while (cursor) {
-    boardSets.push(cursor.value);
-    cursor = await cursor.continue();
-  }
+  const boardSets = await index.getAll();
 
   await tx.done;
 
-  return boardSets;
+  return boardSets.reverse();
 }
 
 export async function deleteBoardSetRecord(setId: string): Promise<void> {
@@ -215,14 +212,16 @@ export async function putBoards(
   const tx = db.transaction(["boards", "boardSets"], "readwrite");
   const boardStore = tx.objectStore("boards");
 
-  for (const board of boards) {
-    await boardStore.put({
-      setId,
-      boardId: board.boardId,
-      name: board.name,
-      obf: board.obf,
-    });
-  }
+  await Promise.all(
+    boards.map((board) =>
+      boardStore.put({
+        setId,
+        boardId: board.boardId,
+        name: board.name,
+        obf: board.obf,
+      }),
+    ),
+  );
 
   const boardSet = await tx.objectStore("boardSets").get(setId);
 
@@ -281,16 +280,17 @@ export async function putAssets(
   const tx = db.transaction(["assets", "boardSets"], "readwrite");
   const assetStore = tx.objectStore("assets");
 
-  for (const asset of assets) {
-    const cleanPath = normalizePath(asset.path);
-    await assetStore.put({
-      setId,
-      path: cleanPath,
-      blob: asset.blob,
-      mime: asset.mime,
-      size: asset.size ?? asset.blob.size,
-    });
-  }
+  await Promise.all(
+    assets.map((asset) =>
+      assetStore.put({
+        setId,
+        path: normalizePath(asset.path),
+        blob: asset.blob,
+        mime: asset.mime,
+        size: asset.size ?? asset.blob.size,
+      }),
+    ),
+  );
 
   const boardSet = await tx.objectStore("boardSets").get(setId);
 


### PR DESCRIPTION
## What

Three IndexedDB access-pattern improvements in `boards-db.ts`, found while reviewing the import / translation / read data flows for performance.

- **`putBoards` / `putAssets`** — replaced the awaited `for…of` put loops with a single `Promise.all` over the puts. The old code paid one main-thread↔IDB round-trip per item; firing them together lets IndexedDB drain the queued writes back-to-back within the same transaction. Biggest effect on asset-heavy `.obz` imports (hundreds of images). The post-write count/metadata update still runs after the puts resolve, so `boardCount` stays accurate.
- **`listBoardSets`** — swapped the row-by-row `byUpdatedAt` cursor (one round-trip per row) for a single `getAll()` + `reverse()`, preserving newest-first order.
- **`terminated()`** — wired `openDB`'s `terminated` callback to clear the memoized `connection`, so a browser-terminated handle self-heals on the next access instead of throwing `InvalidStateError` until reload.

## Scope / impact

Behavior-preserving. The win is coordination/round-trip overhead, not raw write throughput — negligible for a small single `.obf`, meaningful for large asset sets. Not benchmarked.

## Known tradeoff

On a `put` rejection (realistically `QuotaExceededError`), `Promise.all` latches the first rejection while sibling puts reject on transaction abort — those become unhandled rejections. There's no global `unhandledrejection` handler in the app, so the practical effect is console noise; the import still fails atomically (tx rolls back).

## Verification

- `npm run lint` (boards-db.ts) — clean
- `tsc --noEmit` — exit 0
- `boards-db.test.ts` — 29/29 pass

Note: the `terminated()` path is not unit-tested — fake-indexeddb can't simulate browser-initiated termination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)