### PR TITLE
feat(board): snap overflowing boards to pages instead of free scroll

### DIFF
--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -1,20 +1,20 @@
-import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import { m } from "@paraglide/messages.js";
 import { useLanguage } from "@shared/language/use-language";
 import { usePlaybackConfig } from "@shared/playback/playback-store";
 import { createButtonActivation } from "./activation/button-activation";
-import { Grid, type GridItemProps } from "./grid/grid";
+import { getNavigationTargetId } from "./board-button";
+import { type GridItemProps } from "./grid/grid";
+import { ScrollSnapGrid } from "./grid/scroll-snap-grid";
 import { useBoardKeyboard } from "./keyboard/use-board-keyboard";
 import { MessageBar } from "./message/message-bar";
-import { useMessage } from "./message/use-message";
 import { useMessagePlayback } from "./message/playback/use-message-playback";
+import { useMessage } from "./message/use-message";
 import { NavButtons } from "./navigation/nav-buttons";
 import { useBoardNavigation } from "./navigation/use-board-navigation";
 import { SuggestionBar } from "./suggestions/suggestion-bar";
 import { useSuggestions } from "./suggestions/use-suggestions";
 import { Tile } from "./tile/tile";
-import { getNavigationTargetId } from "./board-button";
 import type { Board, BoardButton } from "./types";
 
 export interface BoardViewerProps {
@@ -103,17 +103,15 @@ export function BoardViewer({ board }: BoardViewerProps) {
         )}
       </Stack>
 
-      <Box sx={{ flexGrow: 1, height: 0, overflow: "auto" }}>
-        <Grid<BoardButton>
-          ariaLabel={board.name ?? m.boardGridLabel()}
-          items={board.buttons}
-          rows={board.grid.rows}
-          columns={board.grid.columns}
-          order={board.grid.order}
-          renderItem={renderTile}
-          dir={direction}
-        />
-      </Box>
+      <ScrollSnapGrid<BoardButton>
+        ariaLabel={board.name ?? m.boardGridLabel()}
+        items={board.buttons}
+        rows={board.grid.rows}
+        columns={board.grid.columns}
+        order={board.grid.order}
+        renderItem={renderTile}
+        dir={direction}
+      />
     </Stack>
   );
 }

--- a/src/features/board/grid/grid-metrics.test.ts
+++ b/src/features/board/grid/grid-metrics.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { computeSnapMetrics, type SnapMetricsInput } from "./grid-metrics";
+
+// 72px cells with a 16px gap => 88px pitch.
+const base: SnapMetricsInput = {
+  clientWidth: 400,
+  clientHeight: 600,
+  scrollWidth: 400,
+  scrollHeight: 600,
+  columns: 4,
+  rows: 6,
+  gapPx: 16,
+};
+
+describe("computeSnapMetrics", () => {
+  it("does not snap when the board fits both axes", () => {
+    const metrics = computeSnapMetrics(base);
+
+    expect(metrics.snapType).toBe("none");
+    expect(metrics.snapColumns).toBe(4);
+    expect(metrics.snapRows).toBe(6);
+  });
+
+  it("snaps on the x axis for a wide board", () => {
+    const metrics = computeSnapMetrics({
+      ...base,
+      columns: 14,
+      clientWidth: 360,
+      scrollWidth: 1248, // 14*72 + 13*16 + 32 padding
+    });
+
+    expect(metrics.snapType).toBe("x mandatory");
+    expect(metrics.snapColumns).toBe(4);
+  });
+
+  it("snaps on the y axis for a tall board", () => {
+    const metrics = computeSnapMetrics({
+      ...base,
+      rows: 20,
+      scrollHeight: 1776, // 20*72 + 19*16 + 32 padding
+    });
+
+    expect(metrics.snapType).toBe("y mandatory");
+    expect(metrics.snapRows).toBe(7);
+  });
+
+  it("snaps on both axes when both overflow", () => {
+    const metrics = computeSnapMetrics({
+      ...base,
+      columns: 14,
+      rows: 20,
+      clientWidth: 360,
+      scrollWidth: 1248,
+      scrollHeight: 1776,
+    });
+
+    expect(metrics.snapType).toBe("both mandatory");
+    expect(metrics.snapColumns).toBe(4);
+    expect(metrics.snapRows).toBe(7);
+  });
+
+  it("counts the last partially-visible column correctly (no off-by-one)", () => {
+    // 360px / 88px pitch fits 4 cells (4*72 + 3*16 = 336 <= 360), not 3.
+    const metrics = computeSnapMetrics({
+      ...base,
+      columns: 14,
+      clientWidth: 360,
+      scrollWidth: 1248,
+    });
+
+    expect(metrics.snapColumns).toBe(4);
+  });
+
+  it("never reports more snap stride than authored cells", () => {
+    const metrics = computeSnapMetrics({
+      ...base,
+      columns: 2,
+      rows: 2,
+    });
+
+    expect(metrics.snapColumns).toBe(2);
+    expect(metrics.snapRows).toBe(2);
+  });
+
+  it("clamps to at least one cell per page", () => {
+    const metrics = computeSnapMetrics({
+      ...base,
+      columns: 14,
+      clientWidth: 0,
+      scrollWidth: 1248,
+    });
+
+    expect(metrics.snapColumns).toBe(1);
+  });
+});

--- a/src/features/board/grid/grid-metrics.ts
+++ b/src/features/board/grid/grid-metrics.ts
@@ -1,0 +1,74 @@
+/** Minimum touch-target size for a board cell, in CSS pixels. */
+export const MIN_CELL_PX = 72;
+
+export type ScrollSnapType =
+  | "none"
+  | "x mandatory"
+  | "y mandatory"
+  | "both mandatory";
+
+export interface SnapMetrics {
+  /** Columns that fit in one screenful — spacing between horizontal snap points. */
+  snapColumns: number;
+  /** Rows that fit in one screenful — spacing between vertical snap points. */
+  snapRows: number;
+  /** Value for the scroll container's `scroll-snap-type`. */
+  snapType: ScrollSnapType;
+}
+
+export interface SnapMetricsInput {
+  /** Scroll container's visible width. */
+  clientWidth: number;
+  /** Scroll container's visible height. */
+  clientHeight: number;
+  /** Scroll container's total content width. */
+  scrollWidth: number;
+  /** Scroll container's total content height. */
+  scrollHeight: number;
+  /** Authored column count. */
+  columns: number;
+  /** Authored row count. */
+  rows: number;
+  /** Gap between cells, in CSS pixels. */
+  gapPx: number;
+}
+
+/**
+ * Pure geometry for scroll-snap windowing of a fixed-cell board.
+ *
+ * Computes how many whole {@link MIN_CELL_PX} cells fit per screenful (the snap
+ * stride) and which axes actually overflow (so a fitting axis never snaps). No
+ * DOM or React — measurement is the caller's job, which keeps this testable.
+ */
+export function computeSnapMetrics({
+  clientWidth,
+  clientHeight,
+  scrollWidth,
+  scrollHeight,
+  columns,
+  rows,
+  gapPx,
+}: SnapMetricsInput): SnapMetrics {
+  const pitch = MIN_CELL_PX + gapPx; // cell + gap
+
+  // N cells span N*MIN + (N-1)*gap, so N <= (extent + gap) / pitch.
+  const fitCols = Math.floor((clientWidth + gapPx) / pitch);
+  const fitRows = Math.floor((clientHeight + gapPx) / pitch);
+
+  const snapColumns = Math.max(1, Math.min(columns, fitCols));
+  const snapRows = Math.max(1, Math.min(rows, fitRows));
+
+  const overflowsX = scrollWidth - clientWidth > 1;
+  const overflowsY = scrollHeight - clientHeight > 1;
+
+  const snapType: ScrollSnapType =
+    overflowsX && overflowsY
+      ? "both mandatory"
+      : overflowsX
+        ? "x mandatory"
+        : overflowsY
+          ? "y mandatory"
+          : "none";
+
+  return { snapColumns, snapRows, snapType };
+}

--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -1,7 +1,6 @@
 import Stack from "@mui/material/Stack";
+import { MIN_CELL_PX } from "./grid-metrics";
 import { useGridKeyboard } from "./use-grid-keyboard";
-
-const MIN_CELL_PX = 72;
 
 export interface GridItemProps {
   tabIndex: number;

--- a/src/features/board/grid/scroll-snap-grid.tsx
+++ b/src/features/board/grid/scroll-snap-grid.tsx
@@ -1,0 +1,57 @@
+import Box from "@mui/material/Box";
+import { useRef } from "react";
+import { Grid, type GridProps } from "./grid";
+import { useGridSnap } from "./use-grid-snap";
+
+/**
+ * Renders a board at its authored size and turns any overflow into a
+ * scroll-snapping view instead of free two-axis scrollbars.
+ *
+ * Nothing is reflowed: every button keeps its authored position. Snap points
+ * are placed on page-boundary rows (block axis) and cells (inline axis) by
+ * targeting the grid's ARIA roles from here, so `Grid` stays snap-agnostic.
+ */
+export function ScrollSnapGrid<TItem extends { id: string }>(
+  props: GridProps<TItem>,
+) {
+  const { columns, rows, gap = 2 } = props;
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const { snapColumns, snapRows, snapType } = useGridSnap(
+    scrollRef,
+    columns,
+    rows,
+    gap,
+  );
+
+  return (
+    <Box
+      ref={scrollRef}
+      sx={(theme) => ({
+        flexGrow: 1,
+        minHeight: 0,
+        overflow: "auto",
+        overscrollBehavior: "contain",
+        scrollSnapType: snapType,
+        // Inset snap positions by the grid's own padding so snapping to a page
+        // boundary doesn't scroll the top/left padding out of view.
+        scrollPaddingInlineStart: theme.spacing(gap),
+        scrollPaddingBlockStart: theme.spacing(gap),
+        // Present as snapping pages, not scrollbars.
+        scrollbarWidth: "none",
+        "&::-webkit-scrollbar": { display: "none" },
+        // Snap stride lives here, keyed off the grid's ARIA roles, so the grid
+        // component stays unaware of scrolling.
+        [`& [role="row"]:nth-of-type(${snapRows}n + 1)`]: {
+          scrollSnapAlign: "start none",
+          scrollSnapStop: "always",
+        },
+        [`& [role="gridcell"]:nth-of-type(${snapColumns}n + 1)`]: {
+          scrollSnapAlign: "none start",
+          scrollSnapStop: "always",
+        },
+      })}
+    >
+      <Grid {...props} />
+    </Box>
+  );
+}

--- a/src/features/board/grid/use-grid-snap.ts
+++ b/src/features/board/grid/use-grid-snap.ts
@@ -1,0 +1,59 @@
+import { useTheme } from "@mui/material/styles";
+import { useEffect, useState } from "react";
+import type { RefObject } from "react";
+import { computeSnapMetrics, type SnapMetrics } from "./grid-metrics";
+
+/**
+ * Observes a scroll container and reports scroll-snap geometry for the board
+ * inside it. The board is never reflowed — every button keeps its authored
+ * position; this only decides where snap points go and which axes snap.
+ *
+ * The arithmetic lives in {@link computeSnapMetrics}; this hook only handles the
+ * DOM measurement (size + overflow) on resize.
+ */
+export function useGridSnap(
+  scrollRef: RefObject<HTMLElement | null>,
+  columns: number,
+  rows: number,
+  gap = 2,
+): SnapMetrics {
+  const theme = useTheme();
+  // Gap between cells in px, from the same theme spacing the grid uses.
+  const gapPx = Number.parseFloat(theme.spacing(gap)) || gap * 8;
+
+  const [metrics, setMetrics] = useState<SnapMetrics>({
+    snapColumns: columns,
+    snapRows: rows,
+    snapType: "none",
+  });
+
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (!element) {
+      return;
+    }
+
+    const measure = () => {
+      setMetrics(
+        computeSnapMetrics({
+          clientWidth: element.clientWidth,
+          clientHeight: element.clientHeight,
+          scrollWidth: element.scrollWidth,
+          scrollHeight: element.scrollHeight,
+          columns,
+          rows,
+          gapPx,
+        }),
+      );
+    };
+
+    // ResizeObserver delivers an initial callback on observe(), which performs
+    // the first measurement — so we avoid a synchronous setState in the effect.
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, [scrollRef, columns, rows, gapPx]);
+
+  return metrics;
+}


### PR DESCRIPTION
## What

When a board is authored larger than the viewport, it previously got free two-axis scrolling. That loses the stable spatial frame AAC users rely on — selection is a learned motor plan, and free panning means the board has no fixed "home" view.

This keeps every button at its **authored position** (no reflow) and turns overflow into a **scroll-snapping paged view**: the container snaps to page-boundary rows and columns, so the user moves between whole screenfuls rather than panning to arbitrary offsets.

## Why not reflow

No major AAC product auto-reflows to fit a screen — moving buttons invalidates the rehearsed motor plan and measurably slows access. The industry answer is fixed grids + pagination/scroll (Proloquo's fixed grid, TD Snap's vertical paging). This change is the scroll/paginate side of that consensus.

## How

- **`computeSnapMetrics`** (`grid-metrics.ts`) — pure geometry, no DOM: how many whole `MIN_CELL_PX` cells fit per screenful (the snap stride) and which axes actually overflow (a fitting axis never snaps). Unit-tested.
- **`useGridSnap`** — measures the scroll container via `ResizeObserver` and feeds `computeSnapMetrics`; returns snap stride + `scroll-snap-type`.
- **`ScrollSnapGrid`** — wraps `Grid` in the scroll container and places snap points by targeting the grid's ARIA roles (`[role="row"]`/`[role="gridcell"]`), so `Grid` stays snap-agnostic.
- `MIN_CELL_PX` moved from `grid.tsx` into `grid-metrics.ts` (shared by both).

## Test plan

- [x] `grid-metrics.test.ts` — 7 cases (fit/x/y/both overflow, off-by-one on the last partial column, stride never exceeds authored cells, clamp ≥1)
- [x] `npm run lint` clean, `tsc -b` clean
- [ ] Manual: load a board wider/taller than the viewport, confirm it snaps page-by-page and a fitting board doesn't snap

## Open question

The board snaps on **both** axes when both overflow. The AAC literature flags horizontal panning as worse than vertical for touch/switch scanning (TD Snap pages vertically only). Worth deciding whether to constrain to vertical-only paging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)