### PR TITLE
test(activation): drop phantom message seed from spell test

### DIFF
--- a/src/features/board/activation/button-activation.test.ts
+++ b/src/features/board/activation/button-activation.test.ts
@@ -157,8 +157,7 @@ describe("createButtonActivation", () => {
   });
 
   test("delegates a spell action's text to the message's appendText", async () => {
-    const message = createMessageStub([{ id: "ca", label: "ca" }]);
-    const { activation } = setup({ message });
+    const { activation, message } = setup();
 
     await activation.activateButton({
       id: "btn",


### PR DESCRIPTION
## What

The spell-action test seeded the message stub with `[{ id: "ca", label: "ca" }]`, then asserted only `appendText("t")`.

## Why

The spell path under test is `case "spell": return message.appendText(action.text)` — it never reads `message.parts`, and `appendText` is a bare `vi.fn()`. So the seeded part was inert (it feeds only `message.text`, which this test never asserts). Worse than idle: `"ca"` plus a spelled `"t"` reads like the start of *"cat"*, baiting a reader into hunting for a `"ca" + "t"` relationship that does not exist. It also broke the parallel with every sibling action test (space/backspace/clear/speak/home), all of which use a clean empty `setup()`.

This swaps it for the same `setup()` form. Behavior-preserving: `setup()` mints a fresh empty `createMessageStub()` whose `appendText` is the same bare `vi.fn()`, so the assertion passes identically.

## Test

`vitest run src/features/board/activation/button-activation.test.ts` — 16 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)