### PR TITLE
feat(suggestions): show a progress indicator while AI suggestions generate

### DIFF
--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -4,17 +4,17 @@ import { m } from "@paraglide/messages.js";
 import { useLanguage } from "@shared/language/use-language";
 import { usePlaybackConfig } from "@shared/playback/playback-store";
 import { createButtonActivation } from "./activation/button-activation";
+import { getNavigationTargetId } from "./board-button";
 import { Grid, type GridItemProps } from "./grid/grid";
 import { useBoardKeyboard } from "./keyboard/use-board-keyboard";
 import { MessageBar } from "./message/message-bar";
-import { useMessage } from "./message/use-message";
 import { useMessagePlayback } from "./message/playback/use-message-playback";
+import { useMessage } from "./message/use-message";
 import { NavButtons } from "./navigation/nav-buttons";
 import { useBoardNavigation } from "./navigation/use-board-navigation";
 import { SuggestionBar } from "./suggestions/suggestion-bar";
 import { useSuggestions } from "./suggestions/use-suggestions";
 import { Tile } from "./tile/tile";
-import { getNavigationTargetId } from "./board-button";
 import type { Board, BoardButton } from "./types";
 
 export interface BoardViewerProps {
@@ -95,10 +95,11 @@ export function BoardViewer({ board }: BoardViewerProps) {
         {suggestions.isSupported && (
           <SuggestionBar
             suggestions={suggestions.phrases}
+            isPending={suggestions.isPending}
             tone={suggestions.tone}
             canChangeTone={suggestions.isRewriterSupported}
-            onToneChange={suggestions.setTone}
             onSuggestionClick={message.setFromText}
+            onToneChange={suggestions.setTone}
           />
         )}
       </Stack>

--- a/src/features/board/suggestions/suggestion-bar.test.tsx
+++ b/src/features/board/suggestions/suggestion-bar.test.tsx
@@ -18,6 +18,7 @@ describe("SuggestionBar", () => {
     const screen = await render(
       <SuggestionBar
         suggestions={suggestions}
+        isPending={false}
         tone="as-is"
         canChangeTone
         {...handlers}
@@ -38,6 +39,7 @@ describe("SuggestionBar", () => {
     const screen = await render(
       <SuggestionBar
         suggestions={suggestions}
+        isPending={false}
         tone="as-is"
         canChangeTone
         {...handlers}
@@ -63,6 +65,7 @@ describe("SuggestionBar", () => {
     const screen = await render(
       <SuggestionBar
         suggestions={["Hello"]}
+        isPending={false}
         tone="as-is"
         canChangeTone
         {...handlers}
@@ -80,6 +83,7 @@ describe("SuggestionBar", () => {
     const screen = await render(
       <SuggestionBar
         suggestions={["Hello"]}
+        isPending={false}
         tone="as-is"
         canChangeTone={false}
         {...handlers}
@@ -97,6 +101,7 @@ describe("SuggestionBar", () => {
     const screen = await render(
       <SuggestionBar
         suggestions={["Hello", "How are you?", "Thank you"]}
+        isPending={false}
         tone="as-is"
         canChangeTone
         {...handlers}

--- a/src/features/board/suggestions/suggestion-bar.tsx
+++ b/src/features/board/suggestions/suggestion-bar.tsx
@@ -1,23 +1,25 @@
 import Box from "@mui/material/Box";
 import Chip from "@mui/material/Chip";
 import Stack from "@mui/material/Stack";
-import { LoadingDots } from "@shared/components/loading-dots";
+import { DotsProgress } from "@shared/components/dots-progress";
 import { ToneSelector } from "./tone-selector";
 
 export interface SuggestionBarProps {
   suggestions: string[];
+  isPending: boolean;
   tone: RewriterTone;
   canChangeTone: boolean;
-  onToneChange: (tone: RewriterTone) => void;
   onSuggestionClick: (suggestion: string) => void;
+  onToneChange: (tone: RewriterTone) => void;
 }
 
 export function SuggestionBar({
   suggestions,
+  isPending,
   tone,
   canChangeTone,
-  onToneChange,
   onSuggestionClick,
+  onToneChange,
 }: SuggestionBarProps) {
   return (
     <Stack
@@ -41,8 +43,7 @@ export function SuggestionBar({
         ))}
       </Box>
 
-      <LoadingDots />
-
+      {isPending && <DotsProgress />}
       {canChangeTone && <ToneSelector tone={tone} onChange={onToneChange} />}
     </Stack>
   );

--- a/src/features/board/suggestions/suggestion-bar.tsx
+++ b/src/features/board/suggestions/suggestion-bar.tsx
@@ -1,6 +1,7 @@
 import Box from "@mui/material/Box";
 import Chip from "@mui/material/Chip";
 import Stack from "@mui/material/Stack";
+import { LoadingDots } from "@shared/components/loading-dots";
 import { ToneSelector } from "./tone-selector";
 
 export interface SuggestionBarProps {
@@ -39,6 +40,8 @@ export function SuggestionBar({
           />
         ))}
       </Box>
+
+      <LoadingDots />
 
       {canChangeTone && <ToneSelector tone={tone} onChange={onToneChange} />}
     </Stack>

--- a/src/features/board/suggestions/use-suggestions.test.ts
+++ b/src/features/board/suggestions/use-suggestions.test.ts
@@ -226,6 +226,28 @@ describe("useSuggestions", () => {
     });
   });
 
+  test("reports isPending while a suggestion is in flight and clears it once resolved", async () => {
+    const pending: ((rewritten: string) => void)[] = [];
+    stubRewriter(() => new Promise<string>((resolve) => pending.push(resolve)));
+    stubBuiltInAIUnsupported("Proofreader");
+
+    const { result } = await renderSuggestions("hi");
+
+    await vi.waitFor(() => {
+      expect(result.current.isPending).toBe(true);
+      expect(result.current.isRewriterPending).toBe(true);
+    });
+
+    await vi.waitFor(() => expect(pending).toHaveLength(1));
+    pending[0]("casual hi");
+
+    await vi.waitFor(() => {
+      expect(result.current.phrases).toEqual(["casual hi"]);
+      expect(result.current.isPending).toBe(false);
+      expect(result.current.isRewriterPending).toBe(false);
+    });
+  });
+
   test("ignores a stale in-flight result when the text changes mid-flight", async () => {
     const resolvers = new Map<string, (result: ProofreadResult) => void>();
     stubProofreader(

--- a/src/features/board/suggestions/use-suggestions.ts
+++ b/src/features/board/suggestions/use-suggestions.ts
@@ -12,6 +12,9 @@ export interface UseSuggestionsReturn {
   isSupported: boolean;
   isProofreaderSupported: boolean;
   isRewriterSupported: boolean;
+  isPending: boolean;
+  isProofreaderPending: boolean;
+  isRewriterPending: boolean;
   phrases: string[];
   tone: RewriterTone;
   setTone: (tone: RewriterTone) => void;
@@ -67,7 +70,10 @@ export function useSuggestions(text: string): UseSuggestionsReturn {
     isSupported: isProofreaderSupported || isRewriterSupported,
     isProofreaderSupported,
     isRewriterSupported,
-    phrases: toPhrases(text, [corrected, rewritten]),
+    isPending: corrected.isPending || rewritten.isPending,
+    isProofreaderPending: corrected.isPending,
+    isRewriterPending: rewritten.isPending,
+    phrases: toPhrases(text, [corrected.value, rewritten.value]),
     tone,
     setTone,
   };

--- a/src/shared/components/dots-progress.tsx
+++ b/src/shared/components/dots-progress.tsx
@@ -1,21 +1,21 @@
 import Box from "@mui/material/Box";
 
-export function LoadingDots() {
+export function DotsProgress() {
   return (
     <Box
       sx={{
         display: "flex",
         gap: 1,
         "& span": {
-          width: "12px",
-          height: "12px",
-          backgroundColor: "primary.main",
+          width: 8,
+          height: 8,
+          backgroundColor: "text.primary",
           borderRadius: "50%",
-          animation: "loading-dots 1.4s ease-in-out infinite",
+          animation: "dots-progress 1.4s ease-in-out infinite",
         },
         "& span:nth-of-type(1)": { animationDelay: "-0.32s" },
         "& span:nth-of-type(2)": { animationDelay: "-0.16s" },
-        "@keyframes loading-dots": {
+        "@keyframes dots-progress": {
           "0%, 80%, 100%": { transform: "scale(0)" },
           "40%": { transform: "scale(1)" },
         },

--- a/src/shared/components/loading-dots.tsx
+++ b/src/shared/components/loading-dots.tsx
@@ -1,0 +1,29 @@
+import Box from "@mui/material/Box";
+
+export function LoadingDots() {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        gap: 1,
+        "& span": {
+          width: "12px",
+          height: "12px",
+          backgroundColor: "primary.main",
+          borderRadius: "50%",
+          animation: "loading-dots 1.4s ease-in-out infinite",
+        },
+        "& span:nth-of-type(1)": { animationDelay: "-0.32s" },
+        "& span:nth-of-type(2)": { animationDelay: "-0.16s" },
+        "@keyframes loading-dots": {
+          "0%, 80%, 100%": { transform: "scale(0)" },
+          "40%": { transform: "scale(1)" },
+        },
+      }}
+    >
+      <span />
+      <span />
+      <span />
+    </Box>
+  );
+}

--- a/src/shared/hooks/use-latest-async.test.ts
+++ b/src/shared/hooks/use-latest-async.test.ts
@@ -12,7 +12,7 @@ describe("useLatestAsync", () => {
       }),
     );
 
-    await vi.waitFor(() => expect(result.current).toBe("value-a"));
+    await vi.waitFor(() => expect(result.current.value).toBe("value-a"));
   });
 
   test("stands down without fetching when not enabled", async () => {
@@ -22,7 +22,8 @@ describe("useLatestAsync", () => {
       useLatestAsync({ enabled: false, deps: ["a"], fetch }),
     );
 
-    expect(result.current).toBeUndefined();
+    expect(result.current.value).toBeUndefined();
+    expect(result.current.isPending).toBe(false);
     expect(fetch).not.toHaveBeenCalled();
   });
 
@@ -33,8 +34,51 @@ describe("useLatestAsync", () => {
       useLatestAsync({ enabled: true, deps: [], fetch }),
     );
 
-    await vi.waitFor(() => expect(result.current).toBe("once"));
+    await vi.waitFor(() => expect(result.current.value).toBe("once"));
     expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("is pending from mount until the fetch resolves", async () => {
+    const pending: ((value: string) => void)[] = [];
+    const { result } = await renderHook(() =>
+      useLatestAsync({
+        enabled: true,
+        deps: ["a"],
+        fetch: () => new Promise<string>((r) => pending.push(r)),
+      }),
+    );
+
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.value).toBeUndefined();
+
+    await vi.waitFor(() => expect(pending).toHaveLength(1));
+    pending[0]("value-a");
+
+    await vi.waitFor(() => {
+      expect(result.current.value).toBe("value-a");
+      expect(result.current.isPending).toBe(false);
+    });
+  });
+
+  test("returns to pending the instant deps change, until the next resolves", async () => {
+    const pending: ((value: string) => void)[] = [];
+    const { result, rerender } = await renderHook(
+      ({ id }: { id: string } = { id: "a" }) =>
+        useLatestAsync({
+          enabled: true,
+          deps: [id],
+          fetch: () => new Promise<string>((r) => pending.push(r)),
+        }),
+      { initialProps: { id: "a" } },
+    );
+
+    await vi.waitFor(() => expect(pending).toHaveLength(1));
+    pending[0]("value-a");
+    await vi.waitFor(() => expect(result.current.isPending).toBe(false));
+
+    await rerender({ id: "b" });
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.value).toBeUndefined();
   });
 
   test("hides the previous value the instant deps change, until the next resolves", async () => {
@@ -51,14 +95,14 @@ describe("useLatestAsync", () => {
 
     await vi.waitFor(() => expect(pending).toHaveLength(1));
     pending[0]("value-a");
-    await vi.waitFor(() => expect(result.current).toBe("value-a"));
+    await vi.waitFor(() => expect(result.current.value).toBe("value-a"));
 
     await rerender({ id: "b" });
-    expect(result.current).toBeUndefined();
+    expect(result.current.value).toBeUndefined();
 
     await vi.waitFor(() => expect(pending).toHaveLength(2));
     pending[1]("value-b");
-    await vi.waitFor(() => expect(result.current).toBe("value-b"));
+    await vi.waitFor(() => expect(result.current.value).toBe("value-b"));
   });
 
   test("ignores a stale in-flight result that resolves after deps moved on", async () => {
@@ -80,6 +124,6 @@ describe("useLatestAsync", () => {
     pending.get("b")?.("value-b");
     pending.get("a")?.("value-a");
 
-    await vi.waitFor(() => expect(result.current).toBe("value-b"));
+    await vi.waitFor(() => expect(result.current.value).toBe("value-b"));
   });
 });

--- a/src/shared/hooks/use-latest-async.ts
+++ b/src/shared/hooks/use-latest-async.ts
@@ -6,11 +6,16 @@ export interface UseLatestAsyncOptions<T> {
   fetch: (signal: AbortSignal) => Promise<T>;
 }
 
+export interface UseLatestAsyncReturn<T> {
+  value: T | undefined;
+  isPending: boolean;
+}
+
 export function useLatestAsync<T>({
   enabled,
   deps,
   fetch,
-}: UseLatestAsyncOptions<T>): T | undefined {
+}: UseLatestAsyncOptions<T>): UseLatestAsyncReturn<T> {
   const signature = deps.join("\0");
 
   const fetchRef = useRef(fetch);
@@ -45,5 +50,9 @@ export function useLatestAsync<T>({
     return () => controller.abort();
   }, [enabled, signature]);
 
-  return enabled && result?.signature === signature ? result.value : undefined;
+  return {
+    value:
+      enabled && result?.signature === signature ? result.value : undefined,
+    isPending: enabled && result?.signature !== signature,
+  };
 }


### PR DESCRIPTION
## Summary
- Adds a `DotsProgress` indicator to the suggestion bar that animates only while AI suggestions are being generated (previously it rendered unconditionally).
- Derives a new `isPending` signal in `useLatestAsync` as the complement of its latest-wins value — no extra state, so it can't drift from the returned value.
- `useSuggestions` surfaces aggregate `isPending` plus per-engine `isProofreaderPending` / `isRewriterPending` (symmetric with the existing `*Supported` flags); the bar consumes the aggregate, so the dots stay up until both engines settle.
- Renames the indicator `LoadingDots` → `DotsProgress` to match MUI's `*Progress` vocabulary (`CircularProgress`/`LinearProgress`) and restyles it to the `text.primary` token with unitless px sizing.

## Test plan
- `use-latest-async`: pending lifecycle (pending from mount, false on resolve, true again on deps change) alongside the existing latest-wins / stale-abort cases.
- `use-suggestions`: `isPending` flips true→false across an in-flight rewrite.
- `suggestion-bar`: renders with the required `isPending` prop; a11y check passes.
- Full `tsc --noEmit` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)