### PR TITLE
feat(suggestions): lead with the progress dots, scoped to proofreading

### DIFF
--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -95,7 +95,7 @@ export function BoardViewer({ board }: BoardViewerProps) {
         {suggestions.isSupported && (
           <SuggestionBar
             suggestions={suggestions.phrases}
-            isPending={suggestions.isPending}
+            isPending={suggestions.isProofreaderPending}
             tone={suggestions.tone}
             canChangeTone={suggestions.isRewriterSupported}
             onSuggestionClick={message.setFromText}

--- a/src/features/board/suggestions/suggestion-bar.tsx
+++ b/src/features/board/suggestions/suggestion-bar.tsx
@@ -26,6 +26,8 @@ export function SuggestionBar({
       direction="row"
       sx={{ flex: "1", alignItems: "center", gap: 2, overflow: "hidden" }}
     >
+      {isPending && <DotsProgress />}
+
       <Box
         sx={{
           display: "flex",
@@ -43,7 +45,6 @@ export function SuggestionBar({
         ))}
       </Box>
 
-      {isPending && <DotsProgress />}
       {canChangeTone && <ToneSelector tone={tone} onChange={onToneChange} />}
     </Stack>
   );


### PR DESCRIPTION
## Summary
- Moves the `DotsProgress` indicator to the **start** of the suggestion bar (ahead of the chips) so it reads as a leading "working" cue.
- Drives it from `isProofreaderPending` instead of the aggregate `isPending`, so the dots track proofreading specifically.

## Test plan
- Lint + `suggestion-bar` tests pass; `isPending`/`isProofreaderPending` are already covered by the hook tests on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)