### PR TITLE
fix(library): drop dead rethrow in handleDelete

### DIFF
--- a/src/pages/library-page.tsx
+++ b/src/pages/library-page.tsx
@@ -48,12 +48,11 @@ export const Component = function LibraryPage() {
         message: m.libraryDeleted({ name }),
         severity: "success",
       });
-    } catch (error) {
+    } catch {
       showSnackbar({
         message: m.libraryDeleteFailed({ name }),
         severity: "error",
       });
-      throw error;
     }
   }
 


### PR DESCRIPTION
## Summary

Removes the rethrow after the delete-failure snackbar in the library page's `handleDelete`. The handler is invoked from a click event, so the rethrown error had no caller to reach — it only surfaced as an unhandled rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)