### PR TITLE
fix(import): close setId/boardId validation gaps in URL imports and storage writes

### DIFF
--- a/src/features/board/import/board-import.test.ts
+++ b/src/features/board/import/board-import.test.ts
@@ -182,6 +182,28 @@ describe("importBoardFiles", () => {
       boardCount: archive.boards.size,
     });
   });
+
+  test("falls back to a default setId when the filename is only an extension", async () => {
+    const obzFile = await loadFixtureFile(OBZ_FIXTURE);
+    const extensionOnlyFile = new File([obzFile], ".obz", {
+      type: "application/octet-stream",
+    });
+
+    const importResults = await importBoardFiles(extensionOnlyFile);
+
+    expect(importResults[0].setId).toBe("imported-board");
+  });
+
+  test("clamps the derived setId to 255 characters", async () => {
+    const obfFile = await loadFixtureFile(OBF_FIXTURE);
+    const longNamedFile = new File([obfFile], `${"x".repeat(300)}.obf`, {
+      type: "application/octet-stream",
+    });
+
+    const importResults = await importBoardFiles(longNamedFile);
+
+    expect(importResults[0].setId).toBe("x".repeat(255));
+  });
 });
 
 describe("resolveLoadBoardPaths", () => {

--- a/src/features/board/import/board-import.ts
+++ b/src/features/board/import/board-import.ts
@@ -176,5 +176,7 @@ async function importOBFBoard(
 }
 
 function deriveSetId(filename: string): string {
-  return filename.replace(/\.(obz|obf|zip|json)$/i, "").toLowerCase();
+  const stem = filename.replace(/\.(obz|obf|zip|json)$/i, "").toLowerCase();
+
+  return stem.slice(0, 255) || "imported-board";
 }

--- a/src/features/board/import/import-from-url.test.ts
+++ b/src/features/board/import/import-from-url.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { resetBoardsDB } from "../storage/test-helpers";
+import { importBoardFromUrl } from "./import-from-url";
+
+const SAMPLE_BOARDS_DIR = "/src/shared/testing/sample-boards";
+const OBZ_FIXTURE = "lots-of-stuff.obz";
+
+async function loadFixtureBlob(name: string): Promise<Blob> {
+  const response = await fetch(`${SAMPLE_BOARDS_DIR}/${name}`);
+
+  if (!response.ok) {
+    throw new Error(`Failed to load test fixture: ${response.status}`);
+  }
+
+  return response.blob();
+}
+
+describe("importBoardFromUrl", () => {
+  beforeEach(async () => {
+    await resetBoardsDB();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("imports a board from a URL and derives the setId from the filename", async () => {
+    const result = await importBoardFromUrl(
+      `${SAMPLE_BOARDS_DIR}/${OBZ_FIXTURE}`,
+    );
+
+    expect(result.setId).toBe("lots-of-stuff");
+    expect(result.rootBoardId).toBeTruthy();
+  });
+
+  test("derives the setId from the last non-empty segment when the URL path ends with a slash", async () => {
+    const fixtureBlob = await loadFixtureBlob(OBZ_FIXTURE);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(fixtureBlob));
+
+    const result = await importBoardFromUrl("https://example.com/boards/");
+
+    expect(result.setId).toBe("boards");
+  });
+
+  test("falls back to the default filename when the URL has no path segments", async () => {
+    const fixtureBlob = await loadFixtureBlob(OBZ_FIXTURE);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(fixtureBlob));
+
+    const result = await importBoardFromUrl("https://example.com/");
+
+    expect(result.setId).toBe("board");
+  });
+
+  test("throws on HTTP error responses", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 404 }),
+    );
+
+    await expect(
+      importBoardFromUrl("https://example.com/missing.obz"),
+    ).rejects.toThrow("Failed to fetch board: HTTP 404");
+  });
+});

--- a/src/features/board/import/import-from-url.ts
+++ b/src/features/board/import/import-from-url.ts
@@ -9,7 +9,7 @@ export async function importBoardFromUrl(url: string): Promise<ImportResult> {
 
   const blob = await response.blob();
   const pathname = new URL(url, window.location.origin).pathname;
-  const filename = pathname.split("/").at(-1) ?? "board.obz";
+  const filename = pathname.split("/").filter(Boolean).at(-1) ?? "board.obz";
 
   const file = new File([blob], filename, {
     type: blob.type || "application/octet-stream",

--- a/src/features/board/storage/boards-db.test.ts
+++ b/src/features/board/storage/boards-db.test.ts
@@ -76,6 +76,12 @@ describe("upsertBoardSet", () => {
       ),
     ).rejects.toThrow("Invalid setId");
   });
+
+  test("rejects empty rootBoardId", async () => {
+    await expect(
+      upsertBoardSet(makeBoardSetInput({ rootBoardId: "" })),
+    ).rejects.toThrow("Invalid rootBoardId");
+  });
 });
 
 describe("listBoardSets", () => {
@@ -162,6 +168,20 @@ describe("putBoards and getBoard", () => {
     await expect(
       putBoards("", [{ boardId: "b1", name: "B", obf: makeOBFBoard() }]),
     ).rejects.toThrow("Invalid setId");
+  });
+
+  test("rejects empty boardId", async () => {
+    await expect(
+      putBoards("set-1", [{ boardId: "", name: "B", obf: makeOBFBoard() }]),
+    ).rejects.toThrow("Invalid boardId");
+  });
+
+  test("rejects boardId longer than 255 characters", async () => {
+    await expect(
+      putBoards("set-1", [
+        { boardId: "x".repeat(256), name: "B", obf: makeOBFBoard() },
+      ]),
+    ).rejects.toThrow("Invalid boardId");
   });
 });
 

--- a/src/features/board/storage/boards-db.ts
+++ b/src/features/board/storage/boards-db.ts
@@ -152,6 +152,7 @@ export async function upsertBoardSet(
   input: UpsertBoardSetInput,
 ): Promise<void> {
   validateId(input.setId, "setId");
+  validateId(input.rootBoardId, "rootBoardId");
   const db = await getBoardsDB();
   const tx = db.transaction("boardSets", "readwrite");
   const existing = await tx.store.get(input.setId);
@@ -215,6 +216,9 @@ export async function putBoards(
   boards: UpsertBoardInput[],
 ): Promise<void> {
   validateId(setId, "setId");
+  for (const board of boards) {
+    validateId(board.boardId, "boardId");
+  }
   const db = await getBoardsDB();
   const tx = db.transaction(["boards", "boardSets"], "readwrite");
   const boardStore = tx.objectStore("boards");


### PR DESCRIPTION
## Summary

Three small validation fixes found during a storage-boundary review:

- **`importBoardFromUrl` broke on slash-terminated URLs.** `pathname.split("/").at(-1) ?? "board.obz"` returns `""` for a URL ending in `/` (nullish coalescing ignores empty strings), which flowed into an empty setId and failed with a cryptic "Invalid setId" error. The filename now comes from the last *non-empty* path segment, so `https://example.com/myboard/` imports as `myboard` and a bare origin falls back to the default.
- **`deriveSetId` hardening.** Extension-only filenames (`.obz`) now fall back to `imported-board`, and the derived id is clamped to 255 characters (URL segments, unlike filesystem names, are unbounded).
- **Symmetric id validation in `boards-db`.** `putBoards` and `upsertBoardSet` accepted `boardId`/`rootBoardId` values that `getBoard` and navigation later refuse, so a bad id imported cleanly and only surfaced as an unreachable board or unopenable set. Writes now enforce the same 1-255 rule reads do, turning the silent dead record into an import-time error the existing snackbar surfaces.

## Tests

- New `import-from-url.test.ts`: happy path, slash-terminated URL, bare-origin fallback, HTTP error.
- `board-import.test.ts`: extension-only filename fallback, 255-char clamp.
- `boards-db.test.ts`: empty/overlong `boardId`, empty `rootBoardId` rejections.

All 45 affected tests pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)