### PR TITLE
ci: enforce coverage thresholds as a regression floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Run lint
         run: npm run lint
 
-      - name: Run tests
-        run: npm test
+      - name: Run tests with coverage
+        run: npm run coverage
 
       - name: Build project
         run: npm run build

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -111,6 +111,14 @@ export default defineConfig({
     },
     coverage: {
       exclude: [...coverageConfigDefaults.exclude, "src/paraglide/**"],
+      // Regression floor ~2 points under the measured baseline; ratchet up
+      // alongside meaningful coverage gains, never down.
+      thresholds: {
+        statements: 87,
+        branches: 76,
+        functions: 89,
+        lines: 91,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

Phase 4 of the coverage work (follows #533): the suite's coverage is now enforced, not just measured.

- `vite.config.ts` gains `coverage.thresholds` set ~2 points under the post-#533 baseline — statements 87 (at 89.15), branches 76 (at 79.34), functions 89 (at 91.55), lines 91 (at 93.22). A regression alarm, not a target: ratchet the numbers up alongside meaningful gains, never down.
- CI's test step switches from `npm test` to `npm run coverage` so the thresholds actually gate PRs. Coverage overhead on this suite is negligible (~20s total run).

## Verification

- `npm run lint` clean
- `npm run coverage` passes locally with all four thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)