### PR TITLE
feat(suggestions): AI error plumbing and onboarding model prefetch

### DIFF
--- a/src/app/layouts/app-shell.test.tsx
+++ b/src/app/layouts/app-shell.test.tsx
@@ -40,5 +40,13 @@ describe("AppShell", () => {
     await expect
       .element(screen.getByRole("dialog", { name: "AAC Board AI" }))
       .not.toBeInTheDocument();
+
+    // The dismissal persists on a debounce after this test ends, and test
+    // files share localStorage. Wait it out and clear, or the flag leaks
+    // into other files' import-time store reads.
+    await vi.waitFor(() => {
+      expect(localStorage.getItem("hasSeenOnboarding")).toBe("true");
+    });
+    localStorage.clear();
   });
 });

--- a/src/app/layouts/app-shell.test.tsx
+++ b/src/app/layouts/app-shell.test.tsx
@@ -1,0 +1,44 @@
+import { AppProviders } from "@shared/providers/app-providers";
+import { stubProofreader, stubRewriter } from "@shared/testing/built-in-ai";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { describe, expect, test, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { AppShell } from "./app-shell";
+
+function renderAppShell() {
+  const router = createMemoryRouter([
+    {
+      element: <AppShell />,
+      children: [{ path: "/", element: <p>page content</p> }],
+    },
+  ]);
+
+  return render(
+    <AppProviders>
+      <RouterProvider router={router} />
+    </AppProviders>,
+  );
+}
+
+describe("AppShell", () => {
+  test("dismissing onboarding warms up the suggestion models", async () => {
+    const proofreader = stubProofreader();
+    const rewriter = stubRewriter();
+
+    const screen = await renderAppShell();
+
+    await expect
+      .element(screen.getByRole("dialog", { name: "AAC Board AI" }))
+      .toBeVisible();
+
+    await screen.getByRole("button", { name: "Continue" }).click();
+
+    await vi.waitFor(() => {
+      expect(proofreader.create).toHaveBeenCalledOnce();
+      expect(rewriter.create).toHaveBeenCalledOnce();
+    });
+    await expect
+      .element(screen.getByRole("dialog", { name: "AAC Board AI" }))
+      .not.toBeInTheDocument();
+  });
+});

--- a/src/app/layouts/app-shell.tsx
+++ b/src/app/layouts/app-shell.tsx
@@ -7,6 +7,7 @@ import {
   BoardFileDropOverlay,
   useBoardFileDrop,
   useFileHandlerLaunch,
+  warmUpSuggestionModels,
 } from "@features/board";
 import Box from "@mui/material/Box";
 import { useRevalidateOnLanguageChange } from "@shared/language/use-revalidate-on-language-change";
@@ -45,7 +46,11 @@ export function AppShell() {
 
       <OnboardingDialog
         open={onboarding.shouldShow}
-        onClose={onboarding.dismiss}
+        onClose={() => {
+          // Dismissal is a user gesture, which model downloads require.
+          warmUpSuggestionModels();
+          onboarding.dismiss();
+        }}
       />
 
       <BoardFileDropOverlay open={fileDrop.isDraggingFiles} />

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -16,6 +16,7 @@ export {
 } from "./navigation/board-paths";
 export { hydrateBoard } from "./storage/board-hydration";
 export { BoardNotFoundError, getBoardSet } from "./storage/boards-db";
+export { warmUpSuggestionModels } from "./suggestions/warm-up-suggestion-models";
 export { resolveTranslatedBoard } from "./translation/resolve-translated-board";
 
 export type { BoardSetRecord } from "./storage/boards-db";

--- a/src/features/board/suggestions/use-suggestions.test.ts
+++ b/src/features/board/suggestions/use-suggestions.test.ts
@@ -109,6 +109,33 @@ describe("useSuggestions", () => {
     });
   });
 
+  test("surfaces a proofread failure while the rewrite still suggests", async () => {
+    stubProofreader(() => Promise.reject(new Error("input too long")));
+    stubRewriter(() => "I would like to eat.");
+
+    const { result } = await renderSuggestions("want eat");
+
+    await vi.waitFor(() => {
+      expect(result.current.proofreaderError?.message).toBe("input too long");
+      expect(result.current.phrases).toEqual(["I would like to eat."]);
+    });
+    expect(result.current.rewriterError).toBeUndefined();
+    expect(result.current.isPending).toBe(false);
+  });
+
+  test("surfaces failures from both engines with no phrases", async () => {
+    stubProofreader(() => Promise.reject(new Error("proofread down")));
+    stubRewriter(() => Promise.reject(new Error("rewrite down")));
+
+    const { result } = await renderSuggestions("want eat");
+
+    await vi.waitFor(() => {
+      expect(result.current.proofreaderError?.message).toBe("proofread down");
+      expect(result.current.rewriterError?.message).toBe("rewrite down");
+    });
+    expect(result.current.phrases).toEqual([]);
+  });
+
   test("passes the persisted shared context to the rewriter", async () => {
     setAISharedContext("Talk like a pirate");
     const { create } = stubRewriter();

--- a/src/features/board/suggestions/use-suggestions.ts
+++ b/src/features/board/suggestions/use-suggestions.ts
@@ -15,6 +15,8 @@ export interface UseSuggestionsReturn {
   isPending: boolean;
   isProofreaderPending: boolean;
   isRewriterPending: boolean;
+  proofreaderError: Error | undefined;
+  rewriterError: Error | undefined;
   phrases: string[];
   tone: RewriterTone;
   setTone: (tone: RewriterTone) => void;
@@ -55,15 +57,13 @@ export function useSuggestions(text: string): UseSuggestionsReturn {
     fetch: (signal) =>
       proofreader
         .proofread(text, { signal })
-        .then((result) => result.correctedInput)
-        .catch(() => undefined),
+        .then((result) => result.correctedInput),
   });
 
   const rewritten = useLatestAsync({
     enabled: hasText && rewriter.status === "ready",
     deps: [text, tone, debouncedSharedContext, language],
-    fetch: (signal) =>
-      rewriter.rewrite(text, { signal }).catch(() => undefined),
+    fetch: (signal) => rewriter.rewrite(text, { signal }),
   });
 
   return {
@@ -73,6 +73,8 @@ export function useSuggestions(text: string): UseSuggestionsReturn {
     isPending: corrected.isPending || rewritten.isPending,
     isProofreaderPending: corrected.isPending,
     isRewriterPending: rewritten.isPending,
+    proofreaderError: corrected.error,
+    rewriterError: rewritten.error,
     phrases: toPhrases(text, [corrected.value, rewritten.value]),
     tone,
     setTone,

--- a/src/features/board/suggestions/warm-up-suggestion-models.test.ts
+++ b/src/features/board/suggestions/warm-up-suggestion-models.test.ts
@@ -1,0 +1,65 @@
+import {
+  setStoredLanguage,
+  DEFAULT_LANGUAGE,
+} from "@shared/language/language-store";
+import {
+  stubBuiltInAIUnsupported,
+  stubProofreader,
+  stubRewriter,
+} from "@shared/testing/built-in-ai";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { warmUpSuggestionModels } from "./warm-up-suggestion-models";
+
+describe("warmUpSuggestionModels", () => {
+  beforeEach(() => {
+    setStoredLanguage(DEFAULT_LANGUAGE);
+  });
+
+  test("provisions both engines with the stored language and releases them", async () => {
+    const proofreaderDestroy = vi.fn();
+    const rewriterDestroy = vi.fn();
+    const proofreader = stubProofreader();
+    const rewriter = stubRewriter();
+    proofreader.create.mockResolvedValue({ destroy: proofreaderDestroy });
+    rewriter.create.mockResolvedValue({ destroy: rewriterDestroy });
+    setStoredLanguage("he");
+
+    warmUpSuggestionModels();
+
+    await vi.waitFor(() => {
+      expect(proofreader.create.mock.calls.at(0)?.at(0)).toMatchObject({
+        expectedInputLanguages: ["he"],
+      });
+      expect(rewriter.create.mock.calls.at(0)?.at(0)).toMatchObject({
+        expectedInputLanguages: ["he"],
+        expectedContextLanguages: ["he"],
+        outputLanguage: "he",
+      });
+    });
+
+    await vi.waitFor(() => {
+      expect(proofreaderDestroy).toHaveBeenCalledOnce();
+      expect(rewriterDestroy).toHaveBeenCalledOnce();
+    });
+  });
+
+  test("does nothing on a browser without the APIs", () => {
+    stubBuiltInAIUnsupported("Proofreader", "Rewriter");
+
+    expect(() => warmUpSuggestionModels()).not.toThrow();
+  });
+
+  test("swallows provisioning failures", async () => {
+    const proofreader = stubProofreader();
+    const rewriter = stubRewriter();
+    proofreader.create.mockRejectedValue(new Error("user activation required"));
+    rewriter.create.mockRejectedValue(new Error("user activation required"));
+
+    warmUpSuggestionModels();
+
+    await vi.waitFor(() => {
+      expect(proofreader.create).toHaveBeenCalledOnce();
+      expect(rewriter.create).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/features/board/suggestions/warm-up-suggestion-models.ts
+++ b/src/features/board/suggestions/warm-up-suggestion-models.ts
@@ -1,0 +1,30 @@
+import { getStoredLanguage } from "@shared/language/language-store";
+import {
+  createProofreader,
+  createRewriter,
+  isSupported,
+} from "@shayc/react-built-in-ai";
+
+// Chrome only starts a model download from a user gesture, so this runs in
+// click handlers the user is guaranteed to hit (onboarding's Continue). It's
+// an opportunistic prefetch: failures stay silent because the suggestion
+// bar's own status is the user-facing surface.
+export function warmUpSuggestionModels(): void {
+  const language = getStoredLanguage();
+
+  if (isSupported("Proofreader")) {
+    void createProofreader({ expectedInputLanguages: [language] })
+      .then((proofreader) => proofreader.destroy())
+      .catch(() => undefined);
+  }
+
+  if (isSupported("Rewriter")) {
+    void createRewriter({
+      expectedInputLanguages: [language],
+      expectedContextLanguages: [language],
+      outputLanguage: language,
+    })
+      .then((rewriter) => rewriter.destroy())
+      .catch(() => undefined);
+  }
+}

--- a/src/shared/hooks/use-latest-async.test.ts
+++ b/src/shared/hooks/use-latest-async.test.ts
@@ -105,6 +105,71 @@ describe("useLatestAsync", () => {
     await vi.waitFor(() => expect(result.current.value).toBe("value-b"));
   });
 
+  test("exposes a non-abort rejection as error state", async () => {
+    const { result } = await renderHook(() =>
+      useLatestAsync({
+        enabled: true,
+        deps: ["a"],
+        fetch: () => Promise.reject(new Error("model exploded")),
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(result.current.error?.message).toBe("model exploded");
+    });
+    expect(result.current.value).toBeUndefined();
+    expect(result.current.isPending).toBe(false);
+  });
+
+  test("clears the error the instant deps change, and recovers on success", async () => {
+    const { result, rerender } = await renderHook(
+      ({ id }: { id: string } = { id: "a" }) =>
+        useLatestAsync({
+          enabled: true,
+          deps: [id],
+          fetch: () =>
+            id === "a"
+              ? Promise.reject(new Error("bad round"))
+              : Promise.resolve("good round"),
+        }),
+      { initialProps: { id: "a" } },
+    );
+
+    await vi.waitFor(() => {
+      expect(result.current.error?.message).toBe("bad round");
+    });
+
+    await rerender({ id: "b" });
+    expect(result.current.error).toBeUndefined();
+
+    await vi.waitFor(() => {
+      expect(result.current.value).toBe("good round");
+    });
+    expect(result.current.error).toBeUndefined();
+  });
+
+  test("stays silent when the rejection comes from its own abort", async () => {
+    const { result, rerender } = await renderHook(
+      ({ enabled }: { enabled: boolean } = { enabled: true }) =>
+        useLatestAsync({
+          enabled,
+          deps: ["a"],
+          fetch: (signal) =>
+            new Promise<string>((_resolve, reject) => {
+              signal.addEventListener("abort", () => {
+                reject(new DOMException("Aborted", "AbortError"));
+              });
+            }),
+        }),
+      { initialProps: { enabled: true } },
+    );
+
+    await rerender({ enabled: false });
+
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.value).toBeUndefined();
+  });
+
   test("ignores a stale in-flight result that resolves after deps moved on", async () => {
     const pending = new Map<string, (value: string) => void>();
     const { result, rerender } = await renderHook(

--- a/src/shared/hooks/use-latest-async.ts
+++ b/src/shared/hooks/use-latest-async.ts
@@ -8,8 +8,13 @@ export interface UseLatestAsyncOptions<T> {
 
 export interface UseLatestAsyncReturn<T> {
   value: T | undefined;
+  error: Error | undefined;
   isPending: boolean;
 }
+
+type SettledRound<T> =
+  | { signature: string; status: "resolved"; value: T }
+  | { signature: string; status: "rejected"; error: Error };
 
 export function useLatestAsync<T>({
   enabled,
@@ -23,7 +28,7 @@ export function useLatestAsync<T>({
     fetchRef.current = fetch;
   });
 
-  const [result, setResult] = useState<{ signature: string; value: T }>();
+  const [round, setRound] = useState<SettledRound<T>>();
 
   useEffect(() => {
     if (!enabled) {
@@ -37,22 +42,28 @@ export function useLatestAsync<T>({
       .current(signal)
       .then((value) => {
         if (!signal.aborted) {
-          setResult({ signature, value });
+          setRound({ signature, status: "resolved", value });
         }
       })
-      .catch((error) => {
+      .catch((error: unknown) => {
         if (signal.aborted) {
           return;
         }
-        throw error;
+        setRound({
+          signature,
+          status: "rejected",
+          error: error instanceof Error ? error : new Error(String(error)),
+        });
       });
 
     return () => controller.abort();
   }, [enabled, signature]);
 
+  const settled = enabled && round?.signature === signature ? round : undefined;
+
   return {
-    value:
-      enabled && result?.signature === signature ? result.value : undefined,
-    isPending: enabled && result?.signature !== signature,
+    value: settled?.status === "resolved" ? settled.value : undefined,
+    error: settled?.status === "rejected" ? settled.error : undefined,
+    isPending: enabled && round?.signature !== signature,
   };
 }


### PR DESCRIPTION
## Summary

PR A1 of the AI error-surfacing plan — the invisible plumbing half; the visible suggestion-bar states follow in A2.

- **`useLatestAsync` returns `{ value, error, isPending }`.** Non-abort rejections become state instead of rethrowing into an unhandled rejection; aborts stay silent. Errors are signature-scoped: they clear the instant deps change and on the next successful round.
- **`useSuggestions` stops swallowing.** Both `.catch(() => undefined)` are gone; per-engine `proofreaderError`/`rewriterError` join the return surface. A failed proofread no longer masquerades as "no suggestions" — and the other engine's suggestions still flow.
- **Onboarding Continue prefetches the models.** The dismissal click is a guaranteed once-per-user gesture, which is exactly what Chrome requires to start a model download. `warmUpSuggestionModels()` fire-and-forgets `createProofreader`/`createRewriter` (guarded by `isSupported`, instances destroyed on resolve). The library writes download progress to its global store, so the suggestion bar's hooks will reflect the download A2 makes visible. This is the one place a swallow remains, deliberately: it's an opportunistic prefetch and the bar's status is the real surface.

## Tests

Nine new/updated tests, each mutation-verified (deliberately broke the behavior, watched the right test fail, restored):

- `use-latest-async`: rejection → error state; error clears on deps change and recovers on success; own-abort rejections stay silent.
- `use-suggestions`: one engine fails → error exposed, other engine still suggests; both fail → both errors, no phrases.
- `warm-up-suggestion-models`: provisions both engines with the stored language and releases them; no-ops without the APIs; swallows provisioning failures.
- `app-shell` (first test for it): dismissing onboarding warms up both engines and closes the dialog.

`npm run lint` clean · 416/416 tests · build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)