### PR TITLE
test(translation): pin the deliberately-total fallback catch

### DIFF
--- a/src/features/board/translation/resolve-translated-board.test.ts
+++ b/src/features/board/translation/resolve-translated-board.test.ts
@@ -134,14 +134,14 @@ describe("resolveTranslatedBoard", () => {
     expect(result).toBe(board);
   });
 
-  test("lets a programming bug propagate instead of swallowing it", async () => {
+  test("falls back even on unexpected errors so the board always renders", async () => {
     const board = makeBoard();
     stubTranslator(() => {
       throw new TypeError("undefined is not a function");
     });
 
-    await expect(resolveTranslatedBoard("set-1", board, "es")).rejects.toThrow(
-      TypeError,
-    );
+    const result = await resolveTranslatedBoard("set-1", board, "es");
+
+    expect(result).toBe(board);
   });
 });

--- a/src/features/board/translation/resolve-translated-board.test.ts
+++ b/src/features/board/translation/resolve-translated-board.test.ts
@@ -112,12 +112,36 @@ describe("resolveTranslatedBoard", () => {
     expect(result).toBe(board);
   });
 
-  test("falls back to the source board when translation throws", async () => {
+  test("falls back to the source board when the platform fails mid-translation", async () => {
     const board = makeBoard();
-    stubTranslator(() => Promise.reject(new Error("model failure")));
+    stubTranslator(() =>
+      Promise.reject(new DOMException("model failure", "UnknownError")),
+    );
 
     const result = await resolveTranslatedBoard("set-1", board, "es");
 
     expect(result).toBe(board);
+  });
+
+  test("falls back to the source board when the navigation is aborted", async () => {
+    const board = makeBoard();
+    stubTranslator(() =>
+      Promise.reject(new DOMException("Aborted", "AbortError")),
+    );
+
+    const result = await resolveTranslatedBoard("set-1", board, "es");
+
+    expect(result).toBe(board);
+  });
+
+  test("lets a programming bug propagate instead of swallowing it", async () => {
+    const board = makeBoard();
+    stubTranslator(() => {
+      throw new TypeError("undefined is not a function");
+    });
+
+    await expect(resolveTranslatedBoard("set-1", board, "es")).rejects.toThrow(
+      TypeError,
+    );
   });
 });

--- a/src/features/board/translation/resolve-translated-board.ts
+++ b/src/features/board/translation/resolve-translated-board.ts
@@ -1,4 +1,4 @@
-import { BuiltInAIError, createTranslator } from "@shayc/react-built-in-ai";
+import { createTranslator } from "@shayc/react-built-in-ai";
 import { updateBoardStrings } from "../storage/boards-db";
 import type { Board } from "../types";
 import {
@@ -36,15 +36,12 @@ export async function resolveTranslatedBoard(
     } finally {
       translator.destroy();
     }
-  } catch (error) {
-    // Platform failures (Translator unavailable, aborted navigation, download
-    // errors) render the source board — its pictograms carry the meaning
-    // until a translation lands. Anything else is a bug and must surface.
-    if (error instanceof BuiltInAIError || error instanceof DOMException) {
-      return board;
-    }
-
-    throw error;
+  } catch {
+    // Deliberately total: the board must render no matter what — pictograms
+    // carry the meaning. With no telemetry, rethrowing a bug here would only
+    // trade the user's communication surface for an error page nobody hears
+    // about.
+    return board;
   }
 }
 

--- a/src/features/board/translation/resolve-translated-board.ts
+++ b/src/features/board/translation/resolve-translated-board.ts
@@ -1,4 +1,4 @@
-import { createTranslator } from "@shayc/react-built-in-ai";
+import { BuiltInAIError, createTranslator } from "@shayc/react-built-in-ai";
 import { updateBoardStrings } from "../storage/boards-db";
 import type { Board } from "../types";
 import {
@@ -36,10 +36,15 @@ export async function resolveTranslatedBoard(
     } finally {
       translator.destroy();
     }
-  } catch {
-    // Translator unavailable or aborted — render the source board; its
-    // pictograms carry the meaning until a translation lands.
-    return board;
+  } catch (error) {
+    // Platform failures (Translator unavailable, aborted navigation, download
+    // errors) render the source board — its pictograms carry the meaning
+    // until a translation lands. Anything else is a bug and must surface.
+    if (error instanceof BuiltInAIError || error instanceof DOMException) {
+      return board;
+    }
+
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Summary

This PR changed direction mid-review, and the history tells the story honestly: the first commit narrowed the translation fallback catch so programming bugs would propagate; the second reverts that on reflection.

**Why the reversal:** a propagated bug in the translation path reaches the router error boundary — the board doesn't render. For an AAC user, that trades the communication surface (the app's one inviolable invariant) for an error page that, in an app with no telemetry by design, nobody ever hears about. Untranslated-but-communicating beats diagnosable-but-blocked.

**What lands:**
- The catch stays total, now with the *why* in the comment instead of a vague "unavailable or aborted" — the next reader re-litigates a decision, not a smell.
- Three tests pin the contract: platform failure → source board, aborted navigation → source board, and **even an unexpected `TypeError` → source board** (the executable record of this trade-off).

Net production-code change vs `main`: a better comment. Net test change: the fallback contract is pinned where it was previously incidental.

## Verification

440/440, lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)