### PR TITLE
refactor(suggestions): name the best-effort prepare

### DIFF
--- a/src/app/settings/ai-settings.tsx
+++ b/src/app/settings/ai-settings.tsx
@@ -11,6 +11,7 @@ import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import {
   deriveEngineView,
+  prepareQuietly,
   proofreaderLanguageOptions,
   rewriterLanguageOptions,
   type EngineView,
@@ -79,12 +80,12 @@ export function AISettings() {
     {
       title: m.aiFeatureProofreading(),
       view: proofreaderView,
-      onDownload: () => void proofreader.prepare().catch(() => undefined),
+      onDownload: () => prepareQuietly(proofreader),
     },
     {
       title: m.aiFeatureRewriting(),
       view: rewriterView,
-      onDownload: () => void rewriter.prepare().catch(() => undefined),
+      onDownload: () => prepareQuietly(rewriter),
     },
     {
       title: m.aiFeatureTranslation(),

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -21,6 +21,7 @@ export {
   rewriterLanguageOptions,
 } from "./suggestions/engine-language-options";
 export { deriveEngineView } from "./suggestions/engine-view";
+export { prepareQuietly } from "./suggestions/prepare-quietly";
 export { resolveTranslatedBoard } from "./translation/resolve-translated-board";
 
 export type { BoardSetRecord } from "./storage/boards-db";

--- a/src/features/board/suggestions/prepare-quietly.test.ts
+++ b/src/features/board/suggestions/prepare-quietly.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test, vi } from "vitest";
+import { prepareQuietly } from "./prepare-quietly";
+
+describe("prepareQuietly", () => {
+  test("invokes prepare", () => {
+    const prepare = vi.fn(() => Promise.resolve());
+
+    prepareQuietly({ prepare });
+
+    expect(prepare).toHaveBeenCalledOnce();
+  });
+
+  test("swallows a rejection", async () => {
+    const prepare = vi.fn(() =>
+      Promise.reject(new Error("user activation required")),
+    );
+
+    prepareQuietly({ prepare });
+
+    await vi.waitFor(() => expect(prepare).toHaveBeenCalledOnce());
+  });
+});

--- a/src/features/board/suggestions/prepare-quietly.ts
+++ b/src/features/board/suggestions/prepare-quietly.ts
@@ -1,0 +1,7 @@
+import type { BaseHookReturn } from "@shayc/react-built-in-ai";
+
+// Best-effort warm-up: the engine's status is the user-facing feedback, so a
+// rejection here (e.g. the gesture expired) has nothing useful to add.
+export function prepareQuietly(engine: Pick<BaseHookReturn, "prepare">): void {
+  void engine.prepare().catch(() => undefined);
+}

--- a/src/features/board/suggestions/use-suggestions.ts
+++ b/src/features/board/suggestions/use-suggestions.ts
@@ -18,6 +18,7 @@ import {
 } from "./derive-suggestion-status";
 import { toPhrases } from "./to-phrases";
 import { deriveEngineView } from "./engine-view";
+import { prepareQuietly } from "./prepare-quietly";
 
 const SHARED_CONTEXT_DEBOUNCE_MS = 400;
 
@@ -103,10 +104,10 @@ export function useSuggestions(text: string): UseSuggestionsReturn {
 
   const enable = () => {
     if (proofreaderView.kind === "awaits-gesture") {
-      void proofreader.prepare().catch(() => undefined);
+      prepareQuietly(proofreader);
     }
     if (rewriterView.kind === "awaits-gesture") {
-      void rewriter.prepare().catch(() => undefined);
+      prepareQuietly(rewriter);
     }
   };
 


### PR DESCRIPTION
## Summary

The sole survivor of the polish list: `void engine.prepare().catch(() => undefined)` appeared at four sites (the suggestion bar's `enable()` × 2, the AI settings Download actions × 2). `prepareQuietly(engine)` names the behavior and carries its why — the engine's lifecycle status is the user-facing feedback, so the rejection has nothing useful to add.

Behavior-only deduplication; no semantics change.

## Verification

440/440, lint clean. Mutation-verified: a no-op `prepareQuietly` fails 3 tests across the board-viewer enable chip, the settings download flow, and the helper's own unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)