### PR TITLE
chore(comments): drop restating comments, fix one stale why

### DIFF
--- a/src/features/board/suggestions/engine-view.ts
+++ b/src/features/board/suggestions/engine-view.ts
@@ -13,9 +13,6 @@ export type EngineSnapshot = Pick<
   "status" | "progress" | "error"
 >;
 
-// Interprets the library lifecycle for humans: app vocabulary over machine
-// states. "downloadable" means the fetch awaits the user gesture Chrome
-// requires, so it maps to the bar's enable affordance.
 export function deriveEngineView(engine: EngineSnapshot): EngineView {
   switch (engine.status) {
     case "unsupported":

--- a/src/features/board/suggestions/use-suggestions.test.ts
+++ b/src/features/board/suggestions/use-suggestions.test.ts
@@ -302,7 +302,6 @@ describe("useSuggestions", () => {
       expect(result.current.phrases).toEqual(["casual hi"]);
     });
 
-    // Switching tone must drop the prior rewrite while the new one is in flight.
     result.current.setTone("more-formal");
     await vi.waitFor(() => {
       expect(result.current.phrases).toEqual([]);

--- a/src/features/board/suggestions/use-suggestions.ts
+++ b/src/features/board/suggestions/use-suggestions.ts
@@ -35,8 +35,6 @@ export interface UseSuggestionsReturn {
   setTone: (tone: RewriterTone) => void;
 }
 
-// Distinguishes real call failures from cancellations, wherever the abort
-// originated.
 function isRealError(error: Error | undefined): boolean {
   return error !== undefined && error.name !== "AbortError";
 }
@@ -81,8 +79,8 @@ export function useSuggestions(text: string): UseSuggestionsReturn {
     fetch: (signal) => rewriter.rewrite(text, { signal }),
   });
 
-  // The global store also sees downloads the onboarding warm-up started, which
-  // the hook instances can't.
+  // Settings' Download action provisions its own hook instances; only the
+  // global store sees the downloads they start.
   const downloadProgress = useGlobalDownloadProgress([
     "Proofreader",
     "Rewriter",


### PR DESCRIPTION
## Summary

Full comment audit of src (≈35 comments). Four actionable findings, applied here; the other ~31 survive on their merits (decision records, platform tricks, empty-catch justifications, API contracts, CI-flake tripwires).

- **Deleted** `isRealError`'s comment — restated the name and one-line body; the real subtlety (abort-by-name catches foreign aborts) is pinned by the "stays quiet when a rejection is an abort by name" test.
- **Deleted** `engine-view.ts`'s header — post-0.8.0 the mapping is near-1:1 and the library's `Status` JSDoc documents `downloadable`; the header also claimed the bar as its consumer, which settings disproved.
- **Deleted** a test comment that repeated the test's own name.
- **Rewrote** the `useGlobalDownloadProgress` comment — it cited the removed onboarding warm-up; the surviving reason is that settings' Download action provisions separate hook instances only the global store can see. Without a correct why, a cleanup pass would "simplify" to per-hook progress and break that flow.

Comment-only; no behavior change. Lint clean, suggestions suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)