### PR TITLE
refactor: encode switch exhaustiveness via satisfies never

### DIFF
--- a/src/app/settings/ai-settings.tsx
+++ b/src/app/settings/ai-settings.tsx
@@ -26,9 +26,8 @@ import {
   useRewriter,
   type Status,
 } from "@shayc/react-built-in-ai";
-import type { ReactElement } from "react";
 
-function statusLabel(status: Status, progress: number): string {
+function statusLabel(status: Status, progress: number) {
   switch (status) {
     case "ready":
       return m.aiStatusAvailable();
@@ -43,10 +42,12 @@ function statusLabel(status: Status, progress: number): string {
     case "error":
     case "unsupported":
       return m.aiStatusUnavailable();
+    default:
+      return status satisfies never;
   }
 }
 
-function statusIcon(status: Status, progress: number): ReactElement {
+function statusIcon(status: Status, progress: number) {
   const title = statusLabel(status, progress);
   switch (status) {
     case "ready":
@@ -63,6 +64,8 @@ function statusIcon(status: Status, progress: number): ReactElement {
     case "error":
     case "unsupported":
       return <CancelIcon color="error" fontSize="small" titleAccess={title} />;
+    default:
+      return status satisfies never;
   }
 }
 

--- a/src/features/board/suggestions/suggestion-status.tsx
+++ b/src/features/board/suggestions/suggestion-status.tsx
@@ -3,7 +3,6 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
 import { DotsProgress } from "@shared/components/dots-progress";
-import type { ReactElement } from "react";
 import type { SuggestionStatusView } from "./derive-suggestion-status";
 
 export interface SuggestionStatusProps {
@@ -11,11 +10,7 @@ export interface SuggestionStatusProps {
   onEnable: () => void;
 }
 
-// The explicit return type makes TS2366 reject a switch that misses a kind.
-export function SuggestionStatus({
-  status,
-  onEnable,
-}: SuggestionStatusProps): ReactElement | null {
+export function SuggestionStatus({ status, onEnable }: SuggestionStatusProps) {
   if (status === null) {
     return null;
   }
@@ -55,5 +50,7 @@ export function SuggestionStatus({
           {m.suggestionsUnavailable()}
         </Typography>
       );
+    default:
+      return status satisfies never;
   }
 }


### PR DESCRIPTION
## Summary
- Replace the explicit-return-type exhaustiveness guard with `default: return status satisfies never;` in the three variant switches (`SuggestionStatus`, `statusLabel`, `statusIcon`)
- Delete the comment that defended the old guard and the `ReactElement` type-only imports that existed solely to serve the annotations

## Why
The old guard worked, but its mechanism was invisible: the return-type annotations looked like incidental style, so a cleanup pass could strip one and silently disarm the check. With `satisfies never`, adding a new `Status`/`kind` variant errors on the `default` line of the exact switch that missed it, with a message naming the unhandled member. The constraint is in the code, no comment needed.

No behavior change. Lint and `tsc --noEmit` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)