### PR TITLE
fix(i18n): improve translation quality across locales

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "ترجمة",
   "navBack": "رجوع",
   "navHome": "الانتقال إلى الرئيسية",
-  "messageBackspace": "مسافة للخلف",
+  "messageBackspace": "مسح",
   "messageBackspaceLongPressHint": "اضغط مطوّلًا لمسح الرسالة.",
   "messagePlay": "تشغيل الرسالة",
   "messageStop": "إيقاف",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "Превод",
   "navBack": "Назад",
   "navHome": "Към началото",
-  "messageBackspace": "Backspace",
+  "messageBackspace": "Изтриване",
   "messageBackspaceLongPressHint": "Задръжте, за да изчистите съобщението.",
   "messagePlay": "Възпроизвеждане на съобщението",
   "messageStop": "Спиране",

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "অনুবাদ",
   "navBack": "ফিরে যান",
   "navHome": "হোমে যান",
-  "messageBackspace": "ব্যাকস্পেস",
+  "messageBackspace": "মুছুন",
   "messageBackspaceLongPressHint": "বার্তা মুছতে দীর্ঘক্ষণ চাপুন।",
   "messagePlay": "বার্তা চালান",
   "messageStop": "থামান",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "Překlad",
   "navBack": "Zpět",
   "navHome": "Přejít domů",
-  "messageBackspace": "Backspace",
+  "messageBackspace": "Smazat",
   "messageBackspaceLongPressHint": "Dlouhým stisknutím zprávu vymažete.",
   "messagePlay": "Přehrát zprávu",
   "messageStop": "Zastavit",

--- a/messages/da.json
+++ b/messages/da.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "Oversættelse",
   "navBack": "Tilbage",
   "navHome": "Gå til start",
-  "messageBackspace": "Tilbagetast",
+  "messageBackspace": "Slet",
   "messageBackspaceLongPressHint": "Hold nede for at rydde beskeden.",
   "messagePlay": "Afspil besked",
   "messageStop": "Stop",

--- a/messages/de.json
+++ b/messages/de.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "Übersetzung",
   "navBack": "Zurück",
   "navHome": "Zur Startseite",
-  "messageBackspace": "Rücktaste",
+  "messageBackspace": "Löschen",
   "messageBackspaceLongPressHint": "Lange drücken, um die Nachricht zu löschen.",
   "messagePlay": "Nachricht abspielen",
   "messageStop": "Stopp",

--- a/messages/el.json
+++ b/messages/el.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "Μετάφραση",
   "navBack": "Πίσω",
   "navHome": "Μετάβαση στην αρχική",
-  "messageBackspace": "Backspace",
+  "messageBackspace": "Διαγραφή",
   "messageBackspaceLongPressHint": "Πατήστε παρατεταμένα για εκκαθάριση του μηνύματος.",
   "messagePlay": "Αναπαραγωγή μηνύματος",
   "messageStop": "Διακοπή",

--- a/messages/es.json
+++ b/messages/es.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "Traducción",
   "navBack": "Volver",
   "navHome": "Ir al inicio",
-  "messageBackspace": "Retroceso",
+  "messageBackspace": "Borrar",
   "messageBackspaceLongPressHint": "Mantén pulsado para borrar el mensaje.",
   "messagePlay": "Reproducir mensaje",
   "messageStop": "Detener",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "Käännös",
   "navBack": "Takaisin",
   "navHome": "Siirry etusivulle",
-  "messageBackspace": "Askelpalautin",
+  "messageBackspace": "Poista",
   "messageBackspaceLongPressHint": "Tyhjennä viesti painamalla pitkään.",
   "messagePlay": "Toista viesti",
   "messageStop": "Pysäytä",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "Traduction",
   "navBack": "Retour",
   "navHome": "Aller à l'accueil",
-  "messageBackspace": "Retour arrière",
+  "messageBackspace": "Effacer",
   "messageBackspaceLongPressHint": "Appui long pour effacer le message.",
   "messagePlay": "Lire le message",
   "messageStop": "Arrêter",

--- a/messages/he.json
+++ b/messages/he.json
@@ -38,7 +38,7 @@
       }
     }
   ],
-  "libraryDropToImport": "גרור לוחות לכאן כדי לייבא",
+  "libraryDropToImport": "גרירת קובצי לוחות לכאן לייבוא",
   "libraryInfo": "פרטים",
   "libraryDelete": "מחיקה",
   "libraryCancel": "ביטול",
@@ -99,7 +99,7 @@
   "toneProfessional": "סגנון מקצועי",
   "toneFriendly": "סגנון ידידותי",
   "aboutHeading": "אודות",
-  "aboutAppDescription": "{appName} מסייע לאנשים שאינם יכולים להסתמך על דיבור לתקשר בצורה קלה וטבעית יותר. המערכת משתמשת בבינה מלאכותית המופעלת ישירות על המכשיר (On-device AI) כדי לתקן שגיאות דקדוק, להתאים את טון הדיבור ולתרגם הודעות באופן מיידי – תוך שמירה מלאה על הפרטיות.",
+  "aboutAppDescription": "{appName} נועד לסייע לאנשים שאינם יכולים להסתמך על דיבור לתקשר בצורה קלה וטבעית יותר. המערכת משתמשת בבינה מלאכותית המופעלת ישירות על המכשיר (On-device AI) כדי לתקן שגיאות דקדוק, להתאים את טון הדיבור ולתרגם הודעות באופן מיידי – תוך שמירה מלאה על הפרטיות.",
   "aboutAcknowledgmentsHeading": "תודות והוקרה",
   "aboutAcknowledgments": "פרויקט זה זכה באתגר {#challenge}Google Chrome Built-in AI Challenge 2025{/challenge}. האפליקציה פותחה על בסיס {#obf}Open Board Format{/obf}, וכוללת את אוצר המילים Quick Core 24 של {#openaac}OpenAAC{/openaac}.",
   "aboutViewSource": "צפייה ב-GitHub",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "अनुवाद",
   "navBack": "वापस जाएँ",
   "navHome": "होम पर जाएँ",
-  "messageBackspace": "बैकस्पेस",
+  "messageBackspace": "मिटाएं",
   "messageBackspaceLongPressHint": "संदेश साफ़ करने के लिए देर तक दबाएँ।",
   "messagePlay": "संदेश चलाएँ",
   "messageStop": "रोकें",

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "Prijevod",
   "navBack": "Natrag",
   "navHome": "Idi na početnu",
-  "messageBackspace": "Backspace",
+  "messageBackspace": "Obriši",
   "messageBackspaceLongPressHint": "Dugo pritisnite za brisanje poruke.",
   "messagePlay": "Reproduciraj poruku",
   "messageStop": "Zaustavi",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "Fordítás",
   "navBack": "Vissza",
   "navHome": "Ugrás a kezdőlapra",
-  "messageBackspace": "Visszatörlés",
+  "messageBackspace": "Törlés",
   "messageBackspaceLongPressHint": "Tartsd lenyomva az üzenet törléséhez.",
   "messagePlay": "Üzenet lejátszása",
   "messageStop": "Leállítás",

--- a/messages/id.json
+++ b/messages/id.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "Terjemahan",
   "navBack": "Kembali",
   "navHome": "Ke beranda",
-  "messageBackspace": "Spasi mundur",
+  "messageBackspace": "Hapus",
   "messageBackspaceLongPressHint": "Tekan lama untuk menghapus pesan.",
   "messagePlay": "Putar pesan",
   "messageStop": "Hentikan",

--- a/messages/it.json
+++ b/messages/it.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "Traduzione",
   "navBack": "Indietro",
   "navHome": "Vai alla home",
-  "messageBackspace": "Backspace",
+  "messageBackspace": "Cancella",
   "messageBackspaceLongPressHint": "Tieni premuto per cancellare il messaggio.",
   "messagePlay": "Riproduci messaggio",
   "messageStop": "Interrompi",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "翻訳",
   "navBack": "戻る",
   "navHome": "ホームに戻る",
-  "messageBackspace": "バックスペース",
+  "messageBackspace": "消去",
   "messageBackspaceLongPressHint": "長押しでメッセージを消去します。",
   "messagePlay": "メッセージを再生",
   "messageStop": "停止",

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "ಅನುವಾದ",
   "navBack": "ಹಿಂದಕ್ಕೆ",
   "navHome": "ಮುಖಪುಟಕ್ಕೆ ಹೋಗಿ",
-  "messageBackspace": "ಬ್ಯಾಕ್‌ಸ್ಪೇಸ್",
+  "messageBackspace": "ಅಳಿಸು",
   "messageBackspaceLongPressHint": "ಸಂದೇಶವನ್ನು ತೆರವುಗೊಳಿಸಲು ದೀರ್ಘವಾಗಿ ಒತ್ತಿರಿ.",
   "messagePlay": "ಸಂದೇಶವನ್ನು ಪ್ಲೇ ಮಾಡಿ",
   "messageStop": "ನಿಲ್ಲಿಸಿ",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "번역",
   "navBack": "뒤로",
   "navHome": "홈으로",
-  "messageBackspace": "백스페이스",
+  "messageBackspace": "지우기",
   "messageBackspaceLongPressHint": "길게 눌러 메시지를 지웁니다.",
   "messagePlay": "메시지 재생",
   "messageStop": "중지",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "Vertaling",
   "navBack": "Terug",
   "navHome": "Naar start",
-  "messageBackspace": "Backspace",
+  "messageBackspace": "Wissen",
   "messageBackspaceLongPressHint": "Houd ingedrukt om het bericht te wissen.",
   "messagePlay": "Bericht afspelen",
   "messageStop": "Stoppen",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "Tłumaczenie",
   "navBack": "Wstecz",
   "navHome": "Przejdź do strony głównej",
-  "messageBackspace": "Backspace",
+  "messageBackspace": "Usuń",
   "messageBackspaceLongPressHint": "Przytrzymaj, aby wyczyścić wiadomość.",
   "messagePlay": "Odtwórz wiadomość",
   "messageStop": "Zatrzymaj",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "Tradução",
   "navBack": "Voltar",
   "navHome": "Ir para o início",
-  "messageBackspace": "Backspace",
+  "messageBackspace": "Apagar",
   "messageBackspaceLongPressHint": "Pressione e segure para limpar a mensagem.",
   "messagePlay": "Reproduzir mensagem",
   "messageStop": "Parar",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "Traducere",
   "navBack": "Înapoi",
   "navHome": "Mergi la pagina principală",
-  "messageBackspace": "Ștergere înapoi",
+  "messageBackspace": "Șterge",
   "messageBackspaceLongPressHint": "Apasă lung pentru a șterge mesajul.",
   "messagePlay": "Redă mesajul",
   "messageStop": "Oprește",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -38,7 +38,7 @@
       }
     }
   ],
-  "libraryDropToImport": "Отпустите файлы досок для импорта",
+  "libraryDropToImport": "Перетащите файлы досок для импорта",
   "libraryInfo": "Сведения",
   "libraryDelete": "Удалить",
   "libraryCancel": "Отмена",
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "Перевод",
   "navBack": "Назад",
   "navHome": "На главную",
-  "messageBackspace": "Backspace",
+  "messageBackspace": "Стереть",
   "messageBackspaceLongPressHint": "Удерживайте, чтобы очистить сообщение.",
   "messagePlay": "Воспроизвести сообщение",
   "messageStop": "Остановить",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "Preklad",
   "navBack": "Späť",
   "navHome": "Prejsť domov",
-  "messageBackspace": "Backspace",
+  "messageBackspace": "Vymazať",
   "messageBackspaceLongPressHint": "Dlhým stlačením vymažete správu.",
   "messagePlay": "Prehrať správu",
   "messageStop": "Zastaviť",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "Prevajanje",
   "navBack": "Nazaj",
   "navHome": "Pojdi domov",
-  "messageBackspace": "Vračalka",
+  "messageBackspace": "Briši",
   "messageBackspaceLongPressHint": "Za izbris sporočila pridržite.",
   "messagePlay": "Predvajaj sporočilo",
   "messageStop": "Ustavi",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "Översättning",
   "navBack": "Tillbaka",
   "navHome": "Till startsidan",
-  "messageBackspace": "Backsteg",
+  "messageBackspace": "Radera",
   "messageBackspaceLongPressHint": "Håll inne för att rensa meddelandet.",
   "messagePlay": "Spela upp meddelande",
   "messageStop": "Stoppa",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "மொழிபெயர்ப்பு",
   "navBack": "பின்செல்",
   "navHome": "முகப்புக்குச் செல்",
-  "messageBackspace": "பின்னடைவு",
+  "messageBackspace": "அழி",
   "messageBackspaceLongPressHint": "செய்தியை அழிக்க நீண்ட நேரம் அழுத்தவும்.",
   "messagePlay": "செய்தியை இயக்கு",
   "messageStop": "நிறுத்து",

--- a/messages/te.json
+++ b/messages/te.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "అనువాదం",
   "navBack": "వెనుకకు",
   "navHome": "హోమ్‌కు వెళ్లు",
-  "messageBackspace": "బ్యాక్‌స్పేస్",
+  "messageBackspace": "తుడిచివేయి",
   "messageBackspaceLongPressHint": "సందేశాన్ని క్లియర్ చేయడానికి నొక్కి ఉంచండి.",
   "messagePlay": "సందేశాన్ని ప్లే చేయి",
   "messageStop": "ఆపు",

--- a/messages/th.json
+++ b/messages/th.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "การแปล",
   "navBack": "กลับ",
   "navHome": "ไปที่หน้าแรก",
-  "messageBackspace": "ลบย้อนกลับ",
+  "messageBackspace": "ลบ",
   "messageBackspaceLongPressHint": "กดค้างเพื่อล้างข้อความ",
   "messagePlay": "เล่นข้อความ",
   "messageStop": "หยุด",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -38,7 +38,7 @@
       }
     }
   ],
-  "libraryDropToImport": "Відпустіть файли дошок для імпорту",
+  "libraryDropToImport": "Перетягніть файли дошок для імпорту",
   "libraryInfo": "Інформація",
   "libraryDelete": "Видалити",
   "libraryCancel": "Скасувати",
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "Переклад",
   "navBack": "Назад",
   "navHome": "На головну",
-  "messageBackspace": "Backspace",
+  "messageBackspace": "Стерти",
   "messageBackspaceLongPressHint": "Утримуйте, щоб очистити повідомлення.",
   "messagePlay": "Відтворити повідомлення",
   "messageStop": "Зупинити",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "Dịch",
   "navBack": "Quay lại",
   "navHome": "Về trang chủ",
-  "messageBackspace": "Xóa lùi",
+  "messageBackspace": "Xóa",
   "messageBackspaceLongPressHint": "Nhấn giữ để xóa tin nhắn.",
   "messagePlay": "Phát tin nhắn",
   "messageStop": "Dừng",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -90,7 +90,7 @@
   "aiFeatureTranslation": "翻译",
   "navBack": "返回",
   "navHome": "返回主页",
-  "messageBackspace": "退格",
+  "messageBackspace": "删除",
   "messageBackspaceLongPressHint": "长按可清空消息。",
   "messagePlay": "播放消息",
   "messageStop": "停止",


### PR DESCRIPTION
## Summary
- Replace keyboard-key names for `messageBackspace` with action labels (e.g. "Rücktaste" → "Löschen", "Retour arrière" → "Effacer", "Backspace" → "Стерти")
- Fix `libraryDropToImport` phrasing (e.g. Ukrainian "Відпустіть" → "Перетягніть")
- Polish wording across all 33 locales, including Hebrew nominal-form fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)