### PR TITLE
docs(readme): add Edge proofreader API flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ chrome://flags/#rewriter-api-for-gemini-nano
 **Edge:**
 
 ```
+edge://flags/#edge-proofreader-api
 edge://flags/#edge-llm-rewriter-api-for-phi-mini
 ```
 


### PR DESCRIPTION
Adds the `edge://flags/#edge-proofreader-api` flag to the Edge setup section of the README, alongside the existing rewriter flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)