### PR TITLE
feat(suggestions): tune pulsing dot and reserve its slot in the bar

### DIFF
--- a/src/features/board/suggestions/suggestion-bar.tsx
+++ b/src/features/board/suggestions/suggestion-bar.tsx
@@ -1,9 +1,10 @@
 import Box from "@mui/material/Box";
 import Chip from "@mui/material/Chip";
 import Stack from "@mui/material/Stack";
+import { DOT_PROGRESS_SIZE } from "@shared/components/dot-progress";
+import type { SuggestionStatusView } from "./derive-suggestion-status";
 import { SuggestionStatus } from "./suggestion-status";
 import { ToneSelector } from "./tone-selector";
-import type { SuggestionStatusView } from "./derive-suggestion-status";
 
 export interface SuggestionBarProps {
   phrases: string[];
@@ -29,7 +30,9 @@ export function SuggestionBar({
       direction="row"
       sx={{ flex: "1", alignItems: "center", gap: 2, overflow: "hidden" }}
     >
-      <SuggestionStatus status={status} onEnable={onEnable} />
+      <Box sx={{ minWidth: DOT_PROGRESS_SIZE }}>
+        <SuggestionStatus status={status} onEnable={onEnable} />
+      </Box>
 
       <Box
         sx={{

--- a/src/features/board/suggestions/suggestion-status.tsx
+++ b/src/features/board/suggestions/suggestion-status.tsx
@@ -1,5 +1,4 @@
 import Chip from "@mui/material/Chip";
-import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
 import { DotProgress } from "@shared/components/dot-progress";
@@ -27,26 +26,17 @@ export function SuggestionStatus({ status, onEnable }: SuggestionStatusProps) {
       );
     case "downloading":
       return (
-        <Stack
-          direction="row"
-          sx={{ alignItems: "center", gap: 1, whiteSpace: "nowrap" }}
-        >
-          <DotProgress />
-          <Typography variant="body2" sx={{ color: "text.secondary" }}>
-            {m.suggestionsDownloading({
-              progress: Math.round(status.progress * 100),
-            })}
-          </Typography>
-        </Stack>
+        <Typography variant="body2" sx={{ color: "text.secondary" }}>
+          {m.suggestionsDownloading({
+            progress: Math.round(status.progress * 100),
+          })}
+        </Typography>
       );
     case "pending":
       return <DotProgress />;
     case "unavailable":
       return (
-        <Typography
-          variant="body2"
-          sx={{ color: "text.secondary", whiteSpace: "nowrap" }}
-        >
+        <Typography variant="body2" sx={{ color: "text.secondary" }}>
           {m.suggestionsUnavailable()}
         </Typography>
       );

--- a/src/shared/components/dot-progress.tsx
+++ b/src/shared/components/dot-progress.tsx
@@ -1,17 +1,20 @@
 import Box from "@mui/material/Box";
 import { orange } from "@mui/material/colors";
 
+export const DOT_PROGRESS_SIZE = 12;
+
 export function DotProgress() {
   return (
     <Box
       sx={{
-        width: 12,
+        width: DOT_PROGRESS_SIZE,
         aspectRatio: "1",
         borderRadius: "50%",
         backgroundColor: orange[500],
-        animation: "dot-progress 1s ease-in-out infinite alternate",
+        animation: "dot-progress 0.6s ease-in-out infinite alternate",
         "@keyframes dot-progress": {
-          to: { opacity: 0.2 },
+          from: { opacity: 0.2 },
+          to: { opacity: 1 },
         },
       }}
     />


### PR DESCRIPTION
## Summary
- Pulse now rises from dim to full opacity (0.2 → 1) at 0.6s per leg, so the dot enters softly and a short inference still shows complete pulses
- Export `DOT_PROGRESS_SIZE` and reserve that width in the suggestion bar, so phrase chips no longer shift when the dot appears/disappears
- The dot now signals only `pending`; the downloading state keeps just its progress text

## Test plan
- [x] `vitest run src/features/board/suggestions/` — 48 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)