### PR TITLE
feat(suggestions): shrink pulsing dot and speed up its pulse

### DIFF
--- a/src/shared/components/dot-progress.tsx
+++ b/src/shared/components/dot-progress.tsx
@@ -1,7 +1,7 @@
 import Box from "@mui/material/Box";
 import { orange } from "@mui/material/colors";
 
-export const DOT_PROGRESS_SIZE = 12;
+export const DOT_PROGRESS_SIZE = 10;
 
 export function DotProgress() {
   return (
@@ -10,8 +10,8 @@ export function DotProgress() {
         width: DOT_PROGRESS_SIZE,
         aspectRatio: "1",
         borderRadius: "50%",
-        backgroundColor: orange[500],
-        animation: "dot-progress 0.6s ease-in-out infinite alternate",
+        backgroundColor: orange[400],
+        animation: "dot-progress 0.4s ease-in-out infinite alternate",
         "@keyframes dot-progress": {
           from: { opacity: 0.2 },
           to: { opacity: 1 },


### PR DESCRIPTION
Tune the suggestion-bar pulsing dot: size 12→10px, orange 500→400, pulse 0.6s→0.4s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)