### PR TITLE
feat(suggestions): flatten pulsing dot and tune its pulse

### DIFF
--- a/src/shared/components/dot-progress.tsx
+++ b/src/shared/components/dot-progress.tsx
@@ -22,7 +22,7 @@ export function DotProgress() {
         width: DOT_PROGRESS_SIZE,
         aspectRatio: "1",
         borderRadius: "50%",
-        backgroundColor: orange[400],
+        backgroundColor: orange[500],
         animation: `${pulse} 1.2s ${theme.transitions.easing.easeInOut} infinite`,
       })}
     />

--- a/src/shared/components/dot-progress.tsx
+++ b/src/shared/components/dot-progress.tsx
@@ -6,11 +6,11 @@ export const DOT_PROGRESS_SIZE = 10;
 
 const pulse = keyframes`
   0%, 100% {
-    transform: scale(0.95);
+    transform: scale(0.85);
     opacity: 0.3;
   }
   35% {
-    transform: scale(1.1);
+    transform: scale(1);
     opacity: 1;
   }
 `;
@@ -18,13 +18,13 @@ const pulse = keyframes`
 export function DotProgress() {
   return (
     <Box
-      sx={{
+      sx={(theme) => ({
         width: DOT_PROGRESS_SIZE,
         aspectRatio: "1",
         borderRadius: "50%",
         backgroundColor: orange[400],
-        animation: `${pulse} 1.6s cubic-bezier(0.4, 0, 0.2, 1) infinite`,
-      }}
+        animation: `${pulse} 1.2s ${theme.transitions.easing.easeInOut} infinite`,
+      })}
     />
   );
 }

--- a/src/shared/components/dot-progress.tsx
+++ b/src/shared/components/dot-progress.tsx
@@ -1,7 +1,19 @@
 import Box from "@mui/material/Box";
 import { orange } from "@mui/material/colors";
+import { keyframes } from "@mui/material/styles";
 
 export const DOT_PROGRESS_SIZE = 10;
+
+const pulse = keyframes`
+  0%, 100% {
+    transform: scale(0.95);
+    opacity: 0.3;
+  }
+  35% {
+    transform: scale(1.1);
+    opacity: 1;
+  }
+`;
 
 export function DotProgress() {
   return (
@@ -11,11 +23,7 @@ export function DotProgress() {
         aspectRatio: "1",
         borderRadius: "50%",
         backgroundColor: orange[400],
-        animation: "dot-progress 0.4s ease-in-out infinite alternate",
-        "@keyframes dot-progress": {
-          from: { opacity: 0.2 },
-          to: { opacity: 1 },
-        },
+        animation: `${pulse} 1.6s cubic-bezier(0.4, 0, 0.2, 1) infinite`,
       }}
     />
   );


### PR DESCRIPTION
## Summary
- Flatten the suggestions pulsing dot to scale + opacity only (no blur/glow)
- Tighten the pulse range (scale 0.85→1) and speed it up to 1.2s
- Source the easing from `theme.transitions.easing.easeInOut` instead of a hardcoded cubic-bezier
- Darken the dot to `orange[500]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)