### PR TITLE
feat(suggestions): center chips in scroll area and speed up pulse

### DIFF
--- a/src/features/board/suggestions/suggestion-bar.tsx
+++ b/src/features/board/suggestions/suggestion-bar.tsx
@@ -36,7 +36,9 @@ export function SuggestionBar({
 
       <Box
         sx={{
+          height: "100%",
           display: "flex",
+          alignItems: "center",
           gap: 2,
           marginInlineEnd: "auto",
           overflowX: "auto",

--- a/src/shared/components/dot-progress.tsx
+++ b/src/shared/components/dot-progress.tsx
@@ -23,7 +23,7 @@ export function DotProgress() {
         aspectRatio: "1",
         borderRadius: "50%",
         backgroundColor: orange[500],
-        animation: `${pulse} 1.2s ${theme.transitions.easing.easeInOut} infinite`,
+        animation: `${pulse} 1s ${theme.transitions.easing.easeInOut} infinite`,
       })}
     />
   );


### PR DESCRIPTION
## Summary
- Give the chip scroll container full height with centered alignment so chips stay vertically centered when a horizontal scrollbar appears
- Speed up the pulsing dot to 1s per cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)