### PR TITLE
chore: add baseline security headers to Netlify config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,16 @@
   from = "/*"
   to   = "/index.html"
   status = 200
+
+# CSP intentionally absent for now: index.html's inline theme script would need
+# hash upkeep on every edit. X-Frame-Options covers framing until a CSP ships.
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Strict-Transport-Security = "max-age=31536000; includeSubDomains"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "no-referrer"
+    Permissions-Policy = "geolocation=(), camera=(), microphone=(), payment=(), usb=(), display-capture=()"
+    X-Frame-Options = "DENY"
+    Cross-Origin-Opener-Policy = "same-origin"
+    Cross-Origin-Resource-Policy = "same-origin"


### PR DESCRIPTION
## Summary

Adds the static security-header baseline to `netlify.toml`, sent on every response:

- **Strict-Transport-Security** — browser-enforced HTTPS (1 year, subdomains; no `preload` by choice)
- **X-Content-Type-Options: nosniff** — no MIME sniffing
- **Referrer-Policy: no-referrer** — board URL imports don't leak our origin to board hosts
- **Permissions-Policy** — explicit denials for geolocation, camera, microphone, payment, USB, display-capture (fullscreen deliberately left ungated for a possible kiosk mode; `microphone` must be revisited if voice input ever lands)
- **X-Frame-Options: DENY** — clickjacking protection, standing in for CSP `frame-ancestors`
- **COOP/CORP same-origin** — tab isolation (COEP intentionally omitted; no `SharedArrayBuffer` use)

**CSP is deliberately deferred**, not forgotten — the inline pre-paint theme script in `index.html` would require hash upkeep. Documented in a comment in the file.

This makes the privacy posture externally verifiable: anyone can scan the deployed origin (e.g. securityheaders.com) instead of taking the docs' word for it.

## Test plan

- [ ] Deploy preview: confirm headers present via `curl -sI <preview-url>`
- [ ] App loads and core flows work unchanged (headers are response metadata only; no app code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)