### PR TITLE
feat(app): add end-to-end app flow test

### DIFF
--- a/src/app/app-router.tsx
+++ b/src/app/app-router.tsx
@@ -1,73 +1,8 @@
-import { AppShell } from "@app/layouts/app-shell";
-import { boardLoader } from "@app/loaders/board-loader";
-import { boardSetIndexLoader } from "@app/loaders/board-set-index-loader";
-import { rootIndexLoader } from "@app/loaders/root-index-loader";
-import { ROUTE_PATTERNS } from "@app/route-patterns";
-import { BOARD_PATTERN, BOARD_SET_PATTERN } from "@features/board";
-import Button from "@mui/material/Button";
-import { m } from "@paraglide/messages.js";
-import { ErrorState } from "@shared/components/error-state";
-import { LoadingState } from "@shared/components/loading-state";
-import {
-  createBrowserRouter,
-  isRouteErrorResponse,
-  Link,
-  useRouteError,
-} from "react-router";
+import { appRoutes } from "@app/app-routes";
+import { createBrowserRouter } from "react-router";
 import { RouterProvider } from "react-router/dom";
 
-function RouteErrorBoundary() {
-  const error = useRouteError();
-  const title =
-    isRouteErrorResponse(error) && typeof error.data === "string"
-      ? error.data
-      : m.errorGenericTitle();
-
-  return (
-    <ErrorState
-      title={title}
-      action={
-        <Button component={Link} to="/" variant="contained">
-          {m.errorGoHome()}
-        </Button>
-      }
-    />
-  );
-}
-
-const router = createBrowserRouter([
-  {
-    Component: AppShell,
-    HydrateFallback: LoadingState,
-    children: [
-      {
-        ErrorBoundary: RouteErrorBoundary,
-        children: [
-          { index: true, loader: rootIndexLoader },
-          {
-            path: BOARD_SET_PATTERN,
-            children: [
-              { index: true, loader: boardSetIndexLoader },
-              {
-                path: BOARD_PATTERN,
-                loader: boardLoader,
-                lazy: async () => import("@pages/board-page"),
-              },
-            ],
-          },
-          {
-            path: ROUTE_PATTERNS.LIBRARY,
-            lazy: async () => import("@pages/library-page"),
-          },
-          {
-            path: ROUTE_PATTERNS.ABOUT,
-            lazy: async () => import("@pages/about-page"),
-          },
-        ],
-      },
-    ],
-  },
-]);
+const router = createBrowserRouter(appRoutes);
 
 export function AppRouter() {
   return <RouterProvider router={router} />;

--- a/src/app/app-routes.test.tsx
+++ b/src/app/app-routes.test.tsx
@@ -1,0 +1,77 @@
+import { importBoardFromUrl } from "@features/board";
+import { resetBoardsDB } from "@features/board/testing";
+import { AppProviders } from "@shared/providers/app-providers";
+import { stubAudio, stubSpeech } from "@shared/testing/device-output";
+import { createMemoryRouter, type RouteObject } from "react-router";
+import { RouterProvider } from "react-router/dom";
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+const OBZ_FIXTURE_URL = "/src/shared/testing/sample-boards/lots-of-stuff.obz";
+
+// The onboarding store reads localStorage when its module first loads, and a
+// previously run test file may have persisted a dismissal. Seeding before a
+// dynamic import pins this file to a first-run state.
+let appRoutes: RouteObject[];
+
+beforeAll(async () => {
+  localStorage.setItem("hasSeenOnboarding", "false");
+  ({ appRoutes } = await import("./app-routes"));
+});
+
+async function renderApp() {
+  const router = createMemoryRouter(appRoutes, { initialEntries: ["/"] });
+
+  return render(
+    <AppProviders>
+      <RouterProvider router={router} />
+    </AppProviders>,
+  );
+}
+
+describe("app flow", () => {
+  let speech: ReturnType<typeof stubSpeech>;
+
+  beforeEach(async () => {
+    speech = stubSpeech();
+    stubAudio();
+    await resetBoardsDB();
+  });
+
+  test("first run: imported board set opens, composes across boards, and speaks", async () => {
+    await importBoardFromUrl(OBZ_FIXTURE_URL);
+
+    const screen = await renderApp();
+
+    await screen.getByRole("button", { name: "Continue" }).click();
+    await expect
+      .element(screen.getByRole("grid", { name: "Lots of Stuff Board" }))
+      .toBeVisible();
+
+    await screen.getByRole("button", { name: "No way" }).click();
+    await screen.getByRole("button", { name: "living things" }).click();
+
+    await expect
+      .element(screen.getByRole("grid", { name: "Inline Images Board" }))
+      .toBeVisible();
+
+    await screen.getByRole("button", { name: "cat" }).click();
+    // Tile taps speak per-tile feedback; only the played message is asserted.
+    speech.speak.mockClear();
+
+    await screen.getByRole("button", { name: "Play message" }).click();
+
+    await vi.waitFor(() => {
+      expect(speech.speak.mock.calls).toHaveLength(1);
+      expect(speech.speak.mock.calls[0][0].text).toBe("no way feline");
+    });
+  });
+
+  test("empty database: imports and opens the bundled starter board", async () => {
+    const screen = await renderApp();
+
+    await expect
+      .element(screen.getByRole("grid", { name: "Quick Core 24" }))
+      .toBeVisible();
+  });
+});

--- a/src/app/app-routes.tsx
+++ b/src/app/app-routes.tsx
@@ -1,0 +1,43 @@
+import { AppShell } from "@app/layouts/app-shell";
+import { boardLoader } from "@app/loaders/board-loader";
+import { boardSetIndexLoader } from "@app/loaders/board-set-index-loader";
+import { rootIndexLoader } from "@app/loaders/root-index-loader";
+import { RouteErrorBoundary } from "@app/route-error-boundary";
+import { ROUTE_PATTERNS } from "@app/route-patterns";
+import { BOARD_PATTERN, BOARD_SET_PATTERN } from "@features/board";
+import { LoadingState } from "@shared/components/loading-state";
+import { type RouteObject } from "react-router";
+
+export const appRoutes: RouteObject[] = [
+  {
+    Component: AppShell,
+    HydrateFallback: LoadingState,
+    children: [
+      {
+        ErrorBoundary: RouteErrorBoundary,
+        children: [
+          { index: true, loader: rootIndexLoader },
+          {
+            path: BOARD_SET_PATTERN,
+            children: [
+              { index: true, loader: boardSetIndexLoader },
+              {
+                path: BOARD_PATTERN,
+                loader: boardLoader,
+                lazy: async () => import("@pages/board-page"),
+              },
+            ],
+          },
+          {
+            path: ROUTE_PATTERNS.LIBRARY,
+            lazy: async () => import("@pages/library-page"),
+          },
+          {
+            path: ROUTE_PATTERNS.ABOUT,
+            lazy: async () => import("@pages/about-page"),
+          },
+        ],
+      },
+    ],
+  },
+];

--- a/src/app/route-error-boundary.tsx
+++ b/src/app/route-error-boundary.tsx
@@ -1,0 +1,23 @@
+import Button from "@mui/material/Button";
+import { m } from "@paraglide/messages.js";
+import { ErrorState } from "@shared/components/error-state";
+import { isRouteErrorResponse, Link, useRouteError } from "react-router";
+
+export function RouteErrorBoundary() {
+  const error = useRouteError();
+  const title =
+    isRouteErrorResponse(error) && typeof error.data === "string"
+      ? error.data
+      : m.errorGenericTitle();
+
+  return (
+    <ErrorState
+      title={title}
+      action={
+        <Button component={Link} to="/" variant="contained">
+          {m.errorGoHome()}
+        </Button>
+      }
+    />
+  );
+}


### PR DESCRIPTION
## Summary

Adds the missing "spine" test: every link of import → navigate → compose → speak was tested individually, but nothing proved the whole chain. Now one test does, end to end, against the real app:

- **Real routes** — `app-routes.tsx` is extracted from `app-router.tsx` so the test mounts the actual route table (loaders, lazy pages, error boundary) on a `createMemoryRouter`. `RouteErrorBoundary` moves to its own file (react-refresh requires data-only exports to live apart from components).
- **Real storage** — imports `lots-of-stuff.obz` through `importBoardFromUrl` into real IndexedDB; loaders hydrate it with real blob URLs.
- **Real first run** — onboarding is pinned to "not seen" by seeding localStorage before a dynamic route import (the store reads storage at module load), then dismissed through the UI.
- **The flow** — land on the imported root board via the root redirect → compose "No way" → navigate to a linked board via a `load_board` tile (message persists across navigation) → compose "cat" (spoken via its vocalization) → play → assert the merged utterance `"no way feline"`.
- **Bonus test** — empty database at `/` exercises the real default-board fetch+import path (`public/quick-core-24.obz` served by Vite) and lands on "Quick Core 24".

Only stubs: `speechSynthesis` and `HTMLAudioElement` (device output), per the project's mocking policy. No internals mocked.

## Test plan

- [x] New file: 2/2 passing, stable across repeated runs (~6s)
- [x] Full suite: 66 files / 437 tests passing
- [x] `npm run lint` clean, `npm run build` (incl. typecheck) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)