### PR TITLE
refactor(suggestions): collapse per-engine flags into canChangeTone

### DIFF
--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -97,7 +97,7 @@ export function BoardViewer({ board }: BoardViewerProps) {
             phrases={suggestions.phrases}
             status={suggestions.status}
             tone={suggestions.tone}
-            canChangeTone={suggestions.isRewriterSupported}
+            canChangeTone={suggestions.canChangeTone}
             onPhraseClick={message.setFromText}
             onToneChange={suggestions.setTone}
             onEnable={suggestions.enable}

--- a/src/features/board/suggestions/use-suggestions.test.ts
+++ b/src/features/board/suggestions/use-suggestions.test.ts
@@ -35,7 +35,7 @@ describe("useSuggestions", () => {
     expect(result.current.phrases).toEqual([]);
   });
 
-  test("reports per-engine support when only one capability is available", async () => {
+  test("stays supported but locks the tone when only the proofreader is available", async () => {
     stubProofreader();
     stubBuiltInAIUnsupported("Rewriter");
 
@@ -43,8 +43,7 @@ describe("useSuggestions", () => {
 
     await vi.waitFor(() => {
       expect(result.current.isSupported).toBe(true);
-      expect(result.current.isProofreaderSupported).toBe(true);
-      expect(result.current.isRewriterSupported).toBe(false);
+      expect(result.current.canChangeTone).toBe(false);
     });
   });
 
@@ -109,59 +108,69 @@ describe("useSuggestions", () => {
     });
   });
 
-  test("surfaces a proofread failure while the rewrite still suggests", async () => {
+  test("still suggests the rewrite when the proofread fails", async () => {
     stubProofreader(() => Promise.reject(new Error("input too long")));
     stubRewriter(() => "I would like to eat.");
 
     const { result } = await renderSuggestions("want eat");
 
     await vi.waitFor(() => {
-      expect(result.current.proofreaderError?.message).toBe("input too long");
       expect(result.current.phrases).toEqual(["I would like to eat."]);
+      expect(result.current.status).toBeNull();
     });
-    expect(result.current.rewriterError).toBeUndefined();
-    expect(result.current.status).toBeNull();
   });
 
-  test("surfaces failures from both engines with no phrases", async () => {
+  test("reports unavailable when both engines fail", async () => {
     stubProofreader(() => Promise.reject(new Error("proofread down")));
     stubRewriter(() => Promise.reject(new Error("rewrite down")));
 
     const { result } = await renderSuggestions("want eat");
 
     await vi.waitFor(() => {
-      expect(result.current.proofreaderError?.message).toBe("proofread down");
-      expect(result.current.rewriterError?.message).toBe("rewrite down");
+      expect(result.current.status).toEqual({ kind: "unavailable" });
     });
     expect(result.current.phrases).toEqual([]);
-    expect(result.current.status).toEqual({ kind: "unavailable" });
   });
 
   test("stays silent when the healthy engine has nothing to suggest and the other is broken", async () => {
+    const rejecters: ((error: Error) => void)[] = [];
     stubProofreader((input) => makeProofreadResult(input));
-    stubRewriter(() => Promise.reject(new Error("rewrite down")));
+    stubRewriter(
+      () => new Promise<string>((_, reject) => rejecters.push(reject)),
+    );
 
     const { result } = await renderSuggestions("unchanged");
 
     await vi.waitFor(() => {
-      expect(result.current.rewriterError?.message).toBe("rewrite down");
+      expect(rejecters).toHaveLength(1);
+      expect(result.current.status).toEqual({ kind: "pending" });
+    });
+    rejecters[0](new Error("rewrite down"));
+
+    await vi.waitFor(() => {
+      expect(result.current.status).toBeNull();
     });
     expect(result.current.phrases).toEqual([]);
-    expect(result.current.status).toBeNull();
   });
 
   test("stays quiet when a rejection is an abort by name", async () => {
-    stubRewriter(() =>
-      Promise.reject(new DOMException("Aborted", "AbortError")),
+    const rejecters: ((error: Error) => void)[] = [];
+    stubRewriter(
+      () => new Promise<string>((_, reject) => rejecters.push(reject)),
     );
     stubBuiltInAIUnsupported("Proofreader");
 
     const { result } = await renderSuggestions("want eat");
 
     await vi.waitFor(() => {
-      expect(result.current.rewriterError?.name).toBe("AbortError");
+      expect(rejecters).toHaveLength(1);
+      expect(result.current.status).toEqual({ kind: "pending" });
     });
-    expect(result.current.status).toBeNull();
+    rejecters[0](new DOMException("Aborted", "AbortError"));
+
+    await vi.waitFor(() => {
+      expect(result.current.status).toBeNull();
+    });
   });
 
   test("asks for activation when the model needs a user-gesture download", async () => {

--- a/src/features/board/suggestions/use-suggestions.ts
+++ b/src/features/board/suggestions/use-suggestions.ts
@@ -23,10 +23,7 @@ const SHARED_CONTEXT_DEBOUNCE_MS = 400;
 
 export interface UseSuggestionsReturn {
   isSupported: boolean;
-  isProofreaderSupported: boolean;
-  isRewriterSupported: boolean;
-  proofreaderError: Error | undefined;
-  rewriterError: Error | undefined;
+  canChangeTone: boolean;
   status: SuggestionStatusView;
   enable: () => void;
   phrases: string[];
@@ -106,20 +103,19 @@ export function useSuggestions(text: string): UseSuggestionsReturn {
     if (proofreader.status === "downloadable") {
       prepareQuietly(proofreader);
     }
+
     if (rewriter.status === "downloadable") {
       prepareQuietly(rewriter);
     }
   };
 
-  const isProofreaderSupported = proofreader.status !== "unsupported";
-  const isRewriterSupported = rewriter.status !== "unsupported";
+  const isSupported =
+    proofreader.status !== "unsupported" || rewriter.status !== "unsupported";
+  const canChangeTone = rewriter.status !== "unsupported";
 
   return {
-    isSupported: isProofreaderSupported || isRewriterSupported,
-    isProofreaderSupported,
-    isRewriterSupported,
-    proofreaderError: corrected.error,
-    rewriterError: rewritten.error,
+    isSupported,
+    canChangeTone,
     status,
     enable,
     phrases,


### PR DESCRIPTION
## Summary
- Replace `isProofreaderSupported`/`isRewriterSupported` on `UseSuggestionsReturn` with the single question the UI actually asks: `canChangeTone` (rewriter available).
- Drop `proofreaderError`/`rewriterError` from the return surface — no consumer read them, and the status view already covers the both-engines-failed case.
- Rework tests to assert observable behavior (status transitions) instead of internal error objects, holding rejections open to assert the pending state first.

## Test plan
- `npx vitest run src/features/board/suggestions/use-suggestions.test.ts` — 23 passed
- Lint and typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)