### PR TITLE
fix: keep a grid tab stop when the active cell empties on board change

### DIFF
--- a/src/features/board/grid/grid.test.tsx
+++ b/src/features/board/grid/grid.test.tsx
@@ -287,6 +287,42 @@ describe("Grid", () => {
       await expect.element(item1).toHaveAttribute("tabindex", "-1");
     });
 
+    test("keeps a tab stop when the grid changes and the active cell becomes empty while focus is outside the grid", async () => {
+      const renderItem = (
+        item: { id: string; label: string },
+        props: { tabIndex: number },
+      ) => <button {...props}>{item.label}</button>;
+
+      const oldItems = [
+        { id: "1", label: "Item 1" },
+        { id: "2", label: "Item 2" },
+        { id: "3", label: "Item 3" },
+        { id: "4", label: "Item 4" },
+      ];
+      const newItems = [{ id: "5", label: "Item 5" }];
+
+      const screen = await render(
+        <div>
+          <button>Outside</button>
+          <Grid rows={2} columns={2} items={oldItems} renderItem={renderItem} />
+        </div>,
+      );
+
+      screen.getByRole("button", { name: "Item 4" }).element().focus();
+      screen.getByRole("button", { name: "Outside" }).element().focus();
+
+      await screen.rerender(
+        <div>
+          <button>Outside</button>
+          <Grid rows={2} columns={2} items={newItems} renderItem={renderItem} />
+        </div>,
+      );
+
+      const item5 = screen.getByRole("button", { name: "Item 5" });
+
+      await expect.element(item5).toHaveAttribute("tabindex", "0");
+    });
+
     test("moves focus with arrow keys to the next focusable cell", async () => {
       const items = [
         { id: "1", label: "Item 1" },

--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -12,7 +12,7 @@ export interface GridProps<TItem extends { id: string }> {
   items: readonly TItem[];
   rows: number;
   columns: number;
-  order?: (string | null)[][];
+  order?: readonly (readonly (string | null)[])[];
   renderItem: (item: TItem, props: GridItemProps) => React.ReactNode;
   dir?: "ltr" | "rtl";
   gap?: number;
@@ -40,8 +40,6 @@ export function Grid<TItem extends { id: string }>({
       ref={rootRef}
       role="grid"
       aria-label={ariaLabel}
-      aria-rowcount={rows}
-      aria-colcount={columns}
       direction="column"
       dir={dir}
       sx={(theme) => ({
@@ -87,7 +85,7 @@ function buildGrid<TItem extends { id: string }>(
   items: readonly TItem[],
   rows: number,
   columns: number,
-  order?: (string | null)[][],
+  order?: readonly (readonly (string | null)[])[],
 ): (TItem | undefined)[][] {
   if (order?.length) {
     const itemsById = new Map(items.map((item) => [item.id, item]));

--- a/src/features/board/grid/use-grid-keyboard.ts
+++ b/src/features/board/grid/use-grid-keyboard.ts
@@ -123,7 +123,15 @@ export function useGridKeyboard({
     firstFocusable?.focus();
   }, [grid]);
 
-  return { rootRef, rootProps: { ...keyboardProps, onFocus }, activeCell };
+  const tabStopCell = grid[activeCell.row]?.[activeCell.col]
+    ? activeCell
+    : findFirstNonEmptyCell(grid);
+
+  return {
+    rootRef,
+    rootProps: { ...keyboardProps, onFocus },
+    activeCell: tabStopCell,
+  };
 }
 
 function findFirstNonEmptyCell(grid: readonly (readonly unknown[])[]): Cell {


### PR DESCRIPTION
## Problem

`useGridKeyboard` returned the remembered active cell verbatim, and `Grid` gives `tabIndex 0` only to the matching cell. When the board changes while focus is outside the grid (e.g. activating toolbar Back/Home with the keyboard), the `activeElement === body` repair effect doesn't fire — and if the remembered position is empty or out of bounds in the new grid, no tile renders with `tabIndex 0`. The grid drops out of the Tab order entirely, and a keyboard-only user can't get back in.

Reproduced empirically in a browser-mode test before fixing: after swapping boards with focus on an outside button, the new board's only tile rendered with `tabindex="-1"`.

## Fix

Derive the returned cell at render in the hook: if the remembered position no longer holds an item, fall back to `findFirstNonEmptyCell`. Pure derivation — no effect, no state sync; the underlying state self-corrects on the next focus event via the existing `onFocus` handler, and arrow navigation reads position from the DOM event target. The fallback reuses the same semantics as the initial seed and the repair effect, so all recovery paths agree.

Includes a regression test mirroring the repro (failed before the fix, passes after).

## Also

Small `Grid` props cleanup in a separate commit: `order` accepts readonly arrays (matching `items` and the hook), and `aria-rowcount`/`aria-colcount` are removed since they exist for virtualized grids and every row here is in the DOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)