### PR TITLE
chore: bump @shayc dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mui/icons-material": "^9.1.1",
         "@mui/material": "^9.1.1",
         "@mui/stylis-plugin-rtl": "^9.1.1",
-        "@shayc/open-board-format": "^0.2.0",
+        "@shayc/open-board-format": "^0.3.0",
         "@shayc/react-built-in-ai": "^0.8.1",
         "idb": "^8.0.3",
         "mrmime": "^2.0.1",
@@ -3474,9 +3474,9 @@
       ]
     },
     "node_modules/@shayc/open-board-format": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@shayc/open-board-format/-/open-board-format-0.2.0.tgz",
-      "integrity": "sha512-riOf9Dc0AZdauXZGHCBJ86G8MwySFA3se+7YZ9MoPUQ8ckjhacS/MsKThaD4aEusYs0HP36lQCeTw9sXaFuMuA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@shayc/open-board-format/-/open-board-format-0.3.0.tgz",
+      "integrity": "sha512-n4aEkUSIYggtAN49PPkOU3umHVJSw2VeTJpieqfI6KFz2aeCxGYHYL+85Aq5CgJ5P7Jf4arnh2iVNlUnn16o3w==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@mui/material": "^9.1.1",
         "@mui/stylis-plugin-rtl": "^9.1.1",
         "@shayc/open-board-format": "^0.2.0",
-        "@shayc/react-built-in-ai": "^0.8.0",
+        "@shayc/react-built-in-ai": "^0.8.1",
         "idb": "^8.0.3",
         "mrmime": "^2.0.1",
         "react": "^19.2.7",
@@ -3487,12 +3487,12 @@
       }
     },
     "node_modules/@shayc/react-built-in-ai": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@shayc/react-built-in-ai/-/react-built-in-ai-0.8.0.tgz",
-      "integrity": "sha512-kyPOL++RKJN7JSNQHjWnrZUlF8AYqG1HGi+QDuJEhOdY0fa2zAA1vNCSd9zanyoomF5KmJUwxj9NYEG0V4dtBA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@shayc/react-built-in-ai/-/react-built-in-ai-0.8.1.tgz",
+      "integrity": "sha512-NuTSfUz9mRcw888ORaOrfE4lvJjRNETvdKiWdXuU4W2cbajk/uTqoh2zvpL43cLs3MOGRDWdbaVdN7Z729Zegg==",
       "license": "MIT",
       "dependencies": {
-        "@types/dom-chromium-ai": "^0.0.16"
+        "@types/dom-chromium-ai": "^0.0.17"
       },
       "engines": {
         "node": ">=22"
@@ -3500,12 +3500,6 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0"
       }
-    },
-    "node_modules/@shayc/react-built-in-ai/node_modules/@types/dom-chromium-ai": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/@types/dom-chromium-ai/-/dom-chromium-ai-0.0.16.tgz",
-      "integrity": "sha512-Z0vOBWckovkc85zctYKGEUUBHaqt9Oz8AUhAVyoNLAsMGlBhMNl/8w1n8JG1y0g7TW03EzWt5RsdcDD70ra58g==",
-      "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.31.28",
@@ -3632,7 +3626,6 @@
       "version": "0.0.17",
       "resolved": "https://registry.npmjs.org/@types/dom-chromium-ai/-/dom-chromium-ai-0.0.17.tgz",
       "integrity": "sha512-UnSAIVKONaY2vTAM4TkPpwdKeGgg3tPCwNP3KxR+U8bLYC2rQU7UrgW9LIVx0B02dKZxuPA6a0Q5wvyW5Rk6nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/esrecurse": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@mui/material": "^9.1.1",
     "@mui/stylis-plugin-rtl": "^9.1.1",
     "@shayc/open-board-format": "^0.2.0",
-    "@shayc/react-built-in-ai": "^0.8.0",
+    "@shayc/react-built-in-ai": "^0.8.1",
     "idb": "^8.0.3",
     "mrmime": "^2.0.1",
     "react": "^19.2.7",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@mui/icons-material": "^9.1.1",
     "@mui/material": "^9.1.1",
     "@mui/stylis-plugin-rtl": "^9.1.1",
-    "@shayc/open-board-format": "^0.2.0",
+    "@shayc/open-board-format": "^0.3.0",
     "@shayc/react-built-in-ai": "^0.8.1",
     "idb": "^8.0.3",
     "mrmime": "^2.0.1",


### PR DESCRIPTION
Bumps `@shayc/react-built-in-ai` to ^0.8.1 and `@shayc/open-board-format` to ^0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)