### PR TITLE
refactor(import): use ParsedOBZ.rootBoard from open-board-format 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mui/icons-material": "^9.1.1",
         "@mui/material": "^9.1.1",
         "@mui/stylis-plugin-rtl": "^9.1.1",
-        "@shayc/open-board-format": "^0.3.0",
+        "@shayc/open-board-format": "^0.4.0",
         "@shayc/react-built-in-ai": "^0.8.1",
         "idb": "^8.0.3",
         "mrmime": "^2.0.1",
@@ -3474,9 +3474,9 @@
       ]
     },
     "node_modules/@shayc/open-board-format": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@shayc/open-board-format/-/open-board-format-0.3.0.tgz",
-      "integrity": "sha512-n4aEkUSIYggtAN49PPkOU3umHVJSw2VeTJpieqfI6KFz2aeCxGYHYL+85Aq5CgJ5P7Jf4arnh2iVNlUnn16o3w==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@shayc/open-board-format/-/open-board-format-0.4.0.tgz",
+      "integrity": "sha512-XUohn1eMooIBZ+Nuw4FrGS0YJnK56vgDKCbPBedewR5QRJ8XcG8tfUYxRijXxheoUGnpAEmomg/tHtadm1WNzQ==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@mui/icons-material": "^9.1.1",
     "@mui/material": "^9.1.1",
     "@mui/stylis-plugin-rtl": "^9.1.1",
-    "@shayc/open-board-format": "^0.3.0",
+    "@shayc/open-board-format": "^0.4.0",
     "@shayc/react-built-in-ai": "^0.8.1",
     "idb": "^8.0.3",
     "mrmime": "^2.0.1",

--- a/src/features/board/import/board-import.test.ts
+++ b/src/features/board/import/board-import.test.ts
@@ -69,15 +69,7 @@ describe("importBoardFiles", () => {
     const fixtureFile = await loadFixtureFile(OBZ_FIXTURE);
     const archive = await loadOBZ(fixtureFile);
 
-    const pathToId = new Map(
-      Object.entries(archive.manifest.paths.boards).map(([id, path]) => [
-        path,
-        id,
-      ]),
-    );
-
-    const rootBoardId = pathToId.get(archive.manifest.root);
-    assertDefined(rootBoardId);
+    const rootBoardId = archive.rootBoard.id;
 
     const assetEntries = Array.from(archive.resources.entries()).filter(
       ([path]) => !path.endsWith(".obf") && path !== "manifest.json",
@@ -131,6 +123,13 @@ describe("importBoardFiles", () => {
     );
 
     expect(boardLinks.length).toBeGreaterThan(0);
+
+    const pathToId = new Map(
+      Object.entries(archive.manifest.paths.boards).map(([id, path]) => [
+        path,
+        id,
+      ]),
+    );
 
     for (const link of boardLinks) {
       const expectedChildBoardId = pathToId.get(link.path);

--- a/src/features/board/import/board-import.ts
+++ b/src/features/board/import/board-import.ts
@@ -47,15 +47,10 @@ async function importOBZArchive(
   setId: string,
   fileName: string,
 ): Promise<ImportResult> {
-  const { manifest, boards, resources } = archive;
+  const { manifest, boards, rootBoard, resources } = archive;
   const boardPathToId = buildBoardPathToId(manifest);
 
-  const rootBoardId = resolveRootBoardId(manifest, boardPathToId);
-  const rootBoard = boards.get(rootBoardId);
-
-  await upsertBoardSet(
-    buildBoardSetInput(setId, rootBoard, rootBoardId, fileName),
-  );
+  await upsertBoardSet(buildBoardSetInput(setId, rootBoard, fileName));
   await putBoards(setId, buildBoardInputs(boards, boardPathToId));
 
   const assetInputs = buildAssetInputs(resources);
@@ -63,7 +58,7 @@ async function importOBZArchive(
     await putAssets(setId, assetInputs);
   }
 
-  return { setId, rootBoardId };
+  return { setId, rootBoardId: rootBoard.id };
 }
 
 async function importOBFBoard(
@@ -71,7 +66,7 @@ async function importOBFBoard(
   setId: string,
   fileName: string,
 ): Promise<ImportResult> {
-  await upsertBoardSet(buildBoardSetInput(setId, board, board.id, fileName));
+  await upsertBoardSet(buildBoardSetInput(setId, board, fileName));
 
   await putBoards(setId, [
     {
@@ -113,20 +108,6 @@ export function resolveLoadBoardPaths(
   return { ...board, buttons };
 }
 
-function resolveRootBoardId(
-  manifest: OBFManifest,
-  boardPathToId: Map<string, string>,
-): string {
-  const fromManifest = boardPathToId.get(manifest.root);
-  if (fromManifest) {
-    return fromManifest;
-  }
-
-  throw new Error(
-    `Manifest root "${manifest.root}" does not match any board in manifest.paths.boards`,
-  );
-}
-
 function buildBoardInputs(
   boards: Map<string, OBFBoard>,
   boardPathToId: Map<string, string>,
@@ -156,22 +137,21 @@ function buildAssetInputs(
 
 function buildBoardSetInput(
   setId: string,
-  board: OBFBoard | undefined,
-  rootBoardId: string,
+  board: OBFBoard,
   fallbackSetName: string,
 ): UpsertBoardSetInput {
   return {
     setId,
-    name: board?.name ?? fallbackSetName,
-    rootBoardId,
-    author: board?.license?.author_name,
-    description: board?.description_html
+    name: board.name ?? fallbackSetName,
+    rootBoardId: board.id,
+    author: board.license?.author_name,
+    description: board.description_html
       ? htmlToText(board.description_html)
       : undefined,
-    license: board?.license?.type,
-    locale: board?.locale ? normalizeLocale(board.locale) : undefined,
-    gridRows: board?.grid.rows,
-    gridColumns: board?.grid.columns,
+    license: board.license?.type,
+    locale: board.locale ? normalizeLocale(board.locale) : undefined,
+    gridRows: board.grid.rows,
+    gridColumns: board.grid.columns,
   };
 }
 


### PR DESCRIPTION
Adopts `@shayc/open-board-format@0.4.0`, which resolves the OBZ entry-point board during extraction (`ParsedOBZ.rootBoard`) and validates that each board's `id` matches its manifest key.

## Changes

**`resolveRootBoardId` deleted** — the library now does this resolution, with a guarantee we couldn't express here: its validation makes the root board's existence provable, so our defensive error branch was unreachable.

**`buildBoardSetInput` tightened** — `board` is now non-optional (`rootBoard` is guaranteed, so the `board?.` chaining covered an impossible case) and the separate `rootBoardId` param drops since both callers passed `board.id`.

**Test simplification** — the path→ID inversion for finding the expected root becomes `archive.rootBoard.id`. The inversion *stays* for the `load_board` link assertions, which genuinely need path→ID mapping.

**Behavior note** — 0.4.0 validates manifest-key ↔ board-id consistency, so a malformed foreign `.obz` now fails import with a descriptive error instead of importing with broken board-to-board navigation. The OBZ fixture passes the stricter validation.

## Verification

Lint clean; all 9 import tests pass (real Chromium); full build + typecheck green. Full-suite run shows one failure in `appearance-settings.test.tsx` — a pre-existing locale-leak flake (renders French in-suite, passes in isolation), unrelated to this change.

Net: −21 lines, one deleted function, stronger types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)