### PR TITLE
chore: bump @shayc/open-board-format to 0.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mui/icons-material": "^9.1.1",
         "@mui/material": "^9.1.1",
         "@mui/stylis-plugin-rtl": "^9.1.1",
-        "@shayc/open-board-format": "^0.4.0",
+        "@shayc/open-board-format": "^0.4.1",
         "@shayc/react-built-in-ai": "^0.8.1",
         "idb": "^8.0.3",
         "mrmime": "^2.0.1",
@@ -3474,9 +3474,9 @@
       ]
     },
     "node_modules/@shayc/open-board-format": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@shayc/open-board-format/-/open-board-format-0.4.0.tgz",
-      "integrity": "sha512-XUohn1eMooIBZ+Nuw4FrGS0YJnK56vgDKCbPBedewR5QRJ8XcG8tfUYxRijXxheoUGnpAEmomg/tHtadm1WNzQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@shayc/open-board-format/-/open-board-format-0.4.1.tgz",
+      "integrity": "sha512-7/EZzy3DalrhFJUnxrzfbjoilLpGF4UIVvr5AudX9EQr7dO2a8Kq+9Scloswaz9L9HbEvFG9nFtJxuUYGLWyqg==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mui/icons-material": "^9.1.1",
         "@mui/material": "^9.1.1",
         "@mui/stylis-plugin-rtl": "^9.1.1",
-        "@shayc/open-board-format": "^0.4.1",
+        "@shayc/open-board-format": "^0.4.2",
         "@shayc/react-built-in-ai": "^0.8.1",
         "idb": "^8.0.3",
         "mrmime": "^2.0.1",
@@ -3474,9 +3474,9 @@
       ]
     },
     "node_modules/@shayc/open-board-format": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@shayc/open-board-format/-/open-board-format-0.4.1.tgz",
-      "integrity": "sha512-7/EZzy3DalrhFJUnxrzfbjoilLpGF4UIVvr5AudX9EQr7dO2a8Kq+9Scloswaz9L9HbEvFG9nFtJxuUYGLWyqg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@shayc/open-board-format/-/open-board-format-0.4.2.tgz",
+      "integrity": "sha512-NKdysdXEL5dgJhvW7/cNagFG6qnpV6sa+PnzR4/VNw7DMB7aF1g9tpjvx5vN9h9Xk3jjEVshjMUwpelpw/JcWg==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@mui/icons-material": "^9.1.1",
     "@mui/material": "^9.1.1",
     "@mui/stylis-plugin-rtl": "^9.1.1",
-    "@shayc/open-board-format": "^0.4.1",
+    "@shayc/open-board-format": "^0.4.2",
     "@shayc/react-built-in-ai": "^0.8.1",
     "idb": "^8.0.3",
     "mrmime": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@mui/icons-material": "^9.1.1",
     "@mui/material": "^9.1.1",
     "@mui/stylis-plugin-rtl": "^9.1.1",
-    "@shayc/open-board-format": "^0.4.0",
+    "@shayc/open-board-format": "^0.4.1",
     "@shayc/react-built-in-ai": "^0.8.1",
     "idb": "^8.0.3",
     "mrmime": "^2.0.1",


### PR DESCRIPTION
Pulls in the JSDoc-polished type declarations from open-board-format 0.4.1 (shayc/open-board-format#44), so exported types like `OBFBoard` and `ParsedOBZ` fields show descriptions on hover.

Patch bump, no runtime changes upstream. Verified locally: `tsc -b` clean, 436/436 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)