### PR TITLE
chore: rename coverage script to test:coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: npm run lint
 
       - name: Run tests with coverage
-        run: npm run coverage
+        run: npm run test:coverage
 
       - name: Build project
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "format": "prettier --write .",
     "preview": "vite preview",
     "test": "vitest run",
-    "coverage": "vitest run --coverage",
+    "test:coverage": "vitest run --coverage",
     "prepare": "husky && paraglide-js compile --project ./project.inlang --outdir ./src/paraglide --strategy globalVariable baseLocale"
   },
   "lint-staged": {


### PR DESCRIPTION
Renames the `coverage` npm script to `test:coverage` and updates its only consumer (`ci.yml`). No markdown docs reference the old name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)