### PR TITLE
chore: bump version to 1.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aac-board-ai",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aac-board-ai",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aac-board-ai",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.10.0",
   "license": "MIT",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release prep for v1.10.0 — minor bump covering the AI status surface, suggestion progress indicator, locale work, and persisted-store/a11y/import fixes since v1.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)