### PR TITLE
chore: bump @shayc/open-board-format to 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mui/icons-material": "^9.1.1",
         "@mui/material": "^9.1.1",
         "@mui/stylis-plugin-rtl": "^9.1.1",
-        "@shayc/open-board-format": "^0.4.2",
+        "@shayc/open-board-format": "^0.5.0",
         "@shayc/react-built-in-ai": "^0.8.1",
         "idb": "^8.0.3",
         "mrmime": "^2.0.1",
@@ -3474,9 +3474,9 @@
       ]
     },
     "node_modules/@shayc/open-board-format": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@shayc/open-board-format/-/open-board-format-0.4.2.tgz",
-      "integrity": "sha512-NKdysdXEL5dgJhvW7/cNagFG6qnpV6sa+PnzR4/VNw7DMB7aF1g9tpjvx5vN9h9Xk3jjEVshjMUwpelpw/JcWg==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@shayc/open-board-format/-/open-board-format-0.5.0.tgz",
+      "integrity": "sha512-9tpjDXraA6IyE/JrNOyYBKNiTYnxSWhIbDnykqtfkYM8zvWu9jr48Tk0vuZQQNI3V3XUnpYJ8nd7funrxHVrwg==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@mui/icons-material": "^9.1.1",
     "@mui/material": "^9.1.1",
     "@mui/stylis-plugin-rtl": "^9.1.1",
-    "@shayc/open-board-format": "^0.4.2",
+    "@shayc/open-board-format": "^0.5.0",
     "@shayc/react-built-in-ai": "^0.8.1",
     "idb": "^8.0.3",
     "mrmime": "^2.0.1",


### PR DESCRIPTION
Bumps `@shayc/open-board-format` from `^0.4.2` to `^0.5.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)