### PR TITLE
refactor: replace non-null assertions with explicit guards

### DIFF
--- a/src/app/routing/loaders/board-loader.ts
+++ b/src/app/routing/loaders/board-loader.ts
@@ -12,8 +12,10 @@ export async function boardLoader({
   params,
   request,
 }: LoaderFunctionArgs): Promise<Board> {
-  const setId = params.setId!;
-  const boardId = params.boardId!;
+  const { setId, boardId } = params;
+  if (!setId || !boardId) {
+    throw data(m.boardNotFound(), { status: 404 });
+  }
 
   try {
     const board = await hydrateBoard(setId, boardId, request.signal);

--- a/src/app/routing/loaders/board-set-index-loader.ts
+++ b/src/app/routing/loaders/board-set-index-loader.ts
@@ -5,8 +5,8 @@ import { data, redirect, type LoaderFunctionArgs } from "react-router";
 export async function boardSetIndexLoader({
   params,
 }: LoaderFunctionArgs): Promise<Response> {
-  const setId = params.setId!;
-  const set = await getBoardSet(setId);
+  const { setId } = params;
+  const set = setId ? await getBoardSet(setId) : undefined;
 
   if (!set) {
     throw data(m.errorBoardSetNotFound(), { status: 404 });

--- a/src/features/board/import/board-import.test.ts
+++ b/src/features/board/import/board-import.test.ts
@@ -1,4 +1,5 @@
 import { loadFixtureFile } from "@shared/testing/fixtures";
+import { assertDefined } from "@shared/testing/assert-defined";
 import { loadOBF, loadOBZ, type OBFBoard } from "@shayc/open-board-format";
 import { beforeEach, describe, expect, test } from "vitest";
 import {
@@ -13,10 +14,6 @@ import { importBoardFiles, resolveLoadBoardPaths } from "./board-import";
 const OBZ_FIXTURE = "lots-of-stuff.obz";
 const OBF_FIXTURE = "lots-of-stuff.obf";
 const IMPORTED_SET_ID = "lots-of-stuff";
-
-function assertDefined<T>(value: T | undefined | null): asserts value is T {
-  expect(value).toBeDefined();
-}
 
 describe("importBoardFiles", () => {
   beforeEach(async () => {

--- a/src/features/board/message/backspace-button.test.tsx
+++ b/src/features/board/message/backspace-button.test.tsx
@@ -3,6 +3,7 @@ import {
   ThemeProvider as MUIThemeProvider,
 } from "@mui/material/styles";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { assertDefined } from "@shared/testing/assert-defined";
 import { render } from "vitest-browser-react";
 import { BackspaceButton } from "./backspace-button";
 
@@ -76,9 +77,9 @@ describe("BackspaceButton", () => {
       const button = screen.getByRole("button", { name: "Backspace" });
       const icon = button.element().querySelector("svg");
 
-      expect(icon).not.toBeNull();
+      assertDefined(icon);
       // Browsers resolve scaleX(-1) to its matrix equivalent
-      const styles = getComputedStyle(icon!);
+      const styles = getComputedStyle(icon);
       expect(styles.transform).toBe("matrix(-1, 0, 0, 1, 0, 0)");
     });
 
@@ -95,8 +96,8 @@ describe("BackspaceButton", () => {
       const button = screen.getByRole("button", { name: "Backspace" });
       const icon = button.element().querySelector("svg");
 
-      expect(icon).not.toBeNull();
-      const styles = getComputedStyle(icon!);
+      assertDefined(icon);
+      const styles = getComputedStyle(icon);
       expect(styles.transform).not.toBe("matrix(-1, 0, 0, 1, 0, 0)");
     });
   });

--- a/src/features/board/message/play-button.test.tsx
+++ b/src/features/board/message/play-button.test.tsx
@@ -3,6 +3,7 @@ import {
   ThemeProvider as MUIThemeProvider,
 } from "@mui/material/styles";
 import { describe, expect, test, vi } from "vitest";
+import { assertDefined } from "@shared/testing/assert-defined";
 import { render } from "vitest-browser-react";
 import { PlayButton } from "./play-button";
 
@@ -68,9 +69,9 @@ describe("PlayButton", () => {
       const button = screen.getByRole("button", { name: "Play message" });
       const icon = button.element().querySelector("svg");
 
-      expect(icon).not.toBeNull();
+      assertDefined(icon);
       // Browsers resolve scaleX(-1) to its matrix equivalent
-      const styles = getComputedStyle(icon!);
+      const styles = getComputedStyle(icon);
       expect(styles.transform).toBe("matrix(-1, 0, 0, 1, 0, 0)");
     });
 
@@ -87,8 +88,8 @@ describe("PlayButton", () => {
       const button = screen.getByRole("button", { name: "Play message" });
       const icon = button.element().querySelector("svg");
 
-      expect(icon).not.toBeNull();
-      const styles = getComputedStyle(icon!);
+      assertDefined(icon);
+      const styles = getComputedStyle(icon);
       expect(styles.transform).not.toBe("matrix(-1, 0, 0, 1, 0, 0)");
     });
 
@@ -105,8 +106,8 @@ describe("PlayButton", () => {
       const button = screen.getByRole("button", { name: "Stop" });
       const icon = button.element().querySelector("svg");
 
-      expect(icon).not.toBeNull();
-      const styles = getComputedStyle(icon!);
+      assertDefined(icon);
+      const styles = getComputedStyle(icon);
       expect(styles.transform).not.toBe("matrix(-1, 0, 0, 1, 0, 0)");
     });
   });

--- a/src/features/board/navigation/nav-buttons.test.tsx
+++ b/src/features/board/navigation/nav-buttons.test.tsx
@@ -3,6 +3,7 @@ import {
   ThemeProvider as MUIThemeProvider,
 } from "@mui/material/styles";
 import { describe, expect, test, vi } from "vitest";
+import { assertDefined } from "@shared/testing/assert-defined";
 import { render } from "vitest-browser-react";
 import { NavButtons } from "./nav-buttons";
 
@@ -119,9 +120,9 @@ describe("NavButtons", () => {
       const backButton = screen.getByRole("button", { name: "Back" });
       const icon = backButton.element().querySelector("svg");
 
-      expect(icon).not.toBeNull();
+      assertDefined(icon);
       // Browsers resolve scaleX(-1) to its matrix equivalent
-      const styles = getComputedStyle(icon!);
+      const styles = getComputedStyle(icon);
       expect(styles.transform).toBe("matrix(-1, 0, 0, 1, 0, 0)");
     });
 
@@ -131,8 +132,8 @@ describe("NavButtons", () => {
       const backButton = screen.getByRole("button", { name: "Back" });
       const icon = backButton.element().querySelector("svg");
 
-      expect(icon).not.toBeNull();
-      const styles = getComputedStyle(icon!);
+      assertDefined(icon);
+      const styles = getComputedStyle(icon);
       expect(styles.transform).not.toBe("matrix(-1, 0, 0, 1, 0, 0)");
     });
 
@@ -142,8 +143,8 @@ describe("NavButtons", () => {
       const homeButton = screen.getByRole("button", { name: "Home" });
       const icon = homeButton.element().querySelector("svg");
 
-      expect(icon).not.toBeNull();
-      const styles = getComputedStyle(icon!);
+      assertDefined(icon);
+      const styles = getComputedStyle(icon);
       expect(styles.transform).not.toBe("matrix(-1, 0, 0, 1, 0, 0)");
     });
   });

--- a/src/features/board/storage/board-hydration.test.ts
+++ b/src/features/board/storage/board-hydration.test.ts
@@ -1,5 +1,6 @@
 import type { OBFBoard } from "@shayc/open-board-format";
 import { beforeEach, describe, expect, test } from "vitest";
+import { assertDefined } from "@shared/testing/assert-defined";
 import { invalidateBoardSets } from "../board-sets/board-sets-store";
 import { hydrateBoard } from "./board-hydration";
 import {
@@ -86,9 +87,9 @@ describe("hydrateBoard", () => {
     expect(board.id).toBe(BOARD_ID);
 
     const imageSrc = board.buttons[0].imageSrc;
-    expect(imageSrc).toBeDefined();
-    expect(imageSrc!.startsWith("blob:")).toBe(true);
-    expect(await isObjectUrlAlive(imageSrc!)).toBe(true);
+    assertDefined(imageSrc);
+    expect(imageSrc.startsWith("blob:")).toBe(true);
+    expect(await isObjectUrlAlive(imageSrc)).toBe(true);
   });
 
   test("throws BoardNotFoundError when the board is not in IDB", async () => {
@@ -104,15 +105,15 @@ describe("hydrateBoard", () => {
 
     const first = await hydrateBoard(SET_ID, BOARD_ID);
     const firstUrl = first.buttons[0].imageSrc;
-    expect(firstUrl).toBeDefined();
-    expect(await isObjectUrlAlive(firstUrl!)).toBe(true);
+    assertDefined(firstUrl);
+    expect(await isObjectUrlAlive(firstUrl)).toBe(true);
 
     const second = await hydrateBoard(SET_ID, BOARD_ID);
     const secondUrl = second.buttons[0].imageSrc;
-    expect(secondUrl).toBeDefined();
+    assertDefined(secondUrl);
 
-    expect(await isObjectUrlAlive(firstUrl!)).toBe(false);
-    expect(await isObjectUrlAlive(secondUrl!)).toBe(true);
+    expect(await isObjectUrlAlive(firstUrl)).toBe(false);
+    expect(await isObjectUrlAlive(secondUrl)).toBe(true);
   });
 
   test("a missing-board error does not poison module state for a later success", async () => {
@@ -123,8 +124,8 @@ describe("hydrateBoard", () => {
     const board = await hydrateBoard(SET_ID, BOARD_ID);
     const url = board.buttons[0].imageSrc;
 
-    expect(url).toBeDefined();
-    expect(await isObjectUrlAlive(url!)).toBe(true);
+    assertDefined(url);
+    expect(await isObjectUrlAlive(url)).toBe(true);
   });
 
   test("self-destructs without promoting when the signal is already aborted", async () => {
@@ -132,8 +133,8 @@ describe("hydrateBoard", () => {
 
     const live = await hydrateBoard(SET_ID, BOARD_ID);
     const liveUrl = live.buttons[0].imageSrc;
-    expect(liveUrl).toBeDefined();
-    expect(await isObjectUrlAlive(liveUrl!)).toBe(true);
+    assertDefined(liveUrl);
+    expect(await isObjectUrlAlive(liveUrl)).toBe(true);
 
     const aborted = new AbortController();
     aborted.abort();
@@ -144,7 +145,7 @@ describe("hydrateBoard", () => {
     expect((error as Error).name).toBe("AbortError");
     // A superseded load self-destructs instead of promoting, so the live load's
     // URLs aren't orphaned.
-    expect(await isObjectUrlAlive(liveUrl!)).toBe(true);
+    expect(await isObjectUrlAlive(liveUrl)).toBe(true);
   });
 
   test("a later load still hydrates after an aborted one", async () => {
@@ -157,7 +158,7 @@ describe("hydrateBoard", () => {
     const board = await hydrateBoard(SET_ID, BOARD_ID);
     const url = board.buttons[0].imageSrc;
 
-    expect(url).toBeDefined();
-    expect(await isObjectUrlAlive(url!)).toBe(true);
+    assertDefined(url);
+    expect(await isObjectUrlAlive(url)).toBe(true);
   });
 });

--- a/src/features/board/storage/boards-db.test.ts
+++ b/src/features/board/storage/boards-db.test.ts
@@ -1,5 +1,6 @@
 import type { OBFBoard } from "@shayc/open-board-format";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { assertDefined } from "@shared/testing/assert-defined";
 import {
   closeBoardsDB,
   deleteBoardSetRecord,
@@ -112,10 +113,10 @@ describe("putBoards and getBoard", () => {
     await putBoards("set-1", [{ boardId: "b1", name: "Board One", obf }]);
 
     const board = await getBoard("set-1", "b1");
-    expect(board).toBeDefined();
-    expect(board!.boardId).toBe("b1");
-    expect(board!.name).toBe("Board One");
-    expect(board!.obf.id).toBe("b1");
+    assertDefined(board);
+    expect(board.boardId).toBe("b1");
+    expect(board.name).toBe("Board One");
+    expect(board.obf.id).toBe("b1");
   });
 
   test("counts only unique boards", async () => {
@@ -160,8 +161,8 @@ describe("putBoards and getBoard", () => {
     await putBoards("orphan-set", [{ boardId: "b1", name: "B1", obf }]);
 
     const board = await getBoard("orphan-set", "b1");
-    expect(board).toBeDefined();
-    expect(board!.boardId).toBe("b1");
+    assertDefined(board);
+    expect(board.boardId).toBe("b1");
   });
 
   test("rejects empty setId", async () => {
@@ -196,7 +197,8 @@ describe("putAssets and getAssetBlob", () => {
 
     const retrieved = await getAssetBlob("set-1", "images/logo.png");
     expect(retrieved).toBeInstanceOf(Blob);
-    expect(await retrieved!.text()).toBe("hello");
+    assertDefined(retrieved);
+    expect(await retrieved.text()).toBe("hello");
   });
 
   test.each([
@@ -213,7 +215,8 @@ describe("putAssets and getAssetBlob", () => {
 
       const retrieved = await getAssetBlob("set-1", "images/photo.png");
       expect(retrieved).toBeInstanceOf(Blob);
-      expect(await retrieved!.text()).toBe("data");
+      assertDefined(retrieved);
+      expect(await retrieved.text()).toBe("data");
     },
   );
 
@@ -232,8 +235,8 @@ describe("putAssets and getAssetBlob", () => {
 
     const db = await getBoardsDB();
     const record = await db.get("assets", ["set-1", "file.bin"]);
-    expect(record).toBeDefined();
-    expect(record!.size).toBe(5);
+    assertDefined(record);
+    expect(record.size).toBe(5);
   });
 });
 
@@ -250,7 +253,8 @@ describe("updateBoardStrings", () => {
     });
 
     const board = await getBoard("set-1", "b1");
-    expect(board!.obf.strings).toEqual({
+    assertDefined(board);
+    expect(board.obf.strings).toEqual({
       es: { hello: "hola", world: "mundo" },
     });
   });
@@ -267,7 +271,8 @@ describe("updateBoardStrings", () => {
     await updateBoardStrings("set-1", "b1", "es", { hello: "hola" });
 
     const board = await getBoard("set-1", "b1");
-    expect(board!.obf.strings).toEqual({
+    assertDefined(board);
+    expect(board.obf.strings).toEqual({
       fr: { hello: "bonjour" },
       es: { hello: "hola" },
     });
@@ -286,7 +291,8 @@ describe("updateBoardStrings", () => {
     await updateBoardStrings("set-1", "b1", "es", { hello: "ey" });
 
     const board = await getBoard("set-1", "b1");
-    expect(board!.obf.strings).toEqual({ es: { hello: "ey" } });
+    assertDefined(board);
+    expect(board.obf.strings).toEqual({ es: { hello: "ey" } });
   });
 
   test("throws when board does not exist", async () => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,12 @@ import { AppProviders } from "@shared/providers/app-providers";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
-createRoot(document.getElementById("root")!).render(
+const rootElement = document.getElementById("root");
+if (!rootElement) {
+  throw new Error("Root element #root not found");
+}
+
+createRoot(rootElement).render(
   <StrictMode>
     <AppProviders>
       <AppRouter />

--- a/src/shared/testing/assert-defined.ts
+++ b/src/shared/testing/assert-defined.ts
@@ -1,0 +1,8 @@
+import { expect } from "vitest";
+
+export function assertDefined<T>(
+  value: T | undefined | null,
+): asserts value is T {
+  expect(value).toBeDefined();
+  expect(value).not.toBeNull();
+}


### PR DESCRIPTION
## Summary

A single-themed cleanup: eliminate `!` non-null assertions across loaders, the app entrypoint, and tests.

- **Loaders & entrypoint now fail at the boundary.** `board-loader`, `board-set-index-loader`, and `main.tsx` replace `params.setId!` / `getElementById("root")!` with explicit guards that throw meaningful errors (404 / clear `Error`) instead of passing `undefined` downstream to crash deeper.
- **Shared test helper.** Promote the local `assertDefined` (previously duplicated in a test file) into `@shared/testing/assert-defined`, used across 5 test files in place of `expect(...).not.toBeNull()` + `x!`.
- **Helper hardened.** The new version also asserts `not.toBeNull()`, so its runtime check matches its `asserts value is T` signature (the old one only checked `toBeDefined()`, letting `null` slip through the type claim).

## Test plan

- `npm run lint` clean on all changed files
- Behavior-preserving for the happy path; missing route params now yield a proper 404 instead of a downstream crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)