### PR TITLE
ci: cache npm, add timeout and least-privilege permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,13 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout repository
@@ -18,6 +22,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "24"
+          cache: npm
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Lean CI hardening — no change to the lint/test/build steps.

- `cache: npm` on setup-node — skips the npm registry fetch on cached runs (the one real speed win)
- `timeout-minutes: 20` — caps a hung job
- `permissions: contents: read` — least-privilege GITHUB_TOKEN

Deliberately skipped: Playwright browser caching (system deps reinstall on every cache hit anyway, so it's high-complexity for ~20s/run at solo cadence) and a concurrency cancel group (near-zero value without overlapping runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)