### PR TITLE
chore: bump @shayc/open-board-format to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,14 +16,15 @@
         "@mui/icons-material": "^9.1.1",
         "@mui/material": "^9.1.1",
         "@mui/stylis-plugin-rtl": "^9.1.1",
-        "@shayc/open-board-format": "^0.5.0",
+        "@shayc/open-board-format": "^1.0.0",
         "@shayc/react-built-in-ai": "^0.8.1",
         "idb": "^8.0.3",
         "mrmime": "^2.0.1",
         "react": "^19.2.7",
         "react-aria": "^3.49.0",
         "react-dom": "^19.2.7",
-        "react-router": "^7.17.0"
+        "react-router": "^7.17.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@babel/core": "^7.29.7",
@@ -3474,16 +3475,18 @@
       ]
     },
     "node_modules/@shayc/open-board-format": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@shayc/open-board-format/-/open-board-format-0.5.0.tgz",
-      "integrity": "sha512-9tpjDXraA6IyE/JrNOyYBKNiTYnxSWhIbDnykqtfkYM8zvWu9jr48Tk0vuZQQNI3V3XUnpYJ8nd7funrxHVrwg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@shayc/open-board-format/-/open-board-format-1.0.0.tgz",
+      "integrity": "sha512-fY07CVwgeT7PzF6y2LrChp/DHqoKmgRmWljESemaBE5jsKbVWEBsSq9Ot7Qi22dLu5yysDGBgJz6IZ0m1QzVqw==",
       "license": "MIT",
       "dependencies": {
-        "fflate": "^0.8.3",
-        "zod": "^4.4.3"
+        "fflate": "^0.8.3"
       },
       "engines": {
         "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^4.4.3"
       }
     },
     "node_modules/@shayc/react-built-in-ai": {

--- a/package.json
+++ b/package.json
@@ -35,14 +35,15 @@
     "@mui/icons-material": "^9.1.1",
     "@mui/material": "^9.1.1",
     "@mui/stylis-plugin-rtl": "^9.1.1",
-    "@shayc/open-board-format": "^0.5.0",
+    "@shayc/open-board-format": "^1.0.0",
     "@shayc/react-built-in-ai": "^0.8.1",
     "idb": "^8.0.3",
     "mrmime": "^2.0.1",
     "react": "^19.2.7",
     "react-aria": "^3.49.0",
     "react-dom": "^19.2.7",
-    "react-router": "^7.17.0"
+    "react-router": "^7.17.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",


### PR DESCRIPTION
Bumps `@shayc/open-board-format` to `1.0.0`.

The 1.0 release moves `zod` to a **peer dependency**, so this adds `zod` `^4.4.3` as a direct dependency. It resolves to `4.4.3`, deduped with the copy already in the tree (no net install-size change).

## Verification
- `npm run build` ✓
- `npm run lint` ✓
- `npm test` ✓ (436/436)

🤖 Generated with [Claude Code](https://claude.com/claude-code)