### PR TITLE
refactor: drop app name suffix from document title

### DIFF
--- a/src/app/layouts/page-title.tsx
+++ b/src/app/layouts/page-title.tsx
@@ -1,4 +1,3 @@
-import { APP_NAME } from "@app/app-info";
 import { useSetPageTitle } from "./page-title-store";
 
 export interface PageTitleProps {
@@ -7,9 +6,10 @@ export interface PageTitleProps {
 
 export function PageTitle({ children }: PageTitleProps) {
   useSetPageTitle(children);
+
   if (!children) {
     return null;
   }
 
-  return <title>{`${children} | ${APP_NAME}`}</title>;
+  return <title>{children}</title>;
 }


### PR DESCRIPTION
## Summary
- Render the bare page title in `PageTitle` instead of `${children} | APP_NAME`
- Remove the now-unused `APP_NAME` import

🤖 Generated with [Claude Code](https://claude.com/claude-code)