### PR TITLE
feat: reveal board set list actions on hover (md+)

### DIFF
--- a/src/features/board/board-sets/board-set-list.tsx
+++ b/src/features/board/board-sets/board-set-list.tsx
@@ -1,6 +1,7 @@
 import DeleteOutlinedIcon from "@mui/icons-material/DeleteOutlined";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
+import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
@@ -35,6 +36,7 @@ export function BoardSetList({
   } | null>(null);
 
   const menuOpen = Boolean(menuAnchor);
+  const activeMenuSetId = menuAnchor?.boardSet.setId;
 
   function handleMenuOpen(
     event: React.MouseEvent<HTMLElement>,
@@ -65,35 +67,71 @@ export function BoardSetList({
 
   return (
     <>
-      <List sx={{ px: 1 }}>
-        {boardSets.map((boardSet) => (
-          <ListItem
-            disablePadding
-            key={boardSet.setId}
-            secondaryAction={
-              <Tooltip title={m.libraryMoreOptions()}>
-                <IconButton
-                  edge="end"
-                  aria-label={m.libraryMoreOptionsFor({ name: boardSet.name })}
-                  aria-controls={menuOpen ? "board-set-menu" : undefined}
-                  aria-haspopup="menu"
-                  aria-expanded={menuOpen ? "true" : undefined}
-                  onClick={(event) => handleMenuOpen(event, boardSet)}
-                >
-                  <MoreVertIcon />
-                </IconButton>
-              </Tooltip>
-            }
-          >
-            <ListItemButton
-              selected={boardSet.setId === selectedSetId}
-              onClick={() => onSelect(boardSet)}
-              sx={{ borderRadius: 6 }}
+      <List
+        sx={(theme) => ({
+          px: 1,
+          "@media (hover: hover)": {
+            [theme.breakpoints.up("md")]: {
+              "& .MuiListItemSecondaryAction-root": {
+                opacity: 0,
+                pointerEvents: "none",
+                transition: theme.transitions.create("opacity", {
+                  duration: theme.transitions.duration.shortest,
+                }),
+              },
+              "& .MuiListItem-root:is(:hover, :focus-within, [data-menu-open]) .MuiListItemSecondaryAction-root":
+                { opacity: 1, pointerEvents: "auto" },
+            },
+          },
+        })}
+      >
+        {boardSets.map((boardSet) => {
+          const isMenuOpen = activeMenuSetId === boardSet.setId;
+
+          return (
+            <ListItem
+              disablePadding
+              key={boardSet.setId}
+              data-menu-open={isMenuOpen || undefined}
+              secondaryAction={
+                <Tooltip title={m.libraryMoreOptions()}>
+                  <IconButton
+                    edge="end"
+                    aria-label={m.libraryMoreOptionsFor({
+                      name: boardSet.name,
+                    })}
+                    aria-controls={isMenuOpen ? "board-set-menu" : undefined}
+                    aria-haspopup="menu"
+                    aria-expanded={isMenuOpen ? "true" : undefined}
+                    onClick={(event) => handleMenuOpen(event, boardSet)}
+                  >
+                    <MoreVertIcon />
+                  </IconButton>
+                </Tooltip>
+              }
             >
-              <ListItemText primary={boardSet.name} />
-            </ListItemButton>
-          </ListItem>
-        ))}
+              <ListItemButton
+                selected={boardSet.setId === selectedSetId}
+                onClick={() => onSelect(boardSet)}
+                sx={{ borderRadius: 6 }}
+              >
+                <ListItemText
+                  primary={
+                    <Box
+                      sx={{
+                        whiteSpace: "nowrap",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                      }}
+                    >
+                      {boardSet.name}
+                    </Box>
+                  }
+                />
+              </ListItemButton>
+            </ListItem>
+          );
+        })}
       </List>
 
       <Menu


### PR DESCRIPTION
## What

On **md+ hover-capable screens**, each board set's more-options (⋮) button stays hidden until the row is **hovered**, **focused** (keyboard/`:focus-within`), or its menu is open. On touch devices and small screens (below `md`) the button stays visible as before, since there's no hover.

## Why

The library drawer is persistent on `md+`, so always-visible action buttons add clutter to every row. Revealing them on interaction keeps the list clean on desktop while staying fully usable on touch.

## How

- Reveal is pure CSS on the `List`, gated by `@media (hover: hover)` + `theme.breakpoints.up("md")`, targeting MUI's own `.MuiListItemSecondaryAction-root` wrapper (no custom class to keep in sync).
- `opacity` transition keeps the button in the tab order so keyboard users reach it and `:focus-within` reveals it; `pointer-events: none` while hidden so it can't be clicked before it's visible, restored to `auto` on reveal.
- `aria-controls`/`aria-expanded` now derive from per-row state, so only the row whose menu is open reports `expanded` (previously a global flag marked every row).
- Also truncates long board set names with an ellipsis.

## Testing

- `npm run lint` — clean
- `npm test` — 437 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)