### PR TITLE
feat: add icon to enable suggestions chip

### DIFF
--- a/src/features/board/suggestions/suggestion-status.tsx
+++ b/src/features/board/suggestions/suggestion-status.tsx
@@ -1,3 +1,4 @@
+import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import Chip from "@mui/material/Chip";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
@@ -26,8 +27,8 @@ function statusMessage(status: SuggestionStatusView, onEnable: () => void) {
     case "needs-activation":
       return (
         <Chip
+          icon={<AutoAwesomeIcon />}
           label={m.suggestionsEnable()}
-          variant="outlined"
           color="primary"
           onClick={onEnable}
         />


### PR DESCRIPTION
## Summary
- Add an `AutoAwesome` icon to the "Enable suggestions" chip
- Switch the chip from outlined to filled primary so the call-to-action reads as the AI affordance it is

## Test plan
- [x] `npm run lint`
- [ ] Verify the chip renders with the icon in the suggestions status area

🤖 Generated with [Claude Code](https://claude.com/claude-code)