### PR TITLE
feat: use library-add icon for the import boards button

### DIFF
--- a/src/features/board/board-sets/board-set-library.tsx
+++ b/src/features/board/board-sets/board-set-library.tsx
@@ -1,4 +1,4 @@
-import AddIcon from "@mui/icons-material/Add";
+import LibraryAddOutlinedIcon from "@mui/icons-material/LibraryAddOutlined";
 import FilterNoneOutlinedIcon from "@mui/icons-material/FilterNoneOutlined";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -78,7 +78,7 @@ export function BoardSetLibrary({
           action={
             <Button
               variant="contained"
-              startIcon={<AddIcon />}
+              startIcon={<LibraryAddOutlinedIcon />}
               onClick={() => void pickAndImportBoardFiles()}
             >
               {m.libraryImportBoards()}
@@ -102,7 +102,7 @@ export function BoardSetLibrary({
       >
         <Button
           variant="text"
-          startIcon={<AddIcon />}
+          startIcon={<LibraryAddOutlinedIcon />}
           onClick={() => void pickAndImportBoardFiles()}
         >
           {m.libraryImportBoards()}


### PR DESCRIPTION
Swap the generic `Add` ("+") icon on the **Import boards** button for `LibraryAddOutlined`, in both the empty state and the list header. It ties the action to the library the boards land in (and matches the feature's existing `Outlined` icon style) rather than reading as a bare plus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)