### PR TITLE
refactor: remove the icon from the library empty state

### DIFF
--- a/src/features/board/board-sets/board-set-library.tsx
+++ b/src/features/board/board-sets/board-set-library.tsx
@@ -1,5 +1,4 @@
 import LibraryAddOutlinedIcon from "@mui/icons-material/LibraryAddOutlined";
-import FilterNoneOutlinedIcon from "@mui/icons-material/FilterNoneOutlined";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
@@ -72,7 +71,6 @@ export function BoardSetLibrary({
     return (
       <Box sx={{ px: 2, height: "100%" }}>
         <EmptyState
-          icon={<FilterNoneOutlinedIcon />}
           title={m.libraryEmptyTitle()}
           description={m.libraryEmptyDescription()}
           action={


### PR DESCRIPTION
Drops the `FilterNoneOutlined` icon (and its import) from the library **EmptyState**, leaving the title, description, and import action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)