### PR TITLE
feat: increase minimum grid cell size to 96px

### DIFF
--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -1,7 +1,7 @@
 import Stack from "@mui/material/Stack";
 import { useGridKeyboard } from "./use-grid-keyboard";
 
-const MIN_CELL_PX = 72;
+const MIN_CELL_PX = 96;
 const PADDING = 2;
 
 export interface GridItemProps {


### PR DESCRIPTION
## Summary
- Bump `MIN_CELL_PX` in the board grid from `72` to `96`, enlarging the minimum size of each board cell.

## Why
- Larger minimum cells improve touch target size and symbol legibility on the AAC board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)