### PR TITLE
refactor: always show app header

### DIFF
--- a/src/app/layouts/app-header.tsx
+++ b/src/app/layouts/app-header.tsx
@@ -22,18 +22,7 @@ export function AppHeader({
   const pageTitle = usePageTitle();
 
   return (
-    <AppBar
-      position="static"
-      sx={[
-        (theme) => ({
-          [theme.breakpoints.down("md")]: {
-            "@media (orientation: landscape)": {
-              display: "none",
-            },
-          },
-        }),
-      ]}
-    >
+    <AppBar position="static">
       <Toolbar>
         {!libraryButtonHidden && (
           <Tooltip title={m.libraryOpen()}>


### PR DESCRIPTION
## Summary
- Remove the `sx` rule that hid the `AppBar` on small screens in landscape orientation, so the app header is now always shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)