### PR TITLE
refactor: deep-review polish across boards, speech, and onboarding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "react": "^19.2.7",
         "react-aria": "^3.49.0",
         "react-dom": "^19.2.7",
-        "react-router": "^7.17.0",
+        "react-router": "^8.0.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -4734,18 +4734,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -7956,20 +7949,19 @@
       "license": "MIT"
     },
     "node_modules/react-router": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
-      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.0.0.tgz",
+      "integrity": "sha512-AyS7LUn9M3g2/IBJDJNpWqElaQjPVBHGgMsdLGee6B2JLwP9STSpRwN8N4SauOeFTb0X5ZN0wxa1Iek78jF8Iw==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
@@ -8336,12 +8328,6 @@
       "engines": {
         "node": ">=20.0.0"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react": "^19.2.7",
     "react-aria": "^3.49.0",
     "react-dom": "^19.2.7",
-    "react-router": "^7.17.0",
+    "react-router": "^8.0.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/src/app/layouts/app-shell.test.tsx
+++ b/src/app/layouts/app-shell.test.tsx
@@ -32,9 +32,5 @@ describe("AppShell", () => {
     await expect
       .element(screen.getByRole("dialog", { name: "AAC Board AI" }))
       .not.toBeInTheDocument();
-
-    // Test files share localStorage; clear or the flag leaks into other
-    // files' import-time store reads.
-    localStorage.clear();
   });
 });

--- a/src/app/layouts/drawer-width.ts
+++ b/src/app/layouts/drawer-width.ts
@@ -1,0 +1,1 @@
+export const DRAWER_BASE_WIDTH = "320px";

--- a/src/app/library/library-drawer.tsx
+++ b/src/app/library/library-drawer.tsx
@@ -23,8 +23,8 @@ export function LibraryDrawer({
   variant = "temporary",
 }: LibraryDrawerProps) {
   const navigate = useNavigate();
-  const activeSetId = useMatches().find((match) => match.params.setId)?.params
-    .setId;
+  const activeMatch = useMatches().find((match) => match.params.setId);
+  const activeSetId = activeMatch?.params.setId;
 
   const closeOnNavigate = variant === "temporary" ? onClose : undefined;
 
@@ -52,7 +52,7 @@ export function LibraryDrawer({
           },
         })}
       >
-        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+        <Typography component="h2" variant="h6" sx={{ flexGrow: 1 }}>
           {m.libraryTitle()}
         </Typography>
 

--- a/src/app/library/library-drawer.tsx
+++ b/src/app/library/library-drawer.tsx
@@ -1,3 +1,4 @@
+import { DRAWER_BASE_WIDTH } from "@app/layouts/drawer-width";
 import { BoardSetLibrary, boardSetPath } from "@features/board";
 import CloseIcon from "@mui/icons-material/Close";
 import Box from "@mui/material/Box";
@@ -9,7 +10,7 @@ import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
 import { useMatches, useNavigate } from "react-router";
 
-export const LIBRARY_DRAWER_WIDTH = "calc(320px + env(safe-area-inset-left))";
+export const LIBRARY_DRAWER_WIDTH = `calc(${DRAWER_BASE_WIDTH} + env(safe-area-inset-left))`;
 
 export interface LibraryDrawerProps {
   open: boolean;

--- a/src/app/onboarding/onboarding-dialog.tsx
+++ b/src/app/onboarding/onboarding-dialog.tsx
@@ -24,24 +24,31 @@ export interface OnboardingDialogProps {
 export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
   const fullScreen = useMediaQuery((theme) => theme.breakpoints.down("sm"));
 
-  const highlights: { icon: ReactNode; primary: string; secondary: string }[] =
-    [
-      {
-        icon: <AutoAwesomeOutlinedIcon color="primary" fontSize="large" />,
-        primary: m.onboardingSmartRewritingTitle(),
-        secondary: m.onboardingSmartRewritingDescription(),
-      },
-      {
-        icon: <TranslateOutlinedIcon color="primary" fontSize="large" />,
-        primary: m.onboardingTranslationTitle(),
-        secondary: m.onboardingTranslationDescription(),
-      },
-      {
-        icon: <LockOutlinedIcon color="primary" fontSize="large" />,
-        primary: m.onboardingPrivacyTitle(),
-        secondary: m.onboardingPrivacyDescription(),
-      },
-    ];
+  const highlights: {
+    id: string;
+    icon: ReactNode;
+    primary: string;
+    secondary: string;
+  }[] = [
+    {
+      id: "rewriting",
+      icon: <AutoAwesomeOutlinedIcon color="primary" fontSize="large" />,
+      primary: m.onboardingSmartRewritingTitle(),
+      secondary: m.onboardingSmartRewritingDescription(),
+    },
+    {
+      id: "translation",
+      icon: <TranslateOutlinedIcon color="primary" fontSize="large" />,
+      primary: m.onboardingTranslationTitle(),
+      secondary: m.onboardingTranslationDescription(),
+    },
+    {
+      id: "privacy",
+      icon: <LockOutlinedIcon color="primary" fontSize="large" />,
+      primary: m.onboardingPrivacyTitle(),
+      secondary: m.onboardingPrivacyDescription(),
+    },
+  ];
 
   return (
     <Dialog
@@ -50,8 +57,8 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
       fullScreen={fullScreen}
       fullWidth
       maxWidth="xs"
-      aria-labelledby="welcome-dialog-title"
-      aria-describedby="welcome-dialog-description"
+      aria-labelledby="onboarding-dialog-title"
+      aria-describedby="onboarding-dialog-description"
       slotProps={{
         paper: {
           sx: {
@@ -62,7 +69,7 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
       }}
     >
       <DialogTitle
-        id="welcome-dialog-title"
+        id="onboarding-dialog-title"
         variant="h4"
         sx={{
           textAlign: "center",
@@ -76,7 +83,7 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
 
       <DialogContent sx={{ pt: 0, pb: 4 }}>
         <DialogContentText
-          id="welcome-dialog-description"
+          id="onboarding-dialog-description"
           variant="body1"
           sx={{ textAlign: "center", mb: 3, px: 2 }}
         >
@@ -86,7 +93,7 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
         <List sx={{ py: 0 }}>
           {highlights.map((highlight) => (
             <ListItem
-              key={highlight.primary}
+              key={highlight.id}
               disableGutters
               sx={{ alignItems: "flex-start" }}
             >

--- a/src/app/routing/app-routes.tsx
+++ b/src/app/routing/app-routes.tsx
@@ -5,7 +5,7 @@ import { rootIndexLoader } from "@app/routing/loaders/root-index-loader";
 import { RouteErrorBoundary } from "@app/routing/route-error-boundary";
 import { BOARD_PATTERN, BOARD_SET_PATTERN } from "@features/board";
 import { LoadingState } from "@shared/components/loading-state";
-import { type RouteObject } from "react-router";
+import type { RouteObject } from "react-router";
 
 export const appRoutes: RouteObject[] = [
   {
@@ -23,7 +23,7 @@ export const appRoutes: RouteObject[] = [
               {
                 path: BOARD_PATTERN,
                 loader: boardLoader,
-                lazy: async () => import("@pages/board-page"),
+                lazy: () => import("@pages/board-page"),
               },
             ],
           },

--- a/src/app/settings/settings-drawer.tsx
+++ b/src/app/settings/settings-drawer.tsx
@@ -1,4 +1,6 @@
+import { DRAWER_BASE_WIDTH } from "@app/layouts/drawer-width";
 import CloseIcon from "@mui/icons-material/Close";
+import Box from "@mui/material/Box";
 import Divider from "@mui/material/Divider";
 import Drawer from "@mui/material/Drawer";
 import IconButton from "@mui/material/IconButton";
@@ -29,7 +31,7 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
           "aria-label": m.settingsTitle(),
           sx: [
             {
-              width: "calc(320px + env(safe-area-inset-right))",
+              width: `calc(${DRAWER_BASE_WIDTH} + env(safe-area-inset-right))`,
             },
             (theme) => ({
               [theme.breakpoints.up("sm")]: {
@@ -64,7 +66,7 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
         </Tooltip>
       </Toolbar>
 
-      <Stack
+      <Box
         sx={[
           { px: 3, pb: 3 },
           (theme) => ({
@@ -90,7 +92,7 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
         <Divider sx={{ my: 3 }} />
 
         <AISettings />
-      </Stack>
+      </Box>
     </Drawer>
   );
 }

--- a/src/app/settings/settings-drawer.tsx
+++ b/src/app/settings/settings-drawer.tsx
@@ -47,7 +47,7 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
           },
         })}
       >
-        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+        <Typography component="h2" variant="h6" sx={{ flexGrow: 1 }}>
           {m.settingsTitle()}
         </Typography>
 

--- a/src/features/board/import/board-import.ts
+++ b/src/features/board/import/board-import.ts
@@ -129,7 +129,6 @@ function buildAssetInputs(
 
       return {
         path,
-        mime: mimeType,
         blob: new Blob([buffer as Uint8Array<ArrayBuffer>], { type: mimeType }),
       };
     });

--- a/src/features/board/keyboard/use-board-keyboard.test.tsx
+++ b/src/features/board/keyboard/use-board-keyboard.test.tsx
@@ -1,4 +1,8 @@
-import { stubAudio, stubSpeech } from "@shared/testing/device-output";
+import {
+  preventSpeechEnd,
+  stubAudio,
+  stubSpeech,
+} from "@shared/testing/device-output";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { userEvent } from "vitest/browser";
 import { renderBoardViewer, TWO_TILE_BOARD } from "../test-utils";
@@ -59,5 +63,24 @@ describe("board keyboard shortcuts", () => {
       expect(speech.speak.mock.calls).toHaveLength(1);
       expect(speech.speak.mock.calls[0][0].text).toBe("hello world");
     });
+  });
+
+  test("Escape stops playback in progress", async () => {
+    const screen = await renderBoardViewer(TWO_TILE_BOARD);
+    await screen.getByRole("button", { name: "hello" }).click();
+
+    preventSpeechEnd(speech.speak);
+
+    await screen.getByRole("button", { name: "Play message" }).click();
+    await expect
+      .element(screen.getByRole("button", { name: "Stop" }))
+      .toBeVisible();
+
+    screen.getByRole("button", { name: "world" }).element().focus();
+    await userEvent.keyboard("{Escape}");
+
+    await expect
+      .element(screen.getByRole("button", { name: "Play message" }))
+      .toBeVisible();
   });
 });

--- a/src/features/board/message/message-bar.test.tsx
+++ b/src/features/board/message/message-bar.test.tsx
@@ -1,0 +1,183 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+  type MockInstance,
+} from "vitest";
+import { render } from "vitest-browser-react";
+import { MessageBar, type MessageBarProps } from "./message-bar";
+import type { MessagePart } from "./use-message";
+
+function createProps(
+  overrides: Partial<MessageBarProps> = {},
+): MessageBarProps {
+  return {
+    parts: [],
+    activePartId: null,
+    isPlaying: false,
+    onBackspacePress: vi.fn(),
+    onBackspaceLongPress: vi.fn(),
+    onPlayClick: vi.fn(),
+    onStopClick: vi.fn(),
+    ...overrides,
+  };
+}
+
+let scrollIntoView: MockInstance<Element["scrollIntoView"]>;
+
+function lastScrollCall() {
+  const { calls, contexts } = scrollIntoView.mock;
+  const index = calls.length - 1;
+  return {
+    options: calls[index][0] as ScrollIntoViewOptions,
+    element: contexts[index] as Element,
+  };
+}
+
+beforeEach(() => {
+  scrollIntoView = vi
+    .spyOn(Element.prototype, "scrollIntoView")
+    .mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("MessageBar", () => {
+  test("renders a label for each message part", async () => {
+    const parts: MessagePart[] = [
+      { id: "a", label: "I" },
+      { id: "b", label: "want" },
+      { id: "c", label: "water" },
+    ];
+
+    const screen = await render(<MessageBar {...createProps({ parts })} />);
+
+    await expect.element(screen.getByText("I")).toBeVisible();
+    await expect.element(screen.getByText("want")).toBeVisible();
+    await expect.element(screen.getByText("water")).toBeVisible();
+  });
+
+  describe("scroll-into-view", () => {
+    test("scrolls the newest part to the trailing edge when a part is added", async () => {
+      const screen = await render(
+        <MessageBar {...createProps({ parts: [] })} />,
+      );
+
+      expect(scrollIntoView).not.toHaveBeenCalled();
+
+      await screen.rerender(
+        <MessageBar
+          {...createProps({
+            parts: [
+              { id: "a", label: "I" },
+              { id: "b", label: "want" },
+            ],
+          })}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(scrollIntoView).toHaveBeenCalled();
+        const { options, element } = lastScrollCall();
+        expect(options).toEqual({
+          block: "nearest",
+          inline: "end",
+          behavior: "instant",
+        });
+        expect(element.textContent).toContain("want");
+      });
+    });
+
+    test("scrolls the active part into view when it changes during playback", async () => {
+      const parts: MessagePart[] = [
+        { id: "a", label: "I" },
+        { id: "b", label: "want" },
+        { id: "c", label: "water" },
+      ];
+
+      const screen = await render(<MessageBar {...createProps({ parts })} />);
+
+      // Drain the mount-time scroll-to-end so only the active-part scroll remains.
+      await vi.waitFor(() => expect(scrollIntoView).toHaveBeenCalled());
+      scrollIntoView.mockClear();
+
+      // Same `parts` reference: the append effect stays put, isolating the
+      // active-part effect we are asserting on.
+      await screen.rerender(
+        <MessageBar {...createProps({ parts, activePartId: "b" })} />,
+      );
+
+      await vi.waitFor(() => {
+        expect(scrollIntoView).toHaveBeenCalled();
+        const { options, element } = lastScrollCall();
+        expect(options).toEqual({
+          block: "nearest",
+          inline: "nearest",
+          behavior: "instant",
+        });
+        expect(element.textContent).toContain("want");
+      });
+    });
+
+    test("performs no active-part scroll while idle", async () => {
+      const parts: MessagePart[] = [
+        { id: "a", label: "I" },
+        { id: "b", label: "want" },
+      ];
+
+      await render(
+        <MessageBar {...createProps({ parts, activePartId: null })} />,
+      );
+
+      await vi.waitFor(() => expect(scrollIntoView).toHaveBeenCalled());
+
+      const scrolledToActive = scrollIntoView.mock.calls.some(
+        ([options]) => (options as ScrollIntoViewOptions).inline === "nearest",
+      );
+      expect(scrolledToActive).toBe(false);
+    });
+  });
+
+  describe("controls", () => {
+    test("delegates a backspace press to onBackspacePress", async () => {
+      const onBackspacePress = vi.fn();
+
+      const screen = await render(
+        <MessageBar {...createProps({ onBackspacePress })} />,
+      );
+
+      await screen.getByRole("button", { name: "Backspace" }).click();
+
+      expect(onBackspacePress).toHaveBeenCalledTimes(1);
+    });
+
+    test("delegates play to onPlayClick while idle", async () => {
+      const onPlayClick = vi.fn();
+
+      const screen = await render(
+        <MessageBar {...createProps({ isPlaying: false, onPlayClick })} />,
+      );
+
+      await screen.getByRole("button", { name: "Play message" }).click();
+
+      expect(onPlayClick).toHaveBeenCalledTimes(1);
+    });
+
+    test("delegates stop to onStopClick while playing", async () => {
+      const onStopClick = vi.fn();
+
+      const screen = await render(
+        <MessageBar {...createProps({ isPlaying: true, onStopClick })} />,
+      );
+
+      await screen.getByRole("button", { name: "Stop" }).click();
+
+      expect(onStopClick).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/features/board/message/message-bar.tsx
+++ b/src/features/board/message/message-bar.tsx
@@ -71,7 +71,7 @@ export function MessageBar({
         sx={[
           {
             height: 104,
-            flexGrow: 2,
+            flexGrow: 1,
             gap: 2,
             paddingInlineEnd: 2,
             borderRadius: 16,

--- a/src/features/board/message/playback/use-message-playback.test.ts
+++ b/src/features/board/message/playback/use-message-playback.test.ts
@@ -143,7 +143,7 @@ describe("useMessagePlayback", () => {
     await playPromise;
   });
 
-  test("swallows playback errors and still resets isPlaying to false", async () => {
+  test("resets isPlaying to false after a speech error", async () => {
     speech.speak.mockImplementationOnce((utterance) => {
       queueMicrotask(() => {
         utterance.onerror?.({

--- a/src/features/board/message/playback/use-message-playback.ts
+++ b/src/features/board/message/playback/use-message-playback.ts
@@ -53,8 +53,6 @@ export function useMessagePlayback(
             assertNever(step);
         }
       }
-    } catch {
-      // Failure is surfaced by the reset in finally.
     } finally {
       if (!signal.aborted) {
         setIsPlaying(false);

--- a/src/features/board/obf/obf-to-board.test.ts
+++ b/src/features/board/obf/obf-to-board.test.ts
@@ -253,6 +253,20 @@ describe("obfToBoard", () => {
       ]);
     });
 
+    test("treats an explicit empty actions array as no actions, ignoring action", () => {
+      const obfBoard: OBFBoard = {
+        format: "open-board-0.1",
+        id: "board-actions-empty-array",
+        buttons: [
+          { id: "btn-1", label: "Speak", action: ":speak", actions: [] },
+        ],
+        grid: { rows: 1, columns: 1, order: [["btn-1"]] },
+      };
+
+      const board = obfToBoard(obfBoard);
+      expect(board.buttons[0]?.actions).toEqual([]);
+    });
+
     test("falls back to the single action when actions is absent", () => {
       const obfBoard: OBFBoard = {
         format: "open-board-0.1",

--- a/src/features/board/obf/obf-to-board.ts
+++ b/src/features/board/obf/obf-to-board.ts
@@ -86,10 +86,11 @@ function transformButton(
 }
 
 function collectActions(obfButton: OBFButton): BoardAction[] {
-  const raw = obfButton.actions ?? (obfButton.action ? [obfButton.action] : []);
+  const rawActions =
+    obfButton.actions ?? (obfButton.action ? [obfButton.action] : []);
 
-  return raw.flatMap((value) => {
-    const action = parseAction(value);
+  return rawActions.flatMap((raw) => {
+    const action = parseAction(raw);
 
     return action ? [action] : [];
   });

--- a/src/features/board/storage/board-hydration.test.ts
+++ b/src/features/board/storage/board-hydration.test.ts
@@ -41,9 +41,7 @@ async function seedTestBoard(): Promise<void> {
   await putBoards(SET_ID, [
     { boardId: BOARD_ID, name: "Test Board", obf: obfBoard },
   ]);
-  await putAssets(SET_ID, [
-    { path: IMAGE_PATH, blob: pngBlob, mime: "image/png" },
-  ]);
+  await putAssets(SET_ID, [{ path: IMAGE_PATH, blob: pngBlob }]);
 
   await invalidateBoardSets();
 }

--- a/src/features/board/storage/boards-db.test.ts
+++ b/src/features/board/storage/boards-db.test.ts
@@ -191,9 +191,7 @@ describe("putAssets and getAssetBlob", () => {
     await upsertBoardSet(makeBoardSetInput());
 
     const blob = new Blob(["hello"], { type: "text/plain" });
-    await putAssets("set-1", [
-      { path: "images/logo.png", blob, mime: "image/png" },
-    ]);
+    await putAssets("set-1", [{ path: "images/logo.png", blob }]);
 
     const retrieved = await getAssetBlob("set-1", "images/logo.png");
     expect(retrieved).toBeInstanceOf(Blob);
@@ -225,18 +223,6 @@ describe("putAssets and getAssetBlob", () => {
 
     const blob = await getAssetBlob("set-1", "nope.png");
     expect(blob).toBeUndefined();
-  });
-
-  test("stores asset size from blob when not explicitly provided", async () => {
-    await upsertBoardSet(makeBoardSetInput());
-
-    const blob = new Blob(["12345"]);
-    await putAssets("set-1", [{ path: "file.bin", blob }]);
-
-    const db = await getBoardsDB();
-    const record = await db.get("assets", ["set-1", "file.bin"]);
-    assertDefined(record);
-    expect(record.size).toBe(5);
   });
 });
 

--- a/src/features/board/storage/boards-db.ts
+++ b/src/features/board/storage/boards-db.ts
@@ -27,8 +27,6 @@ export interface AssetRecord {
   setId: string;
   path: string;
   blob: Blob;
-  mime?: string;
-  size?: number;
 }
 
 export class BoardNotFoundError extends Error {
@@ -59,8 +57,6 @@ export interface UpsertBoardInput {
 export interface UpsertAssetInput {
   path: string;
   blob: Blob;
-  mime?: string;
-  size?: number;
 }
 
 interface BoardsDBSchema extends DBSchema {
@@ -296,8 +292,6 @@ export async function putAssets(
         setId,
         path: normalizePath(asset.path),
         blob: asset.blob,
-        mime: asset.mime,
-        size: asset.size ?? asset.blob.size,
       }),
     ),
   );

--- a/src/features/board/storage/boards-db.ts
+++ b/src/features/board/storage/boards-db.ts
@@ -99,9 +99,13 @@ function normalizePath(rawPath: string): string {
   return normalized;
 }
 
+const MAX_ID_LENGTH = 255;
+
 function validateId(id: string, fieldName: string): void {
-  if (!id || id.length > 255) {
-    throw new Error(`Invalid ${fieldName}: must be 1-255 characters`);
+  if (!id || id.length > MAX_ID_LENGTH) {
+    throw new Error(
+      `Invalid ${fieldName}: must be 1-${MAX_ID_LENGTH} characters`,
+    );
   }
 }
 
@@ -186,12 +190,7 @@ export async function getBoardSet(
 
 export async function listBoardSets(): Promise<BoardSetRecord[]> {
   const db = await getBoardsDB();
-  const tx = db.transaction("boardSets", "readonly");
-  const index = tx.store.index("byUpdatedAt");
-
-  const boardSets = await index.getAll();
-
-  await tx.done;
+  const boardSets = await db.getAllFromIndex("boardSets", "byUpdatedAt");
 
   return boardSets.reverse();
 }

--- a/src/features/board/suggestions/derive-suggestion-status.ts
+++ b/src/features/board/suggestions/derive-suggestion-status.ts
@@ -13,7 +13,7 @@ export interface EngineCondition {
 }
 
 export interface SuggestionStatusInput {
-  engines: EngineCondition[];
+  engines: readonly EngineCondition[];
   downloadProgress: number | null;
   hasText: boolean;
   isPending: boolean;

--- a/src/features/board/translation/resolve-translated-board.ts
+++ b/src/features/board/translation/resolve-translated-board.ts
@@ -19,6 +19,11 @@ export async function resolveTranslatedBoard(
     return existing;
   }
 
+  const phrases = collectTranslatableStrings(board);
+  if (phrases.size === 0) {
+    return board;
+  }
+
   try {
     const translator = await createTranslator({
       sourceLanguage: getBoardLanguage(board),
@@ -27,7 +32,6 @@ export async function resolveTranslatedBoard(
     });
 
     try {
-      const phrases = collectTranslatableStrings(board);
       const translations = await translatePhrases(phrases, translator, signal);
 
       void persistTranslations(setId, board.id, language, translations);
@@ -37,10 +41,8 @@ export async function resolveTranslatedBoard(
       translator.destroy();
     }
   } catch {
-    // Deliberately total: the board must render no matter what — pictograms
-    // carry the meaning. With no telemetry, rethrowing a bug here would only
-    // trade the user's communication surface for an error page nobody hears
-    // about.
+    // Total by design: translation is an enhancement, not a requirement —
+    // pictograms carry the meaning, so a failure must never block the board.
     return board;
   }
 }

--- a/src/shared/audio/play-audio.test.ts
+++ b/src/shared/audio/play-audio.test.ts
@@ -53,21 +53,21 @@ describe("playAudio", () => {
     expect(audio.play).not.toHaveBeenCalled();
   });
 
-  test("rejects when the element reports a media error", async () => {
+  test("resolves when the element reports a media error", async () => {
     audio.play.mockImplementation(function (this: HTMLAudioElement) {
       queueMicrotask(() => this.dispatchEvent(new Event("error")));
 
       return Promise.resolve();
     });
 
-    await expect(playAudio("boom.mp3")).rejects.toThrow();
+    await expect(playAudio("boom.mp3")).resolves.toBeUndefined();
   });
 
-  test("rejects when playback is blocked", async () => {
+  test("resolves when playback is blocked", async () => {
     audio.play.mockImplementation(() =>
       Promise.reject(new Error("NotAllowedError")),
     );
 
-    await expect(playAudio("a.mp3")).rejects.toThrow("NotAllowedError");
+    await expect(playAudio("a.mp3")).resolves.toBeUndefined();
   });
 });

--- a/src/shared/audio/play-audio.ts
+++ b/src/shared/audio/play-audio.ts
@@ -14,11 +14,11 @@ export function playAudio(
 
   stopCurrent?.();
 
-  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  const { promise, resolve } = Promise.withResolvers<void>();
   const audio = new Audio(url);
   let settled = false;
 
-  function finish(outcome: () => void) {
+  function finish() {
     if (settled) {
       return;
     }
@@ -27,34 +27,22 @@ export function playAudio(
     audio.onended = null;
     audio.onerror = null;
     audio.pause();
-    signal?.removeEventListener("abort", stop);
+    signal?.removeEventListener("abort", finish);
 
-    if (stopCurrent === stop) {
+    if (stopCurrent === finish) {
       stopCurrent = null;
     }
 
-    outcome();
+    resolve();
   }
 
-  function stop() {
-    finish(resolve);
-  }
+  audio.onended = finish;
+  audio.onerror = finish;
 
-  audio.onended = () => finish(resolve);
-  audio.onerror = () => {
-    finish(() =>
-      reject(new Error(audio.error?.message ?? "audio playback failed")),
-    );
-  };
+  signal?.addEventListener("abort", finish, { once: true });
+  stopCurrent = finish;
 
-  signal?.addEventListener("abort", stop, { once: true });
-  stopCurrent = stop;
-
-  audio.play().catch((error: unknown) => {
-    finish(() =>
-      reject(error instanceof Error ? error : new Error(String(error))),
-    );
-  });
+  audio.play().catch(finish);
 
   return promise;
 }

--- a/src/shared/components/status-layout.tsx
+++ b/src/shared/components/status-layout.tsx
@@ -45,12 +45,13 @@ export function StatusLayout({
       )}
 
       <Box sx={{ my: 1 }}>
-        <Typography variant="h5" sx={{ fontWeight: "bold" }}>
+        <Typography component="p" variant="h5" sx={{ fontWeight: "bold" }}>
           {title}
         </Typography>
 
         {description && (
           <Typography
+            component="p"
             variant="subtitle1"
             sx={{ maxWidth: "sm", color: "text.secondary" }}
           >

--- a/src/shared/speech/speech-store.cancellation.test.ts
+++ b/src/shared/speech/speech-store.cancellation.test.ts
@@ -57,8 +57,8 @@ describe("speak() under cancellation", () => {
     expect(onBoundary).toHaveBeenCalledExactlyOnceWith(0);
   });
 
-  test.each(["canceled", "interrupted"] as const)(
-    "resolves when a superseded utterance reports '%s'",
+  test.each(["canceled", "interrupted", "synthesis-failed"] as const)(
+    "resolves when the utterance reports '%s' (speech is best-effort)",
     async (error) => {
       const promise = speak("hello");
 
@@ -67,14 +67,4 @@ describe("speak() under cancellation", () => {
       await expect(promise).resolves.toBeUndefined();
     },
   );
-
-  test("rejects when the utterance reports a genuine failure", async () => {
-    const promise = speak("hello");
-
-    spokenUtterance?.onerror?.({
-      error: "synthesis-failed",
-    } as SpeechSynthesisErrorEvent);
-
-    await expect(promise).rejects.toThrow("synthesis-failed");
-  });
 });

--- a/src/shared/speech/speech-store.ts
+++ b/src/shared/speech/speech-store.ts
@@ -3,7 +3,7 @@ import { createExternalStore } from "@shared/utils/external-store";
 import { getLanguageCode } from "@shared/utils/locale";
 import { useSyncExternalStore } from "react";
 
-export interface SpeechRange {
+export interface SpeechParamSpec {
   min: number;
   max: number;
   fallback: number;
@@ -28,18 +28,21 @@ interface VoiceCatalogState {
   voicesByLanguage: VoicesByLanguage;
 }
 
-export const SPEECH_RATE: SpeechRange = { min: 0.1, max: 2, fallback: 1 };
-export const SPEECH_PITCH: SpeechRange = { min: 0.1, max: 2, fallback: 1 };
-export const SPEECH_VOLUME: SpeechRange = { min: 0, max: 1, fallback: 1 };
+export const SPEECH_RATE: SpeechParamSpec = { min: 0.1, max: 2, fallback: 1 };
+export const SPEECH_PITCH: SpeechParamSpec = { min: 0.1, max: 2, fallback: 1 };
+export const SPEECH_VOLUME: SpeechParamSpec = { min: 0, max: 1, fallback: 1 };
 
-function clamp(value: unknown, { min, max, fallback }: SpeechRange): number {
+function clamp(
+  value: unknown,
+  { min, max, fallback }: SpeechParamSpec,
+): number {
   return typeof value === "number" && Number.isFinite(value)
     ? Math.min(Math.max(value, min), max)
     : fallback;
 }
 
 function parseConfig(raw: unknown): SpeechConfig {
-  const parsed = (raw ?? {}) as Partial<SpeechConfig>;
+  const parsed = (raw ?? {}) as Record<string, unknown>;
 
   return {
     voiceURI: typeof parsed.voiceURI === "string" ? parsed.voiceURI : null,

--- a/src/shared/speech/speech-store.ts
+++ b/src/shared/speech/speech-store.ts
@@ -121,8 +121,27 @@ export function speak(
     return Promise.resolve();
   }
 
-  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  const { promise, resolve } = Promise.withResolvers<void>();
   const utterance = buildUtterance(text);
+  let settled = false;
+
+  const onAbort = () => {
+    synthesis.cancel();
+    finish();
+  };
+
+  function finish() {
+    if (settled) {
+      return;
+    }
+
+    settled = true;
+    utterance.onend = null;
+    utterance.onerror = null;
+    utterance.onboundary = null;
+    signal?.removeEventListener("abort", onAbort);
+    resolve();
+  }
 
   if (onBoundary) {
     utterance.onboundary = (event) => {
@@ -132,23 +151,9 @@ export function speak(
     };
   }
 
-  utterance.onend = () => resolve();
-  utterance.onerror = (event) => {
-    if (event.error === "canceled" || event.error === "interrupted") {
-      resolve();
-    } else {
-      reject(new Error(event.error));
-    }
-  };
-
-  signal?.addEventListener(
-    "abort",
-    () => {
-      synthesis.cancel();
-      resolve();
-    },
-    { once: true },
-  );
+  utterance.onend = finish;
+  utterance.onerror = finish;
+  signal?.addEventListener("abort", onAbort, { once: true });
 
   synthesis.cancel();
   synthesis.speak(utterance);

--- a/src/shared/testing/device-output.ts
+++ b/src/shared/testing/device-output.ts
@@ -16,6 +16,12 @@ export function stubSpeech(): {
   return { speak, cancel };
 }
 
+export function preventSpeechEnd(
+  speak: MockInstance<SpeechSynthesis["speak"]>,
+): void {
+  speak.mockImplementation(() => undefined);
+}
+
 export interface StubVoice {
   voiceURI: string;
   name: string;

--- a/src/shared/testing/global-setup.ts
+++ b/src/shared/testing/global-setup.ts
@@ -1,6 +1,9 @@
-import { beforeEach } from "vitest";
+import { afterEach, beforeEach } from "vitest";
 
-beforeEach(() => {
+function clearStorage() {
   localStorage.clear();
   sessionStorage.clear();
-});
+}
+
+beforeEach(clearStorage);
+afterEach(clearStorage);


### PR DESCRIPTION
## Summary

A batch of post-deep-review polish: small refactors, clearer names, tighter types, and added test coverage. No behavior changes intended beyond making speech/audio playback best-effort and skipping translator creation when nothing is translatable.

### Refactors
- **Drawers** — polish drawer components, extract shared `DRAWER_BASE_WIDTH` constant. Drawer titles are now proper `<h2>` section headings (fixes an `h1`→`h6` heading-order skip in the live app).
- **Onboarding** — stabilize highlight keys, align dialog ids.
- **Speech** — rename `SpeechRange` → `SpeechParamSpec`, parse config as an unknown record; make `speak`/`playAudio` best-effort and polish `speech-store`.
- **Boards DB** — name `MAX_ID_LENGTH`, simplify `listBoardSets`, drop redundant `mime`/`size` from `AssetRecord` (blob is the source of truth).
- **OBF** — clarify action variable names.
- **Translation** — skip translator creation when nothing is translatable.
- **Status layout** — render the empty/error state title and description as text (`<p>`), not headings. A transient placeholder isn't part of the document outline; this removes the context-dependent heading-level problem the `<h2>` drawer titles surfaced.
- **Types** — mark `deriveSuggestionStatus` engines input readonly; align `app-routes` type import and drop redundant `async`.

### Dependencies
- Upgrade react-router to v8.

### Tests
- Clear storage in `afterEach` for cross-file isolation.
- Cover OBF empty-actions semantics.
- Cover message-bar scroll-into-view effects and control wiring.
- Cover Escape stopping in-progress playback in board-keyboard.

## Test plan
- [x] `npm run lint`
- [x] `npm test` — 445 passed (67 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)