### PR TITLE
chore: bump version to 1.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aac-board-ai",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aac-board-ai",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aac-board-ai",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.11.0",
   "license": "MIT",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release **v1.11.0** — bumps `package.json` / `package-lock.json` from 1.10.0.

## What's in this release (since v1.10.0)

**Navigation**
- Menu drawer replaced by a **Library drawer**, persistent on md+ screens (#580, #582)
- Standalone Library and About page routes removed (#582)

**Layout / sizing**
- Minimum grid cell size 72px → **96px** (#587)
- App header now always shown (#588)
- Document title drops the app-name suffix (#577)

**Library polish**
- Hover-reveal board-set actions on md+, selected highlight, name truncation (#583)
- Import button uses the library-add icon (#585); empty-state icon removed (#586)
- Suggestions "enable" chip gained an icon (#584)

**Behavioral / internal**
- Translation short-circuits when a board has no translatable text
- Audio/speech playback errors resolve instead of rejecting
- Non-null assertions replaced with explicit guards (#573)
- `@shayc/open-board-format` 0.5.0 → 1.0.0 (#572, #576); eslint 10.5.0, eslint-react 5.9.0 (#575)

> ⚠️ Note: removing the About page also dropped the acknowledgments (Chrome Built-in AI Challenge 2025 win, Open Board Format / OpenAAC credits) and the "View on GitHub" link — they're no longer reachable in the UI. Confirm that's intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)