### PR TITLE
chore: bump react-aria to 3.50.0 and paraglide-js to 2.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "idb": "^8.0.3",
         "mrmime": "^2.0.1",
         "react": "^19.2.7",
-        "react-aria": "^3.49.0",
+        "react-aria": "^3.50.0",
         "react-dom": "^19.2.7",
         "react-router": "^8.0.0",
         "zod": "^4.4.3"
@@ -29,7 +29,7 @@
       "devDependencies": {
         "@babel/core": "^7.29.7",
         "@eslint/js": "^10.0.1",
-        "@inlang/paraglide-js": "^2.19.0",
+        "@inlang/paraglide-js": "^2.20.0",
         "@rolldown/plugin-babel": "^0.2.3",
         "@types/babel__core": "^7.20.5",
         "@types/dom-chromium-ai": "^0.0.17",
@@ -2144,9 +2144,9 @@
       }
     },
     "node_modules/@inlang/paraglide-js": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/@inlang/paraglide-js/-/paraglide-js-2.19.0.tgz",
-      "integrity": "sha512-aZOn6gM+shvWy24fiDUBZXL+rBLZ+IutSnnZd6WxFyJRaqFCgN/vqnDjWUSUZqBTRDhYiM9rGvOhpPV6r+cThA==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@inlang/paraglide-js/-/paraglide-js-2.20.0.tgz",
+      "integrity": "sha512-vI8PdPVZSnpYnpagjvm+nWSa3nMDRJKVM/2eLAtUHFrNcZZadxVdmP79r4W95+dkMLDFGEyzSSY9sFxvjdkkyQ==",
       "license": "MIT",
       "dependencies": {
         "@inlang/recommend-sherlock": "^0.2.1",
@@ -2622,9 +2622,9 @@
       }
     },
     "node_modules/@react-types/shared": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.35.0.tgz",
-      "integrity": "sha512-iNWvuzEwANttpQpdlu8nPBtdHb0mcCMj1ZTH//iRB5E/14IAnyRlR25rxH7pNLyzHINsPGEKnWvpwDMCT6vziQ==",
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.36.0.tgz",
+      "integrity": "sha512-DkP/H0C2YjjS7gZWKNqOmU8a16qHPjQNdzMwmTq9SzplM6Iw0kVMTZ0OIoe6FOgGqa+FwMsE2QbPjh/n3g/jXQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
@@ -7910,19 +7910,19 @@
       }
     },
     "node_modules/react-aria": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.49.0.tgz",
-      "integrity": "sha512-4+oK9FwJQWYhyA5zLfj/feOGY0zZbkE1muoF4gyxMroHVypjcYaRSTlJwvxph2zIlxt757KX6xIK2wJ5Aw1Kog==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.50.0.tgz",
+      "integrity": "sha512-S0Os6QZk33fzUAKu1QLT9afoUaCBt1ZNdoiq0n2YMVgKIdNIQS8zxiZ8O9hYE6QyDkHKjD6q39LQZ+qaSAIgjw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@internationalized/date": "^3.12.2",
         "@internationalized/number": "^3.6.7",
         "@internationalized/string": "^3.2.9",
-        "@react-types/shared": "^3.35.0",
+        "@react-types/shared": "^3.36.0",
         "@swc/helpers": "^0.5.0",
         "aria-hidden": "^1.2.3",
         "clsx": "^2.0.0",
-        "react-stately": "3.47.0",
+        "react-stately": "3.48.0",
         "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
@@ -7970,15 +7970,15 @@
       }
     },
     "node_modules/react-stately": {
-      "version": "3.47.0",
-      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.47.0.tgz",
-      "integrity": "sha512-H3ar+SOWP920EbVg7qWfP3fZjZiwhlEJAEJQqjt+w8oKijCwFgr0+R4941PIHscOXRNRvEOjvWilitImC0DdBg==",
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.48.0.tgz",
+      "integrity": "sha512-ImicSAG+lTotAe5izcs1fz49Zk48w7pDusqYg04WaPhCoej8BJ24soMu3iLXIrsi273s4P1gZrYGrqReMfgEEA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@internationalized/date": "^3.12.2",
         "@internationalized/number": "^3.6.7",
         "@internationalized/string": "^3.2.9",
-        "@react-types/shared": "^3.35.0",
+        "@react-types/shared": "^3.36.0",
         "@swc/helpers": "^0.5.0",
         "use-sync-external-store": "^1.6.0"
       },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "idb": "^8.0.3",
     "mrmime": "^2.0.1",
     "react": "^19.2.7",
-    "react-aria": "^3.49.0",
+    "react-aria": "^3.50.0",
     "react-dom": "^19.2.7",
     "react-router": "^8.0.0",
     "zod": "^4.4.3"
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@babel/core": "^7.29.7",
     "@eslint/js": "^10.0.1",
-    "@inlang/paraglide-js": "^2.19.0",
+    "@inlang/paraglide-js": "^2.20.0",
     "@rolldown/plugin-babel": "^0.2.3",
     "@types/babel__core": "^7.20.5",
     "@types/dom-chromium-ai": "^0.0.17",


### PR DESCRIPTION
Two non-breaking minor dependency bumps, both within the existing `^` ranges.

| Package | From | To |
|---|---|---|
| `react-aria` | 3.49.0 | 3.50.0 |
| `@inlang/paraglide-js` | 2.19.0 | 2.20.0 |

## Verification

- ✅ `npm run build` (tsc -b + vite build) — passes
- ✅ `npm run test` — 445/445 pass
- ✅ `npm run lint` — clean
- ✅ 0 vulnerabilities; both deps deduped

## Excluded

- `@types/node` — latest is a major (25.x); kept pinned to `^24` to match the Node runtime.
- `@babel/core` — v8 upgrade blocked by toolchain peers, tracked in #591.

🤖 Generated with [Claude Code](https://claude.com/claude-code)