### PR TITLE
feat: add source code link to library drawer footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ AI-expanded output: "I would like to eat pizza later, please."
 
 - **Individuals using AAC** — Communicate faster without typing complete sentences tile by tile.
 - **Speech-language pathologists and educators** — Deploy on school networks without cloud data agreements, subscriptions, or continuous internet access.
-- **Caregivers and families** — Install a customizable communication board onto personal tablets or phones.
+- **Caregivers and families** — Install a ready-to-use communication board on personal tablets or phones, with adjustable voice, language, and appearance.
 - **Developers** — Read an open-source reference implementation of browser-native, on-device language models in a real React 19 app.
 
 ## Key features

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "تعذّر حذف \"{name}\"",
   "libraryTitle": "المكتبة",
   "libraryOpen": "فتح المكتبة",
+  "librarySourceCode": "الكود المصدري",
   "settingsTitle": "الإعدادات",
   "settingsOpen": "فتح الإعدادات",
   "settingsClose": "إغلاق الإعدادات",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "„{name}“ не може да бъде изтрита",
   "libraryTitle": "Библиотека",
   "libraryOpen": "Отваряне на библиотеката",
+  "librarySourceCode": "Изходен код",
   "settingsTitle": "Настройки",
   "settingsOpen": "Отваряне на настройките",
   "settingsClose": "Затваряне на настройките",

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "\"{name}\" মোছা যায়নি",
   "libraryTitle": "লাইব্রেরি",
   "libraryOpen": "লাইব্রেরি খুলুন",
+  "librarySourceCode": "সোর্স কোড",
   "settingsTitle": "সেটিংস",
   "settingsOpen": "সেটিংস খুলুন",
   "settingsClose": "সেটিংস বন্ধ করুন",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "„{name}“ se nepodařilo smazat",
   "libraryTitle": "Knihovna",
   "libraryOpen": "Otevřít knihovnu",
+  "librarySourceCode": "Zdrojový kód",
   "settingsTitle": "Nastavení",
   "settingsOpen": "Otevřít nastavení",
   "settingsClose": "Zavřít nastavení",

--- a/messages/da.json
+++ b/messages/da.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "\"{name}\" kunne ikke slettes",
   "libraryTitle": "Bibliotek",
   "libraryOpen": "Åbn biblioteket",
+  "librarySourceCode": "Kildekode",
   "settingsTitle": "Indstillinger",
   "settingsOpen": "Åbn indstillinger",
   "settingsClose": "Luk indstillinger",

--- a/messages/de.json
+++ b/messages/de.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "„{name}“ konnte nicht gelöscht werden",
   "libraryTitle": "Bibliothek",
   "libraryOpen": "Bibliothek öffnen",
+  "librarySourceCode": "Quellcode",
   "settingsTitle": "Einstellungen",
   "settingsOpen": "Einstellungen öffnen",
   "settingsClose": "Einstellungen schließen",

--- a/messages/el.json
+++ b/messages/el.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "Δεν ήταν δυνατή η διαγραφή του «{name}»",
   "libraryTitle": "Βιβλιοθήκη",
   "libraryOpen": "Άνοιγμα βιβλιοθήκης",
+  "librarySourceCode": "Πηγαίος κώδικας",
   "settingsTitle": "Ρυθμίσεις",
   "settingsOpen": "Άνοιγμα ρυθμίσεων",
   "settingsClose": "Κλείσιμο ρυθμίσεων",

--- a/messages/en.json
+++ b/messages/en.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "Couldn't delete \"{name}\"",
   "libraryTitle": "Library",
   "libraryOpen": "Open library",
+  "librarySourceCode": "Source Code",
   "settingsTitle": "Settings",
   "settingsOpen": "Open settings",
   "settingsClose": "Close settings",

--- a/messages/es.json
+++ b/messages/es.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "No se pudo eliminar \"{name}\"",
   "libraryTitle": "Biblioteca",
   "libraryOpen": "Abrir biblioteca",
+  "librarySourceCode": "Código fuente",
   "settingsTitle": "Ajustes",
   "settingsOpen": "Abrir ajustes",
   "settingsClose": "Cerrar ajustes",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "Kohteen ”{name}” poisto epäonnistui",
   "libraryTitle": "Kirjasto",
   "libraryOpen": "Avaa kirjasto",
+  "librarySourceCode": "Lähdekoodi",
   "settingsTitle": "Asetukset",
   "settingsOpen": "Avaa asetukset",
   "settingsClose": "Sulje asetukset",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "Impossible de supprimer « {name} »",
   "libraryTitle": "Bibliothèque",
   "libraryOpen": "Ouvrir la bibliothèque",
+  "librarySourceCode": "Code source",
   "settingsTitle": "Paramètres",
   "settingsOpen": "Ouvrir les paramètres",
   "settingsClose": "Fermer les paramètres",

--- a/messages/he.json
+++ b/messages/he.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "מחיקת \"{name}\" נכשלה",
   "libraryTitle": "ספרייה",
   "libraryOpen": "פתיחת ספרייה",
+  "librarySourceCode": "קוד מקור",
   "settingsTitle": "הגדרות",
   "settingsOpen": "פתיחת הגדרות",
   "settingsClose": "סגירת הגדרות",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "\"{name}\" को हटाया नहीं जा सका",
   "libraryTitle": "लाइब्रेरी",
   "libraryOpen": "लाइब्रेरी खोलें",
+  "librarySourceCode": "सोर्स कोड",
   "settingsTitle": "सेटिंग्स",
   "settingsOpen": "सेटिंग्स खोलें",
   "settingsClose": "सेटिंग्स बंद करें",

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "„{name}” nije moguće izbrisati",
   "libraryTitle": "Knjižnica",
   "libraryOpen": "Otvori knjižnicu",
+  "librarySourceCode": "Izvorni kod",
   "settingsTitle": "Postavke",
   "settingsOpen": "Otvori postavke",
   "settingsClose": "Zatvori postavke",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "A(z) „{name}” törlése nem sikerült",
   "libraryTitle": "Könyvtár",
   "libraryOpen": "Könyvtár megnyitása",
+  "librarySourceCode": "Forráskód",
   "settingsTitle": "Beállítások",
   "settingsOpen": "Beállítások megnyitása",
   "settingsClose": "Beállítások bezárása",

--- a/messages/id.json
+++ b/messages/id.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "Tidak dapat menghapus \"{name}\"",
   "libraryTitle": "Pustaka",
   "libraryOpen": "Buka pustaka",
+  "librarySourceCode": "Kode sumber",
   "settingsTitle": "Setelan",
   "settingsOpen": "Buka setelan",
   "settingsClose": "Tutup setelan",

--- a/messages/it.json
+++ b/messages/it.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "Impossibile eliminare \"{name}\"",
   "libraryTitle": "Libreria",
   "libraryOpen": "Apri libreria",
+  "librarySourceCode": "Codice sorgente",
   "settingsTitle": "Impostazioni",
   "settingsOpen": "Apri impostazioni",
   "settingsClose": "Chiudi impostazioni",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "「{name}」を削除できませんでした",
   "libraryTitle": "ライブラリ",
   "libraryOpen": "ライブラリを開く",
+  "librarySourceCode": "ソースコード",
   "settingsTitle": "設定",
   "settingsOpen": "設定を開く",
   "settingsClose": "設定を閉じる",

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "\"{name}\" ಅನ್ನು ಅಳಿಸಲಾಗಲಿಲ್ಲ",
   "libraryTitle": "ಗ್ರಂಥಾಲಯ",
   "libraryOpen": "ಗ್ರಂಥಾಲಯವನ್ನು ತೆರೆಯಿರಿ",
+  "librarySourceCode": "ಮೂಲ ಕೋಡ್",
   "settingsTitle": "ಸೆಟ್ಟಿಂಗ್‌ಗಳು",
   "settingsOpen": "ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ತೆರೆಯಿರಿ",
   "settingsClose": "ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಮುಚ್ಚಿ",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "\"{name}\"을(를) 삭제할 수 없습니다",
   "libraryTitle": "라이브러리",
   "libraryOpen": "라이브러리 열기",
+  "librarySourceCode": "소스 코드",
   "settingsTitle": "설정",
   "settingsOpen": "설정 열기",
   "settingsClose": "설정 닫기",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "Kan \"{name}\" niet verwijderen",
   "libraryTitle": "Bibliotheek",
   "libraryOpen": "Bibliotheek openen",
+  "librarySourceCode": "Broncode",
   "settingsTitle": "Instellingen",
   "settingsOpen": "Instellingen openen",
   "settingsClose": "Instellingen sluiten",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "Nie udało się usunąć „{name}”",
   "libraryTitle": "Biblioteka",
   "libraryOpen": "Otwórz bibliotekę",
+  "librarySourceCode": "Kod źródłowy",
   "settingsTitle": "Ustawienia",
   "settingsOpen": "Otwórz ustawienia",
   "settingsClose": "Zamknij ustawienia",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "Não foi possível excluir \"{name}\"",
   "libraryTitle": "Biblioteca",
   "libraryOpen": "Abrir biblioteca",
+  "librarySourceCode": "Código-fonte",
   "settingsTitle": "Configurações",
   "settingsOpen": "Abrir configurações",
   "settingsClose": "Fechar configurações",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "„{name}” nu a putut fi ștearsă",
   "libraryTitle": "Bibliotecă",
   "libraryOpen": "Deschide biblioteca",
+  "librarySourceCode": "Cod sursă",
   "settingsTitle": "Setări",
   "settingsOpen": "Deschide setările",
   "settingsClose": "Închide setările",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "Не удалось удалить «{name}»",
   "libraryTitle": "Библиотека",
   "libraryOpen": "Открыть библиотеку",
+  "librarySourceCode": "Исходный код",
   "settingsTitle": "Настройки",
   "settingsOpen": "Открыть настройки",
   "settingsClose": "Закрыть настройки",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "„{name}“ sa nepodarilo odstrániť",
   "libraryTitle": "Knižnica",
   "libraryOpen": "Otvoriť knižnicu",
+  "librarySourceCode": "Zdrojový kód",
   "settingsTitle": "Nastavenia",
   "settingsOpen": "Otvoriť nastavenia",
   "settingsClose": "Zavrieť nastavenia",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "»{name}« ni bilo mogoče izbrisati",
   "libraryTitle": "Knjižnica",
   "libraryOpen": "Odpri knjižnico",
+  "librarySourceCode": "Izvorna koda",
   "settingsTitle": "Nastavitve",
   "settingsOpen": "Odpri nastavitve",
   "settingsClose": "Zapri nastavitve",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "Det gick inte att ta bort ”{name}”",
   "libraryTitle": "Bibliotek",
   "libraryOpen": "Öppna biblioteket",
+  "librarySourceCode": "Källkod",
   "settingsTitle": "Inställningar",
   "settingsOpen": "Öppna inställningar",
   "settingsClose": "Stäng inställningar",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "\"{name}\" என்பதை நீக்க முடியவில்லை",
   "libraryTitle": "நூலகம்",
   "libraryOpen": "நூலகத்தைத் திற",
+  "librarySourceCode": "மூலக் குறியீடு",
   "settingsTitle": "அமைப்புகள்",
   "settingsOpen": "அமைப்புகளைத் திற",
   "settingsClose": "அமைப்புகளை மூடு",

--- a/messages/te.json
+++ b/messages/te.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "\"{name}\"ను తొలగించలేకపోయాం",
   "libraryTitle": "లైబ్రరీ",
   "libraryOpen": "లైబ్రరీని తెరువు",
+  "librarySourceCode": "సోర్స్ కోడ్",
   "settingsTitle": "సెట్టింగ్‌లు",
   "settingsOpen": "సెట్టింగ్‌లను తెరువు",
   "settingsClose": "సెట్టింగ్‌లను మూసివేయి",

--- a/messages/th.json
+++ b/messages/th.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "ลบ \"{name}\" ไม่สำเร็จ",
   "libraryTitle": "คลัง",
   "libraryOpen": "เปิดคลัง",
+  "librarySourceCode": "ซอร์สโค้ด",
   "settingsTitle": "การตั้งค่า",
   "settingsOpen": "เปิดการตั้งค่า",
   "settingsClose": "ปิดการตั้งค่า",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "\"{name}\" silinemedi",
   "libraryTitle": "Kitaplık",
   "libraryOpen": "Kitaplığı aç",
+  "librarySourceCode": "Kaynak kodu",
   "settingsTitle": "Ayarlar",
   "settingsOpen": "Ayarları aç",
   "settingsClose": "Ayarları kapat",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "Не вдалося видалити «{name}»",
   "libraryTitle": "Бібліотека",
   "libraryOpen": "Відкрити бібліотеку",
+  "librarySourceCode": "Вихідний код",
   "settingsTitle": "Налаштування",
   "settingsOpen": "Відкрити налаштування",
   "settingsClose": "Закрити налаштування",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "Không thể xóa \"{name}\"",
   "libraryTitle": "Thư viện",
   "libraryOpen": "Mở thư viện",
+  "librarySourceCode": "Mã nguồn",
   "settingsTitle": "Cài đặt",
   "settingsOpen": "Mở cài đặt",
   "settingsClose": "Đóng cài đặt",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -54,6 +54,7 @@
   "libraryDeleteFailed": "无法删除“{name}”",
   "libraryTitle": "板库",
   "libraryOpen": "打开板库",
+  "librarySourceCode": "源代码",
   "settingsTitle": "设置",
   "settingsOpen": "打开设置",
   "settingsClose": "关闭设置",

--- a/src/app/library/library-drawer.tsx
+++ b/src/app/library/library-drawer.tsx
@@ -1,6 +1,8 @@
 import { DRAWER_BASE_WIDTH } from "@app/layouts/drawer-width";
 import { BoardSetLibrary, boardSetPath } from "@features/board";
+import { ExternalLink } from "@shared/components/external-link";
 import CloseIcon from "@mui/icons-material/Close";
+import GitHubIcon from "@mui/icons-material/GitHub";
 import Box from "@mui/material/Box";
 import Drawer from "@mui/material/Drawer";
 import IconButton from "@mui/material/IconButton";
@@ -91,6 +93,27 @@ export function LibraryDrawer({
             closeOnNavigate?.();
           }}
         />
+      </Box>
+
+      <Box
+        component="footer"
+        sx={(theme) => ({
+          p: 2,
+          [theme.breakpoints.up("sm")]: {
+            pl: `calc(${theme.spacing(2)} + env(safe-area-inset-left))`,
+          },
+        })}
+      >
+        <ExternalLink
+          href="https://github.com/shayc/aac-board-ai"
+          color="text.secondary"
+        >
+          <GitHubIcon
+            fontSize="small"
+            sx={{ verticalAlign: "text-bottom", mr: 1 }}
+          />
+          {m.librarySourceCode()}
+        </ExternalLink>
       </Box>
     </Drawer>
   );


### PR DESCRIPTION
## Summary

Adds a footer to the library drawer with a single muted external link — a GitHub icon + **Source Code** — pinned to the bottom of the drawer.

- Reuses the shared `ExternalLink` component (`target="_blank" rel="noopener noreferrer"`), linking to the repo.
- Uses the theme's `text.secondary` token so the link reads muted and doesn't compete with the board navigation; the footer pins to the bottom via the drawer's existing flex-column layout (no positioning), with safe-area-inset padding matching the `Toolbar`.
- Adds the `librarySourceCode` message key across **all 35 locales** (parity preserved at 91 keys each).

Also bundles a small unrelated README prose tweak (caregivers/families audience description) as a separate commit.

## Verification

- `eslint` — clean
- `tsc -b` — clean
- `prettier --check` — clean
- `library-drawer.test.tsx` — 2/2 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)