### PR TITLE
style: center the source code link in the library drawer footer

### DIFF
--- a/src/app/library/library-drawer.tsx
+++ b/src/app/library/library-drawer.tsx
@@ -99,6 +99,7 @@ export function LibraryDrawer({
         component="footer"
         sx={(theme) => ({
           p: 2,
+          textAlign: "center",
           [theme.breakpoints.up("sm")]: {
             pl: `calc(${theme.spacing(2)} + env(safe-area-inset-left))`,
           },


### PR DESCRIPTION
## Summary

Follow-up to #593. Centers the **Source Code** link in the library drawer footer by adding `textAlign: "center"` to the footer `Box`.

The footer's `ExternalLink` is an inline element, so `textAlign: "center"` centers it horizontally. On non-notched devices the `sm+` left padding already resolves to the same 16px as the other sides, so it sits symmetrically centered; the `env(safe-area-inset-left)` guard is preserved for notched landscape.

## Verification

- `eslint` — clean
- One-line diff, no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)