### PR TITLE
refactor: remove onActiveSetDeleted from BoardSetLibrary

### DIFF
--- a/src/app/library/library-drawer.tsx
+++ b/src/app/library/library-drawer.tsx
@@ -88,10 +88,6 @@ export function LibraryDrawer({
             void navigate(boardSetPath(boardSet));
             closeOnNavigate?.();
           }}
-          onActiveSetDeleted={() => {
-            void navigate("/");
-            closeOnNavigate?.();
-          }}
         />
       </Box>
 

--- a/src/features/board/board-sets/board-set-library.tsx
+++ b/src/features/board/board-sets/board-set-library.tsx
@@ -18,13 +18,11 @@ import { useBoardSets } from "./use-board-sets";
 export interface BoardSetLibraryProps {
   onSelect: (boardSet: BoardSetRecord) => void;
   activeSetId?: string;
-  onActiveSetDeleted?: () => void;
 }
 
 export function BoardSetLibrary({
   onSelect,
   activeSetId,
-  onActiveSetDeleted,
 }: BoardSetLibraryProps) {
   const { boardSets, isLoading } = useBoardSets();
   const { pickAndImportBoardFiles } = useImportBoardFiles();
@@ -47,10 +45,6 @@ export function BoardSetLibrary({
         message: m.libraryDeleted({ name }),
         severity: "success",
       });
-
-      if (setId === activeSetId) {
-        onActiveSetDeleted?.();
-      }
     } catch {
       showSnackbar({
         message: m.libraryDeleteFailed({ name }),


### PR DESCRIPTION
## Summary

Removes the `onActiveSetDeleted` prop from `BoardSetLibrary`. The callback bolted a **relational, context-dependent** check (`if (setId === activeSetId)`) onto an otherwise self-contained delete — the library had to know what was on screen. Now `handleDelete` just deletes and toasts; the drawer no longer wires the callback.

- `BoardSetLibrary` — dropped the prop and the `setId === activeSetId` branch. `activeSetId` stays (still drives `selectedSetId` highlighting).
- `library-drawer.tsx` — dropped the prop wiring.

Net: 2 files, 10 deletions, no new abstractions.

## Deferred behavior (intentional)

Deleting the board set you're **currently viewing** no longer redirects you off it. The board keeps rendering from already-loaded loader data (still functional), but a reload would 404 since the set is gone from IndexedDB. This is a rare path and not a crash.

The clean home for that redirect is a reactive guard, but the candidate placements either mix routing/lifecycle concerns into the presentational `board-page` (SRP smell) or only partially cover deletion sources. Deferred until there's a clean path rather than relocating the wart — no TODO left in code.

## Verification

- `eslint` — clean
- `tsc -b` — clean
- `board-set-library.test.tsx` — 5/5 passing (the prop was never under test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)