### PR TITLE
i18n: refine Hebrew wording for aiBuiltInSupport

### DIFF
--- a/messages/he.json
+++ b/messages/he.json
@@ -75,7 +75,7 @@
   "aiCustomInstructions": "הוראות מותאמות אישית",
   "aiCustomInstructionsPlaceholder": "למשל: ציני, מנומס.",
   "aiCustomInstructionsHelper": "התאמה אישית של הצעות ה-AI.",
-  "aiBuiltInSupport": "תמיכת AI מובנית",
+  "aiBuiltInSupport": "תמיכה ב-AI מובנה",
   "aiStatusAvailable": "זמין",
   "aiStatusUnavailable": "לא זמין",
   "aiStatusDownloading": "בהורדה… {progress}%",


### PR DESCRIPTION
Refines the Hebrew label for `aiBuiltInSupport`: "תמיכת AI מובנית" → "תמיכה ב-AI מובנה".

🤖 Generated with [Claude Code](https://claude.com/claude-code)