### PR TITLE
feat: fit whole columns to the screen at any width

### DIFF
--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -101,7 +101,7 @@ export function BoardViewer({ board }: BoardViewerProps) {
         )}
       </Stack>
 
-      <Box sx={{ flexGrow: 1, height: 0, overflow: "auto" }}>
+      <Box sx={{ flex: 1, minHeight: 0 }}>
         <Grid<BoardButton>
           ariaLabel={board.name ?? m.boardGridLabel()}
           items={board.buttons}

--- a/src/features/board/grid/grid.test.tsx
+++ b/src/features/board/grid/grid.test.tsx
@@ -949,36 +949,40 @@ describe("Grid", () => {
 
       return {
         cellWidth: cellEl.getBoundingClientRect().width,
+        expectedWidth: expectedCellWidth(containerWidth, columns),
         overflows: scroller.scrollWidth > scroller.clientWidth + 1,
       };
     };
 
     test("enlarges cells past the floor to fill the width when a wide board overflows", async () => {
-      const { cellWidth, overflows } = await renderSizedGrid(1000, 20);
+      const { cellWidth, expectedWidth, overflows } = await renderSizedGrid(
+        1000,
+        20,
+      );
 
       expect(cellWidth).toBeGreaterThan(MIN_CELL);
-      expect(Math.abs(cellWidth - expectedCellWidth(1000, 20))).toBeLessThan(
-        1.5,
-      );
+      expect(Math.abs(cellWidth - expectedWidth)).toBeLessThan(1.5);
       expect(overflows).toBe(true);
     });
 
     test("grows cells to fill the width when the whole board fits", async () => {
-      const { cellWidth, overflows } = await renderSizedGrid(1000, 4);
-
-      expect(Math.abs(cellWidth - expectedCellWidth(1000, 4))).toBeLessThan(
-        1.5,
+      const { cellWidth, expectedWidth, overflows } = await renderSizedGrid(
+        1000,
+        4,
       );
+
+      expect(Math.abs(cellWidth - expectedWidth)).toBeLessThan(1.5);
       expect(overflows).toBe(false);
     });
 
     test("settles on three columns at a phone width, never below the 96px floor", async () => {
-      const { cellWidth, overflows } = await renderSizedGrid(375, 20);
+      const { cellWidth, expectedWidth, overflows } = await renderSizedGrid(
+        375,
+        20,
+      );
 
       expect(cellWidth).toBeGreaterThanOrEqual(MIN_CELL);
-      expect(Math.abs(cellWidth - expectedCellWidth(375, 20))).toBeLessThan(
-        1.5,
-      );
+      expect(Math.abs(cellWidth - expectedWidth)).toBeLessThan(1.5);
       expect(overflows).toBe(true);
     });
   });

--- a/src/features/board/grid/grid.test.tsx
+++ b/src/features/board/grid/grid.test.tsx
@@ -1,3 +1,4 @@
+import CssBaseline from "@mui/material/CssBaseline";
 import { describe, expect, test } from "vitest";
 import { render } from "vitest-browser-react";
 import { userEvent, type Locator } from "vitest/browser";
@@ -896,6 +897,89 @@ describe("Grid", () => {
       await expect
         .element(screen.getByRole("grid", { name: "Core words" }))
         .toBeVisible();
+    });
+  });
+
+  describe("responsive cell sizing", () => {
+    const PAD = 16;
+    const GAP = 16;
+    const MIN_CELL = 96;
+
+    const expectedCellWidth = (containerWidth: number, columns: number) => {
+      const fit = Math.floor(
+        (containerWidth - 2 * PAD + GAP) / (MIN_CELL + GAP),
+      );
+      const visible = Math.min(columns, Math.max(1, fit));
+
+      return (containerWidth - 2 * PAD - (visible - 1) * GAP) / visible;
+    };
+
+    const renderSizedGrid = async (containerWidth: number, columns: number) => {
+      const items = Array.from({ length: columns }, (_, i) => ({
+        id: String(i + 1),
+        label: `Item ${i + 1}`,
+      }));
+
+      const screen = await render(
+        <>
+          <CssBaseline />
+          <div style={{ width: `${containerWidth}px`, height: "400px" }}>
+            <Grid
+              rows={1}
+              columns={columns}
+              items={items}
+              renderItem={(item, props) => (
+                <button {...props}>{item.label}</button>
+              )}
+            />
+          </div>
+        </>,
+      );
+
+      const gridEl = screen.getByRole("grid").element();
+      const cellEl = gridEl.querySelector("[role='gridcell']");
+      if (!(cellEl instanceof HTMLElement)) {
+        throw new Error("grid rendered no cell");
+      }
+
+      const scroller = gridEl.parentElement;
+      if (!scroller) {
+        throw new Error("grid has no scroll container");
+      }
+
+      return {
+        cellWidth: cellEl.getBoundingClientRect().width,
+        overflows: scroller.scrollWidth > scroller.clientWidth + 1,
+      };
+    };
+
+    test("enlarges cells past the floor to fill the width when a wide board overflows", async () => {
+      const { cellWidth, overflows } = await renderSizedGrid(1000, 20);
+
+      expect(cellWidth).toBeGreaterThan(MIN_CELL);
+      expect(Math.abs(cellWidth - expectedCellWidth(1000, 20))).toBeLessThan(
+        1.5,
+      );
+      expect(overflows).toBe(true);
+    });
+
+    test("grows cells to fill the width when the whole board fits", async () => {
+      const { cellWidth, overflows } = await renderSizedGrid(1000, 4);
+
+      expect(Math.abs(cellWidth - expectedCellWidth(1000, 4))).toBeLessThan(
+        1.5,
+      );
+      expect(overflows).toBe(false);
+    });
+
+    test("settles on three columns at a phone width, never below the 96px floor", async () => {
+      const { cellWidth, overflows } = await renderSizedGrid(375, 20);
+
+      expect(cellWidth).toBeGreaterThanOrEqual(MIN_CELL);
+      expect(Math.abs(cellWidth - expectedCellWidth(375, 20))).toBeLessThan(
+        1.5,
+      );
+      expect(overflows).toBe(true);
     });
   });
 });

--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -56,8 +56,8 @@ export function Grid<TItem extends { id: string }>({
         aria-label={ariaLabel}
         direction="column"
         sx={(theme) => ({
-          "--cols": visibleColumns(theme, columns, gap),
-          "--cell-width": `calc((100cqi - ${theme.spacing(PADDING * 2)} - (var(--cols) - 1) * ${theme.spacing(gap)}) / var(--cols))`,
+          "--visible-cols": visibleColumns(theme, columns, gap),
+          "--cell-width": `calc((100cqi - ${theme.spacing(PADDING * 2)} - (var(--visible-cols) - 1) * ${theme.spacing(gap)}) / var(--visible-cols))`,
           minHeight: "100%",
           minWidth: gridMinWidth(theme, columns, gap, "var(--cell-width)"),
           p: PADDING,

--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -1,8 +1,14 @@
+import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
+import type { Theme } from "@mui/material/styles";
+import type { ReactNode } from "react";
 import { useGridKeyboard } from "./use-grid-keyboard";
 
-const MIN_CELL_PX = 96;
+const MIN_CELL_SIZE = "96px";
 const PADDING = 2;
+const MOBILE_COLUMNS = 3;
+
+type GridOrder = readonly (readonly (string | null)[])[];
 
 export interface GridItemProps {
   tabIndex: number;
@@ -13,8 +19,8 @@ export interface GridProps<TItem extends { id: string }> {
   items: readonly TItem[];
   rows: number;
   columns: number;
-  order?: readonly (readonly (string | null)[])[];
-  renderItem: (item: TItem, props: GridItemProps) => React.ReactNode;
+  order?: GridOrder;
+  renderItem: (item: TItem, props: GridItemProps) => ReactNode;
   dir?: "ltr" | "rtl";
   gap?: number;
 }
@@ -36,49 +42,65 @@ export function Grid<TItem extends { id: string }>({
   });
 
   return (
-    <Stack
-      {...rootProps}
-      ref={rootRef}
-      role="grid"
-      aria-label={ariaLabel}
-      direction="column"
+    <Box
       dir={dir}
-      sx={(theme) => ({
-        minHeight: "100%",
-        minWidth: `calc(${columns} * ${MIN_CELL_PX}px + ${columns - 1} * ${theme.spacing(gap)} + ${theme.spacing(PADDING * 2)})`,
-        p: PADDING,
-        gap,
-      })}
+      sx={{
+        height: "100%",
+        overflow: "auto",
+        containerType: "inline-size",
+      }}
     >
-      {grid.map((row, rowIndex) => (
-        <Stack
-          key={rowIndex}
-          role="row"
-          direction="row"
-          sx={{ flexGrow: 1, gap }}
-        >
-          {row.map((item, colIndex) => {
-            const isActive =
-              rowIndex === activeCell.row && colIndex === activeCell.col;
+      <Stack
+        {...rootProps}
+        ref={rootRef}
+        role="grid"
+        aria-label={ariaLabel}
+        direction="column"
+        sx={(theme) => ({
+          "--cell-min-width": MIN_CELL_SIZE,
+          [theme.breakpoints.down("sm")]: {
+            "--cell-min-width": mobileCellWidth(theme, gap),
+          },
+          minHeight: "100%",
+          minWidth: gridMinWidth(theme, columns, gap, "var(--cell-min-width)"),
+          p: PADDING,
+          gap,
+        })}
+      >
+        {grid.map((row, rowIndex) => (
+          <Stack
+            key={rowIndex}
+            role="row"
+            direction="row"
+            sx={{ flexGrow: 1, gap }}
+          >
+            {row.map((item, colIndex) => {
+              const isActive =
+                rowIndex === activeCell.row && colIndex === activeCell.col;
 
-            return (
-              <Stack
-                key={colIndex}
-                role="gridcell"
-                aria-rowindex={rowIndex + 1}
-                aria-colindex={colIndex + 1}
-                sx={{ flex: 1, minWidth: MIN_CELL_PX, minHeight: MIN_CELL_PX }}
-              >
-                {item &&
-                  renderItem(item, {
-                    tabIndex: isActive ? 0 : -1,
-                  })}
-              </Stack>
-            );
-          })}
-        </Stack>
-      ))}
-    </Stack>
+              return (
+                <Stack
+                  key={colIndex}
+                  role="gridcell"
+                  aria-rowindex={rowIndex + 1}
+                  aria-colindex={colIndex + 1}
+                  sx={{
+                    flex: 1,
+                    minWidth: "var(--cell-min-width)",
+                    minHeight: MIN_CELL_SIZE,
+                  }}
+                >
+                  {item &&
+                    renderItem(item, {
+                      tabIndex: isActive ? 0 : -1,
+                    })}
+                </Stack>
+              );
+            })}
+          </Stack>
+        ))}
+      </Stack>
+    </Box>
   );
 }
 
@@ -86,7 +108,7 @@ function buildGrid<TItem extends { id: string }>(
   items: readonly TItem[],
   rows: number,
   columns: number,
-  order?: readonly (readonly (string | null)[])[],
+  order?: GridOrder,
 ): (TItem | undefined)[][] {
   if (order?.length) {
     const itemsById = new Map(items.map((item) => [item.id, item]));
@@ -109,4 +131,17 @@ function buildGrid<TItem extends { id: string }>(
       return items[index];
     }),
   );
+}
+
+function mobileCellWidth(theme: Theme, gap: number): string {
+  return `calc((100cqi - ${theme.spacing(PADDING * 2)} - ${theme.spacing(gap * (MOBILE_COLUMNS - 1))}) / ${MOBILE_COLUMNS})`;
+}
+
+function gridMinWidth(
+  theme: Theme,
+  columns: number,
+  gap: number,
+  cellWidth: string,
+): string {
+  return `calc(${columns} * ${cellWidth} + ${columns - 1} * ${theme.spacing(gap)} + ${theme.spacing(PADDING * 2)})`;
 }

--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -6,7 +6,6 @@ import { useGridKeyboard } from "./use-grid-keyboard";
 
 const MIN_CELL_SIZE = "96px";
 const PADDING = 2;
-const MOBILE_COLUMNS = 3;
 
 type GridOrder = readonly (readonly (string | null)[])[];
 
@@ -57,12 +56,10 @@ export function Grid<TItem extends { id: string }>({
         aria-label={ariaLabel}
         direction="column"
         sx={(theme) => ({
-          "--cell-min-width": MIN_CELL_SIZE,
-          [theme.breakpoints.down("sm")]: {
-            "--cell-min-width": mobileCellWidth(theme, gap),
-          },
+          "--cols": visibleColumns(theme, columns, gap),
+          "--cell-width": `calc((100cqi - ${theme.spacing(PADDING * 2)} - (var(--cols) - 1) * ${theme.spacing(gap)}) / var(--cols))`,
           minHeight: "100%",
-          minWidth: gridMinWidth(theme, columns, gap, "var(--cell-min-width)"),
+          minWidth: gridMinWidth(theme, columns, gap, "var(--cell-width)"),
           p: PADDING,
           gap,
         })}
@@ -86,7 +83,7 @@ export function Grid<TItem extends { id: string }>({
                   aria-colindex={colIndex + 1}
                   sx={{
                     flex: 1,
-                    minWidth: "var(--cell-min-width)",
+                    minWidth: "var(--cell-width)",
                     minHeight: MIN_CELL_SIZE,
                   }}
                 >
@@ -133,8 +130,11 @@ function buildGrid<TItem extends { id: string }>(
   );
 }
 
-function mobileCellWidth(theme: Theme, gap: number): string {
-  return `calc((100cqi - ${theme.spacing(PADDING * 2)} - ${theme.spacing(gap * (MOBILE_COLUMNS - 1))}) / ${MOBILE_COLUMNS})`;
+function visibleColumns(theme: Theme, columns: number, gap: number): string {
+  const inner = `100cqi - ${theme.spacing(PADDING * 2)}`;
+  const pitch = `${MIN_CELL_SIZE} + ${theme.spacing(gap)}`;
+
+  return `min(${columns}, max(1, round(down, (${inner} + ${theme.spacing(gap)}) / (${pitch}), 1)))`;
 }
 
 function gridMinWidth(


### PR DESCRIPTION
## What

Board tiles now size so that the **largest whole number of columns that clears the 96px accessibility floor fills the visible width**, scrolling the rest horizontally. When the whole board fits, tiles simply grow to fill (unchanged desktop behaviour); when it overflows, tiles are enlarged a few pixels so columns tile evenly instead of leaving a sliver of a partial column.

This generalises the original "3 columns on phones" idea into one width-driven rule. A phone resolves to ~3 columns on its own, so the special case — `MOBILE_COLUMNS` and the `sm` breakpoint — is gone. The 96px floor (AAC tap-target accessibility) is the only policy left; the column count is an emergent consequence of it.

Tile order is untouched (it's the optimised AAC layout); only cell sizing changes.

## How

Pure CSS, no JS measurement. The visible-column count is computed with a container query plus `round()` and typed `calc()` division:

```
visibleCols = min(boardColumns, max(1, floor((100cqi − 2·pad + gap) / (minCell + gap))))
cellWidth   = (100cqi − 2·pad − (visibleCols − 1)·gap) / visibleCols
```

`Grid` owns its own scrollport + query container, so `100cqi` is self-contained.

## Browser support

The load-bearing feature is `length / length → number` in `calc()`, nested through custom properties that read `100cqi`. I verified the exact production structure renders correctly in **Chromium and WebKit (Safari engine)** via a throwaway probe (since removed). `round()`, `cqi`, and typed `calc()` division have all shipped in every engine since 2023.

## Testing

- `tsc`, lint, and the grid + board-viewer suites pass (40 tests).
- **New browser tests** measure real cell widths and assert the three regimes: enlarge-on-overflow (wide board), grow-to-fill (board fits), and the phone case (~3 columns, never below 96px) — locking the reflow so it's covered by CI, not just manual inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)