### PR TITLE
feat: paginated board scrolling with whole-row/column fit

### DIFF
--- a/src/features/board/grid/grid.test.tsx
+++ b/src/features/board/grid/grid.test.tsx
@@ -902,7 +902,7 @@ describe("Grid", () => {
 
   describe("responsive cell sizing", () => {
     const PAD = 16;
-    const GAP = 16;
+    const GAP = 8;
     const MIN_CELL = 96;
 
     const expectedCellWidth = (containerWidth: number, columns: number) => {

--- a/src/features/board/grid/grid.test.tsx
+++ b/src/features/board/grid/grid.test.tsx
@@ -900,7 +900,7 @@ describe("Grid", () => {
     });
   });
 
-  describe("responsive cell sizing", () => {
+  describe("responsive column sizing", () => {
     const PAD = 16;
     const GAP = 8;
     const MIN_CELL = 96;
@@ -983,6 +983,93 @@ describe("Grid", () => {
 
       expect(cellWidth).toBeGreaterThanOrEqual(MIN_CELL);
       expect(Math.abs(cellWidth - expectedWidth)).toBeLessThan(1.5);
+      expect(overflows).toBe(true);
+    });
+  });
+
+  describe("responsive row sizing", () => {
+    const PAD = 16;
+    const GAP = 8;
+    const MIN_CELL = 96;
+
+    const expectedCellHeight = (containerHeight: number, rows: number) => {
+      const fit = Math.floor(
+        (containerHeight - 2 * PAD + GAP) / (MIN_CELL + GAP),
+      );
+      const visible = Math.min(rows, Math.max(1, fit));
+
+      return (containerHeight - 2 * PAD - (visible - 1) * GAP) / visible;
+    };
+
+    const renderSizedGrid = async (containerHeight: number, rows: number) => {
+      const items = Array.from({ length: rows }, (_, i) => ({
+        id: String(i + 1),
+        label: `Item ${i + 1}`,
+      }));
+
+      const screen = await render(
+        <>
+          <CssBaseline />
+          <div style={{ width: "400px", height: `${containerHeight}px` }}>
+            <Grid
+              rows={rows}
+              columns={1}
+              items={items}
+              renderItem={(item, props) => (
+                <button {...props}>{item.label}</button>
+              )}
+            />
+          </div>
+        </>,
+      );
+
+      const gridEl = screen.getByRole("grid").element();
+      const cellEl = gridEl.querySelector("[role='gridcell']");
+      if (!(cellEl instanceof HTMLElement)) {
+        throw new Error("grid rendered no cell");
+      }
+
+      const scroller = gridEl.parentElement;
+      if (!scroller) {
+        throw new Error("grid has no scroll container");
+      }
+
+      return {
+        cellHeight: cellEl.getBoundingClientRect().height,
+        expectedHeight: expectedCellHeight(containerHeight, rows),
+        overflows: scroller.scrollHeight > scroller.clientHeight + 1,
+      };
+    };
+
+    test("enlarges cells past the floor to fill the height when a tall board overflows", async () => {
+      const { cellHeight, expectedHeight, overflows } = await renderSizedGrid(
+        1000,
+        20,
+      );
+
+      expect(cellHeight).toBeGreaterThan(MIN_CELL);
+      expect(Math.abs(cellHeight - expectedHeight)).toBeLessThan(1.5);
+      expect(overflows).toBe(true);
+    });
+
+    test("grows cells to fill the height when the whole board fits", async () => {
+      const { cellHeight, expectedHeight, overflows } = await renderSizedGrid(
+        1000,
+        4,
+      );
+
+      expect(Math.abs(cellHeight - expectedHeight)).toBeLessThan(1.5);
+      expect(overflows).toBe(false);
+    });
+
+    test("settles on whole rows at a short height, never below the 96px floor", async () => {
+      const { cellHeight, expectedHeight, overflows } = await renderSizedGrid(
+        375,
+        20,
+      );
+
+      expect(cellHeight).toBeGreaterThanOrEqual(MIN_CELL);
+      expect(Math.abs(cellHeight - expectedHeight)).toBeLessThan(1.5);
       expect(overflows).toBe(true);
     });
   });

--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -32,7 +32,7 @@ export function Grid<TItem extends { id: string }>({
   order,
   renderItem,
   dir = "ltr",
-  gap = 2,
+  gap = 1,
 }: GridProps<TItem>) {
   const grid = buildGrid(items, rows, columns, order);
   const { rootRef, rootProps, activeCell } = useGridKeyboard({

--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -43,11 +43,13 @@ export function Grid<TItem extends { id: string }>({
   return (
     <Box
       dir={dir}
-      sx={{
+      sx={(theme) => ({
         height: "100%",
         overflow: "auto",
         containerType: "inline-size",
-      }}
+        scrollSnapType: "x mandatory",
+        scrollPaddingInline: theme.spacing(PADDING),
+      })}
     >
       <Stack
         {...rootProps}
@@ -85,6 +87,7 @@ export function Grid<TItem extends { id: string }>({
                     flex: 1,
                     minWidth: "var(--cell-width)",
                     minHeight: MIN_CELL_SIZE,
+                    scrollSnapAlign: "start",
                   }}
                 >
                   {item &&

--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -46,9 +46,10 @@ export function Grid<TItem extends { id: string }>({
       sx={(theme) => ({
         height: "100%",
         overflow: "auto",
-        containerType: "inline-size",
-        scrollSnapType: "x mandatory",
+        containerType: "size",
+        scrollSnapType: "both mandatory",
         scrollPaddingInline: theme.spacing(PADDING),
+        scrollPaddingBlock: theme.spacing(PADDING),
       })}
     >
       <Stack
@@ -58,10 +59,22 @@ export function Grid<TItem extends { id: string }>({
         aria-label={ariaLabel}
         direction="column"
         sx={(theme) => ({
-          "--visible-cols": visibleColumns(theme, columns, gap),
-          "--cell-width": `calc((100cqi - ${theme.spacing(PADDING * 2)} - (var(--visible-cols) - 1) * ${theme.spacing(gap)}) / var(--visible-cols))`,
-          minHeight: "100%",
-          minWidth: gridMinWidth(theme, columns, gap, "var(--cell-width)"),
+          "--visible-cols": visibleTracks(theme, columns, gap, "100cqi"),
+          "--visible-rows": visibleTracks(theme, rows, gap, "100cqb"),
+          "--cell-width": trackSize(
+            theme,
+            "100cqi",
+            gap,
+            "var(--visible-cols)",
+          ),
+          "--cell-height": trackSize(
+            theme,
+            "100cqb",
+            gap,
+            "var(--visible-rows)",
+          ),
+          minWidth: gridExtent(theme, columns, gap, "var(--cell-width)"),
+          minHeight: gridExtent(theme, rows, gap, "var(--cell-height)"),
           p: PADDING,
           gap,
         })}
@@ -71,7 +84,7 @@ export function Grid<TItem extends { id: string }>({
             key={rowIndex}
             role="row"
             direction="row"
-            sx={{ flexGrow: 1, gap }}
+            sx={{ flex: 1, minHeight: "var(--cell-height)", gap }}
           >
             {row.map((item, colIndex) => {
               const isActive =
@@ -133,18 +146,32 @@ function buildGrid<TItem extends { id: string }>(
   );
 }
 
-function visibleColumns(theme: Theme, columns: number, gap: number): string {
-  const inner = `100cqi - ${theme.spacing(PADDING * 2)}`;
+function visibleTracks(
+  theme: Theme,
+  count: number,
+  gap: number,
+  extent: string,
+): string {
+  const inner = `${extent} - ${theme.spacing(PADDING * 2)}`;
   const pitch = `${MIN_CELL_SIZE} + ${theme.spacing(gap)}`;
 
-  return `min(${columns}, max(1, round(down, (${inner} + ${theme.spacing(gap)}) / (${pitch}), 1)))`;
+  return `min(${count}, max(1, round(down, (${inner} + ${theme.spacing(gap)}) / (${pitch}), 1)))`;
 }
 
-function gridMinWidth(
+function trackSize(
   theme: Theme,
-  columns: number,
+  extent: string,
   gap: number,
-  cellWidth: string,
+  visible: string,
 ): string {
-  return `calc(${columns} * ${cellWidth} + ${columns - 1} * ${theme.spacing(gap)} + ${theme.spacing(PADDING * 2)})`;
+  return `calc((${extent} - ${theme.spacing(PADDING * 2)} - (${visible} - 1) * ${theme.spacing(gap)}) / ${visible})`;
+}
+
+function gridExtent(
+  theme: Theme,
+  count: number,
+  gap: number,
+  cellSize: string,
+): string {
+  return `calc(${count} * ${cellSize} + ${count - 1} * ${theme.spacing(gap)} + ${theme.spacing(PADDING * 2)})`;
 }

--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -48,8 +48,7 @@ export function Grid<TItem extends { id: string }>({
         overflow: "auto",
         containerType: "size",
         scrollSnapType: "both mandatory",
-        scrollPaddingInline: theme.spacing(PADDING),
-        scrollPaddingBlock: theme.spacing(PADDING),
+        scrollPadding: theme.spacing(PADDING),
       })}
     >
       <Stack
@@ -59,8 +58,8 @@ export function Grid<TItem extends { id: string }>({
         aria-label={ariaLabel}
         direction="column"
         sx={(theme) => ({
-          "--visible-cols": visibleTracks(theme, columns, gap, "100cqi"),
-          "--visible-rows": visibleTracks(theme, rows, gap, "100cqb"),
+          "--visible-cols": visibleTracks(theme, "100cqi", gap, columns),
+          "--visible-rows": visibleTracks(theme, "100cqb", gap, rows),
           "--cell-width": trackSize(
             theme,
             "100cqi",
@@ -73,8 +72,8 @@ export function Grid<TItem extends { id: string }>({
             gap,
             "var(--visible-rows)",
           ),
-          minWidth: gridExtent(theme, columns, gap, "var(--cell-width)"),
-          minHeight: gridExtent(theme, rows, gap, "var(--cell-height)"),
+          minWidth: gridExtent(theme, "var(--cell-width)", gap, columns),
+          minHeight: gridExtent(theme, "var(--cell-height)", gap, rows),
           p: PADDING,
           gap,
         })}
@@ -148,9 +147,9 @@ function buildGrid<TItem extends { id: string }>(
 
 function visibleTracks(
   theme: Theme,
-  count: number,
-  gap: number,
   extent: string,
+  gap: number,
+  count: number,
 ): string {
   const inner = `${extent} - ${theme.spacing(PADDING * 2)}`;
   const pitch = `${MIN_CELL_SIZE} + ${theme.spacing(gap)}`;
@@ -169,9 +168,9 @@ function trackSize(
 
 function gridExtent(
   theme: Theme,
-  count: number,
-  gap: number,
   cellSize: string,
+  gap: number,
+  count: number,
 ): string {
   return `calc(${count} * ${cellSize} + ${count - 1} * ${theme.spacing(gap)} + ${theme.spacing(PADDING * 2)})`;
 }

--- a/src/features/board/tile/tile.tsx
+++ b/src/features/board/tile/tile.tsx
@@ -42,7 +42,7 @@ export function Tile({
         alignItems: "stretch",
         justifyContent: "stretch",
         padding: "4px 4px 0 4px",
-        border: `2px solid ${borderColor ?? backgroundColor ?? "transparent"}`,
+        border: `4px solid ${borderColor ?? backgroundColor ?? "transparent"}`,
         borderRadius: 4,
         overflow: "hidden",
         position: "relative",
@@ -59,12 +59,11 @@ export function Tile({
         },
         "&:active": { backgroundColor: darkened(30) },
         "&:focus-visible": {
-          outline: `3px solid ${
+          outline: `4px solid ${
             theme.vars
               ? `rgba(${theme.vars.palette.text.primaryChannel} / 0.8)`
               : alpha(theme.palette.text.primary, 0.8)
           }`,
-          outlineOffset: 2,
         },
         ...(variant === "folder" && {
           "&::after": {


### PR DESCRIPTION
## What

Makes the board scroll like a paginated surface in both axes, and extends the existing whole-column fit logic to rows.

### Changes

- **Tile spacing** — tighten the default grid gap (`2` → `1`) and thicken tile borders (`2px` → `4px`) / focus outline (`3px` → `4px`).
- **Horizontal snap** — `scroll-snap-type: x` plus per-cell `scroll-snap-align: start`, so horizontal scroll rests on clean column boundaries.
- **Whole-row fit + vertical pagination** — generalize the column-fitting math into axis-agnostic helpers (`visibleTracks` / `trackSize` / `gridExtent`) and apply them to rows against `100cqb`, mirroring how columns fit against `100cqi`. The scroll container moves to `containerType: size` so the block axis is queryable, and snapping extends to both axes.
- **Test fix** — the gap default change (`2` → `1`) left the responsive-sizing assertions computing expected widths with a stale 16px gap; lint-staged doesn't run vitest, so it went unnoticed. Corrected the constant and added a mirror `responsive row sizing` block.

## How it works

The board already showed only whole columns of ≥96px and overflowed the rest to a horizontal scroll. The same mechanic now drives rows against the container's block size: each visible row fills the height, extra rows overflow to a vertical scroll, and both axes snap to track boundaries — so the board pages cleanly in 2D.

## Verification

- `npx vitest run src/features/board/grid/grid.test.tsx` → 37 passed (incl. 3 new row-sizing tests)
- `npx tsc -b` → clean
- `eslint` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)