### PR TITLE
style: restore the 3px focus outline with offset

### DIFF
--- a/src/features/board/tile/tile.tsx
+++ b/src/features/board/tile/tile.tsx
@@ -59,11 +59,12 @@ export function Tile({
         },
         "&:active": { backgroundColor: darkened(30) },
         "&:focus-visible": {
-          outline: `4px solid ${
+          outline: `3px solid ${
             theme.vars
               ? `rgba(${theme.vars.palette.text.primaryChannel} / 0.8)`
               : alpha(theme.palette.text.primary, 0.8)
           }`,
+          outlineOffset: 2,
         },
         ...(variant === "folder" && {
           "&::after": {


### PR DESCRIPTION
Reverts the tile focus ring to a `3px` outline with `outlineOffset: 2`, undoing the focus-styling tweak that was bundled into #598 (which thickened it to `4px` and dropped the offset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)