### PR TITLE
feat: instant persistent library drawer + descriptive board icon

### DIFF
--- a/src/app/layouts/app-header.tsx
+++ b/src/app/layouts/app-header.tsx
@@ -1,4 +1,4 @@
-import MenuIcon from "@mui/icons-material/Menu";
+import GridViewOutlinedIcon from "@mui/icons-material/GridViewOutlined";
 import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
 import AppBar from "@mui/material/AppBar";
 import IconButton from "@mui/material/IconButton";
@@ -34,7 +34,7 @@ export function AppHeader({
               onClick={onLibraryClick}
               sx={{ marginInlineEnd: 2 }}
             >
-              <MenuIcon />
+              <GridViewOutlinedIcon />
             </IconButton>
           </Tooltip>
         )}

--- a/src/app/layouts/content-column.tsx
+++ b/src/app/layouts/content-column.tsx
@@ -13,25 +13,13 @@ export function ContentColumn({
 }: ContentColumnProps) {
   return (
     <Box
-      sx={(theme) => ({
+      sx={{
         display: "flex",
         flexDirection: "column",
         flexGrow: 1,
         width: shifted ? `calc(100% - ${LIBRARY_DRAWER_WIDTH})` : "100%",
         marginLeft: shifted ? LIBRARY_DRAWER_WIDTH : 0,
-        transition: theme.transitions.create(
-          ["margin", "width"],
-          shifted
-            ? {
-                easing: theme.transitions.easing.easeOut,
-                duration: theme.transitions.duration.enteringScreen,
-              }
-            : {
-                easing: theme.transitions.easing.sharp,
-                duration: theme.transitions.duration.leavingScreen,
-              },
-        ),
-      })}
+      }}
     >
       {children}
     </Box>

--- a/src/app/library/library-drawer.tsx
+++ b/src/app/library/library-drawer.tsx
@@ -1,6 +1,5 @@
 import { DRAWER_BASE_WIDTH } from "@app/layouts/drawer-width";
 import { BoardSetLibrary, boardSetPath } from "@features/board";
-import { ExternalLink } from "@shared/components/external-link";
 import CloseIcon from "@mui/icons-material/Close";
 import GitHubIcon from "@mui/icons-material/GitHub";
 import Box from "@mui/material/Box";
@@ -11,6 +10,7 @@ import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { m } from "@paraglide/messages.js";
+import { ExternalLink } from "@shared/components/external-link";
 import { useMatches, useNavigate } from "react-router";
 
 export const LIBRARY_DRAWER_WIDTH = `calc(${DRAWER_BASE_WIDTH} + env(safe-area-inset-left))`;

--- a/src/app/library/library-drawer.tsx
+++ b/src/app/library/library-drawer.tsx
@@ -9,6 +9,7 @@ import IconButton from "@mui/material/IconButton";
 import Toolbar from "@mui/material/Toolbar";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
+import useMediaQuery from "@mui/material/useMediaQuery";
 import { m } from "@paraglide/messages.js";
 import { useMatches, useNavigate } from "react-router";
 
@@ -30,6 +31,8 @@ export function LibraryDrawer({
   const activeSetId = activeMatch?.params.setId;
 
   const closeOnNavigate = variant === "temporary" ? onClose : undefined;
+  const reducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
+  const animated = variant === "temporary" && !reducedMotion;
 
   return (
     <Drawer
@@ -37,7 +40,7 @@ export function LibraryDrawer({
       open={open}
       onClose={onClose}
       variant={variant}
-      transitionDuration={variant === "persistent" ? 0 : undefined}
+      transitionDuration={animated ? undefined : 0}
       slotProps={{
         paper: {
           "aria-label": m.libraryTitle(),

--- a/src/app/library/library-drawer.tsx
+++ b/src/app/library/library-drawer.tsx
@@ -37,6 +37,7 @@ export function LibraryDrawer({
       open={open}
       onClose={onClose}
       variant={variant}
+      transitionDuration={variant === "persistent" ? 0 : undefined}
       slotProps={{
         paper: {
           "aria-label": m.libraryTitle(),


### PR DESCRIPTION
Removes the open/close animation from the library drawer in persistent (desktop) mode and gives the library button a more descriptive icon.

## Changes
- **Persistent drawer snaps instead of slides.** A persistent drawer reconfigures the desktop layout rather than overlaying it, so the drawer and the content column now jump to their final positions (`transitionDuration={0}` + dropped the content-column `margin`/`width` transition). This also avoids the board re-fitting mid-animation as the content width changes.
- **Board-grid icon for the library button.** Replaces the generic hamburger with `GridViewOutlined` — it signals the button reveals a collection of boards, and the outlined weight matches the adjacent settings icon. Same icon on both breakpoints (it describes the destination, not the overlay-vs-push mechanism).
- **Respect `prefers-reduced-motion`.** The mobile temporary drawer still slid; it now snaps too when the OS requests reduced motion. The rule is captured in an `animated` flag: animate only the temporary variant, and only when motion is allowed — relevant for the AAC audience (vestibular/attention sensitivity, eye-gaze/switch users).

## Notes
- Left the content-column width/margin layout math untouched — it's load-bearing and correct; simplifying it blind would be a regression risk for no user-visible gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)