### PR TITLE
refactor: drop tooltips from the backspace and play buttons

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -91,7 +91,6 @@
   "navHome": "الانتقال إلى الرئيسية",
   "messageBackspace": "مسح",
   "messageBackspaceLongPressHint": "اضغط مطوّلًا لمسح الرسالة.",
-  "messageBackspaceTooltip": "مسح · اضغط مطوّلًا لمسح الكل",
   "messagePlay": "تشغيل الرسالة",
   "messageStop": "إيقاف",
   "toneSelection": "اختيار النبرة",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -91,7 +91,6 @@
   "navHome": "Към началото",
   "messageBackspace": "Изтриване",
   "messageBackspaceLongPressHint": "Задръжте, за да изчистите съобщението.",
-  "messageBackspaceTooltip": "Изтриване · Задръжте за изчистване",
   "messagePlay": "Възпроизвеждане на съобщението",
   "messageStop": "Спиране",
   "toneSelection": "Избор на тон",

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -91,7 +91,6 @@
   "navHome": "হোমে যান",
   "messageBackspace": "মুছুন",
   "messageBackspaceLongPressHint": "বার্তা মুছতে দীর্ঘক্ষণ চাপুন।",
-  "messageBackspaceTooltip": "মুছুন · সব মুছতে দীর্ঘক্ষণ চাপুন",
   "messagePlay": "বার্তা চালান",
   "messageStop": "থামান",
   "toneSelection": "টোন নির্বাচন",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -91,7 +91,6 @@
   "navHome": "Přejít domů",
   "messageBackspace": "Smazat",
   "messageBackspaceLongPressHint": "Dlouhým stisknutím zprávu vymažete.",
-  "messageBackspaceTooltip": "Smazat · Podržením vymažete vše",
   "messagePlay": "Přehrát zprávu",
   "messageStop": "Zastavit",
   "toneSelection": "Výběr tónu",

--- a/messages/da.json
+++ b/messages/da.json
@@ -91,7 +91,6 @@
   "navHome": "Gå til start",
   "messageBackspace": "Slet",
   "messageBackspaceLongPressHint": "Hold nede for at rydde beskeden.",
-  "messageBackspaceTooltip": "Slet · Hold nede for at rydde",
   "messagePlay": "Afspil besked",
   "messageStop": "Stop",
   "toneSelection": "Valg af tone",

--- a/messages/de.json
+++ b/messages/de.json
@@ -91,7 +91,6 @@
   "navHome": "Zur Startseite",
   "messageBackspace": "Löschen",
   "messageBackspaceLongPressHint": "Lange drücken, um die Nachricht zu löschen.",
-  "messageBackspaceTooltip": "Löschen · Halten, um alles zu löschen",
   "messagePlay": "Nachricht abspielen",
   "messageStop": "Stopp",
   "toneSelection": "Tonauswahl",

--- a/messages/el.json
+++ b/messages/el.json
@@ -91,7 +91,6 @@
   "navHome": "Μετάβαση στην αρχική",
   "messageBackspace": "Διαγραφή",
   "messageBackspaceLongPressHint": "Πατήστε παρατεταμένα για εκκαθάριση του μηνύματος.",
-  "messageBackspaceTooltip": "Διαγραφή · Πατήστε παρατεταμένα για εκκαθάριση",
   "messagePlay": "Αναπαραγωγή μηνύματος",
   "messageStop": "Διακοπή",
   "toneSelection": "Επιλογή τόνου",

--- a/messages/en.json
+++ b/messages/en.json
@@ -91,7 +91,6 @@
   "navHome": "Go home",
   "messageBackspace": "Backspace",
   "messageBackspaceLongPressHint": "Long press to clear message.",
-  "messageBackspaceTooltip": "Backspace · Hold to clear",
   "messagePlay": "Play message",
   "messageStop": "Stop",
   "toneSelection": "Tone selection",

--- a/messages/es.json
+++ b/messages/es.json
@@ -91,7 +91,6 @@
   "navHome": "Ir al inicio",
   "messageBackspace": "Borrar",
   "messageBackspaceLongPressHint": "Mantén pulsado para borrar el mensaje.",
-  "messageBackspaceTooltip": "Borrar · Mantén pulsado para borrar todo",
   "messagePlay": "Reproducir mensaje",
   "messageStop": "Detener",
   "toneSelection": "Selección de tono",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -91,7 +91,6 @@
   "navHome": "Siirry etusivulle",
   "messageBackspace": "Poista",
   "messageBackspaceLongPressHint": "Tyhjennä viesti painamalla pitkään.",
-  "messageBackspaceTooltip": "Poista · Tyhjennä painamalla pitkään",
   "messagePlay": "Toista viesti",
   "messageStop": "Pysäytä",
   "toneSelection": "Sävyn valinta",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -91,7 +91,6 @@
   "navHome": "Aller à l'accueil",
   "messageBackspace": "Effacer",
   "messageBackspaceLongPressHint": "Appui long pour effacer le message.",
-  "messageBackspaceTooltip": "Effacer · Appui long pour tout effacer",
   "messagePlay": "Lire le message",
   "messageStop": "Arrêter",
   "toneSelection": "Sélection du ton",

--- a/messages/he.json
+++ b/messages/he.json
@@ -91,7 +91,6 @@
   "navHome": "לעמוד הבית",
   "messageBackspace": "מחיקה",
   "messageBackspaceLongPressHint": "לחיצה ארוכה לניקוי ההודעה.",
-  "messageBackspaceTooltip": "מחיקה · לחיצה ארוכה לניקוי",
   "messagePlay": "השמעת הודעה",
   "messageStop": "עצירה",
   "toneSelection": "בחירת סגנון",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -91,7 +91,6 @@
   "navHome": "होम पर जाएँ",
   "messageBackspace": "मिटाएं",
   "messageBackspaceLongPressHint": "संदेश साफ़ करने के लिए देर तक दबाएँ।",
-  "messageBackspaceTooltip": "मिटाएं · सब साफ़ करने के लिए देर तक दबाएँ",
   "messagePlay": "संदेश चलाएँ",
   "messageStop": "रोकें",
   "toneSelection": "टोन चयन",

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -91,7 +91,6 @@
   "navHome": "Idi na početnu",
   "messageBackspace": "Obriši",
   "messageBackspaceLongPressHint": "Dugo pritisnite za brisanje poruke.",
-  "messageBackspaceTooltip": "Obriši · Dugo pritisnite za brisanje svega",
   "messagePlay": "Reproduciraj poruku",
   "messageStop": "Zaustavi",
   "toneSelection": "Odabir tona",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -91,7 +91,6 @@
   "navHome": "Ugrás a kezdőlapra",
   "messageBackspace": "Törlés",
   "messageBackspaceLongPressHint": "Tartsd lenyomva az üzenet törléséhez.",
-  "messageBackspaceTooltip": "Törlés · Tartsd lenyomva a teljes törléshez",
   "messagePlay": "Üzenet lejátszása",
   "messageStop": "Leállítás",
   "toneSelection": "Hangnem kiválasztása",

--- a/messages/id.json
+++ b/messages/id.json
@@ -91,7 +91,6 @@
   "navHome": "Ke beranda",
   "messageBackspace": "Hapus",
   "messageBackspaceLongPressHint": "Tekan lama untuk menghapus pesan.",
-  "messageBackspaceTooltip": "Hapus · Tekan lama untuk menghapus semua",
   "messagePlay": "Putar pesan",
   "messageStop": "Hentikan",
   "toneSelection": "Pemilihan nada",

--- a/messages/it.json
+++ b/messages/it.json
@@ -91,7 +91,6 @@
   "navHome": "Vai alla home",
   "messageBackspace": "Cancella",
   "messageBackspaceLongPressHint": "Tieni premuto per cancellare il messaggio.",
-  "messageBackspaceTooltip": "Cancella · Tieni premuto per cancellare tutto",
   "messagePlay": "Riproduci messaggio",
   "messageStop": "Interrompi",
   "toneSelection": "Selezione del tono",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -91,7 +91,6 @@
   "navHome": "ホームに戻る",
   "messageBackspace": "消去",
   "messageBackspaceLongPressHint": "長押しでメッセージを消去します。",
-  "messageBackspaceTooltip": "消去・長押しで全消去",
   "messagePlay": "メッセージを再生",
   "messageStop": "停止",
   "toneSelection": "トーンの選択",

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -91,7 +91,6 @@
   "navHome": "ಮುಖಪುಟಕ್ಕೆ ಹೋಗಿ",
   "messageBackspace": "ಅಳಿಸು",
   "messageBackspaceLongPressHint": "ಸಂದೇಶವನ್ನು ತೆರವುಗೊಳಿಸಲು ದೀರ್ಘವಾಗಿ ಒತ್ತಿರಿ.",
-  "messageBackspaceTooltip": "ಅಳಿಸು · ಎಲ್ಲವನ್ನೂ ತೆರವುಗೊಳಿಸಲು ದೀರ್ಘವಾಗಿ ಒತ್ತಿರಿ",
   "messagePlay": "ಸಂದೇಶವನ್ನು ಪ್ಲೇ ಮಾಡಿ",
   "messageStop": "ನಿಲ್ಲಿಸಿ",
   "toneSelection": "ಧಾಟಿ ಆಯ್ಕೆ",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -91,7 +91,6 @@
   "navHome": "홈으로",
   "messageBackspace": "지우기",
   "messageBackspaceLongPressHint": "길게 눌러 메시지를 지웁니다.",
-  "messageBackspaceTooltip": "지우기 · 길게 눌러 모두 지우기",
   "messagePlay": "메시지 재생",
   "messageStop": "중지",
   "toneSelection": "어조 선택",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -91,7 +91,6 @@
   "navHome": "Naar start",
   "messageBackspace": "Wissen",
   "messageBackspaceLongPressHint": "Houd ingedrukt om het bericht te wissen.",
-  "messageBackspaceTooltip": "Wissen · Houd ingedrukt om alles te wissen",
   "messagePlay": "Bericht afspelen",
   "messageStop": "Stoppen",
   "toneSelection": "Toonselectie",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -91,7 +91,6 @@
   "navHome": "Przejdź do strony głównej",
   "messageBackspace": "Usuń",
   "messageBackspaceLongPressHint": "Przytrzymaj, aby wyczyścić wiadomość.",
-  "messageBackspaceTooltip": "Usuń · Przytrzymaj, aby wyczyścić",
   "messagePlay": "Odtwórz wiadomość",
   "messageStop": "Zatrzymaj",
   "toneSelection": "Wybór tonu",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -91,7 +91,6 @@
   "navHome": "Ir para o início",
   "messageBackspace": "Apagar",
   "messageBackspaceLongPressHint": "Pressione e segure para limpar a mensagem.",
-  "messageBackspaceTooltip": "Apagar · Pressione e segure para limpar",
   "messagePlay": "Reproduzir mensagem",
   "messageStop": "Parar",
   "toneSelection": "Seleção de tom",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -91,7 +91,6 @@
   "navHome": "Mergi la pagina principală",
   "messageBackspace": "Șterge",
   "messageBackspaceLongPressHint": "Apasă lung pentru a șterge mesajul.",
-  "messageBackspaceTooltip": "Șterge · Apasă lung pentru a șterge tot",
   "messagePlay": "Redă mesajul",
   "messageStop": "Oprește",
   "toneSelection": "Selectarea tonului",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -91,7 +91,6 @@
   "navHome": "На главную",
   "messageBackspace": "Стереть",
   "messageBackspaceLongPressHint": "Удерживайте, чтобы очистить сообщение.",
-  "messageBackspaceTooltip": "Стереть · Удерживайте, чтобы очистить",
   "messagePlay": "Воспроизвести сообщение",
   "messageStop": "Остановить",
   "toneSelection": "Выбор тона",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -91,7 +91,6 @@
   "navHome": "Prejsť domov",
   "messageBackspace": "Vymazať",
   "messageBackspaceLongPressHint": "Dlhým stlačením vymažete správu.",
-  "messageBackspaceTooltip": "Vymazať · Podržaním vymažete všetko",
   "messagePlay": "Prehrať správu",
   "messageStop": "Zastaviť",
   "toneSelection": "Výber tónu",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -91,7 +91,6 @@
   "navHome": "Pojdi domov",
   "messageBackspace": "Briši",
   "messageBackspaceLongPressHint": "Za izbris sporočila pridržite.",
-  "messageBackspaceTooltip": "Briši · Pridržite za izbris vsega",
   "messagePlay": "Predvajaj sporočilo",
   "messageStop": "Ustavi",
   "toneSelection": "Izbira tona",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -91,7 +91,6 @@
   "navHome": "Till startsidan",
   "messageBackspace": "Radera",
   "messageBackspaceLongPressHint": "Håll inne för att rensa meddelandet.",
-  "messageBackspaceTooltip": "Radera · Håll inne för att rensa",
   "messagePlay": "Spela upp meddelande",
   "messageStop": "Stoppa",
   "toneSelection": "Tonval",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -91,7 +91,6 @@
   "navHome": "முகப்புக்குச் செல்",
   "messageBackspace": "அழி",
   "messageBackspaceLongPressHint": "செய்தியை அழிக்க நீண்ட நேரம் அழுத்தவும்.",
-  "messageBackspaceTooltip": "அழி · அனைத்தையும் அழிக்க நீண்ட நேரம் அழுத்தவும்",
   "messagePlay": "செய்தியை இயக்கு",
   "messageStop": "நிறுத்து",
   "toneSelection": "தொனி தேர்வு",

--- a/messages/te.json
+++ b/messages/te.json
@@ -91,7 +91,6 @@
   "navHome": "హోమ్‌కు వెళ్లు",
   "messageBackspace": "తుడిచివేయి",
   "messageBackspaceLongPressHint": "సందేశాన్ని క్లియర్ చేయడానికి నొక్కి ఉంచండి.",
-  "messageBackspaceTooltip": "తుడిచివేయి · అన్నీ క్లియర్ చేయడానికి నొక్కి ఉంచండి",
   "messagePlay": "సందేశాన్ని ప్లే చేయి",
   "messageStop": "ఆపు",
   "toneSelection": "టోన్ ఎంపిక",

--- a/messages/th.json
+++ b/messages/th.json
@@ -91,7 +91,6 @@
   "navHome": "ไปที่หน้าแรก",
   "messageBackspace": "ลบ",
   "messageBackspaceLongPressHint": "กดค้างเพื่อล้างข้อความ",
-  "messageBackspaceTooltip": "ลบ · กดค้างเพื่อล้างทั้งหมด",
   "messagePlay": "เล่นข้อความ",
   "messageStop": "หยุด",
   "toneSelection": "การเลือกโทน",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -91,7 +91,6 @@
   "navHome": "Ana sayfaya git",
   "messageBackspace": "Geri sil",
   "messageBackspaceLongPressHint": "Mesajı temizlemek için uzun basın.",
-  "messageBackspaceTooltip": "Geri sil · Tümünü temizlemek için uzun basın",
   "messagePlay": "Mesajı oynat",
   "messageStop": "Durdur",
   "toneSelection": "Ton seçimi",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -91,7 +91,6 @@
   "navHome": "На головну",
   "messageBackspace": "Стерти",
   "messageBackspaceLongPressHint": "Утримуйте, щоб очистити повідомлення.",
-  "messageBackspaceTooltip": "Стерти · Утримуйте, щоб очистити",
   "messagePlay": "Відтворити повідомлення",
   "messageStop": "Зупинити",
   "toneSelection": "Вибір тону",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -91,7 +91,6 @@
   "navHome": "Về trang chủ",
   "messageBackspace": "Xóa",
   "messageBackspaceLongPressHint": "Nhấn giữ để xóa tin nhắn.",
-  "messageBackspaceTooltip": "Xóa · Nhấn giữ để xóa tất cả",
   "messagePlay": "Phát tin nhắn",
   "messageStop": "Dừng",
   "toneSelection": "Lựa chọn giọng điệu",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -91,7 +91,6 @@
   "navHome": "返回主页",
   "messageBackspace": "删除",
   "messageBackspaceLongPressHint": "长按可清空消息。",
-  "messageBackspaceTooltip": "删除 · 长按清空",
   "messagePlay": "播放消息",
   "messageStop": "停止",
   "toneSelection": "语气选择",

--- a/src/features/board/message/backspace-button.tsx
+++ b/src/features/board/message/backspace-button.tsx
@@ -3,7 +3,6 @@ import Box from "@mui/material/Box";
 import CircularProgress from "@mui/material/CircularProgress";
 import IconButton from "@mui/material/IconButton";
 import { styled } from "@mui/material/styles";
-import Tooltip from "@mui/material/Tooltip";
 import { m } from "@paraglide/messages.js";
 import { flipForRtl } from "@shared/theme/rtl";
 import { useState } from "react";
@@ -48,34 +47,32 @@ export function BackspaceButton({
   });
 
   return (
-    <Tooltip title={m.messageBackspaceTooltip()}>
-      <Box sx={{ alignSelf: "center", position: "relative" }}>
-        <IconButton
-          {...mergeProps(pressProps, longPressProps)}
-          aria-label={m.messageBackspace()}
-          size="large"
-          color="inherit"
-          disabled={disabled}
-          sx={{ width: 72, height: 72 }}
-        >
-          <BackspaceOutlinedIcon sx={flipForRtl} />
-        </IconButton>
+    <Box sx={{ alignSelf: "center", position: "relative" }}>
+      <IconButton
+        {...mergeProps(pressProps, longPressProps)}
+        aria-label={m.messageBackspace()}
+        size="large"
+        color="inherit"
+        disabled={disabled}
+        sx={{ width: 72, height: 72 }}
+      >
+        <BackspaceOutlinedIcon sx={flipForRtl} />
+      </IconButton>
 
-        <StyledCircularProgress
-          aria-hidden
-          variant="determinate"
-          value={progress}
-          active={progress > 0}
-          size={72}
-          sx={{
-            position: "absolute",
-            top: 0,
-            insetInlineStart: 0,
-            zIndex: 1,
-            pointerEvents: "none",
-          }}
-        />
-      </Box>
-    </Tooltip>
+      <StyledCircularProgress
+        aria-hidden
+        variant="determinate"
+        value={progress}
+        active={progress > 0}
+        size={72}
+        sx={{
+          position: "absolute",
+          top: 0,
+          insetInlineStart: 0,
+          zIndex: 1,
+          pointerEvents: "none",
+        }}
+      />
+    </Box>
   );
 }

--- a/src/features/board/message/play-button.tsx
+++ b/src/features/board/message/play-button.tsx
@@ -1,8 +1,6 @@
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import StopIcon from "@mui/icons-material/Stop";
-import Box from "@mui/material/Box";
 import Fab from "@mui/material/Fab";
-import Tooltip from "@mui/material/Tooltip";
 import { m } from "@paraglide/messages.js";
 import { flipForRtl } from "@shared/theme/rtl";
 
@@ -22,25 +20,22 @@ export function PlayButton({
   const playButtonLabel = isPlaying ? m.messageStop() : m.messagePlay();
 
   return (
-    <Tooltip title={playButtonLabel}>
-      <Box sx={{ alignSelf: "center" }}>
-        <Fab
-          color={isPlaying ? "default" : "primary"}
-          disabled={disabled}
-          aria-label={playButtonLabel}
-          onClick={isPlaying ? onStopClick : onPlayClick}
-          sx={{
-            width: 72,
-            height: 72,
-          }}
-        >
-          {isPlaying ? (
-            <StopIcon sx={{ fontSize: 32 }} />
-          ) : (
-            <PlayArrowIcon sx={[flipForRtl, { fontSize: 32 }]} />
-          )}
-        </Fab>
-      </Box>
-    </Tooltip>
+    <Fab
+      color={isPlaying ? "default" : "primary"}
+      disabled={disabled}
+      aria-label={playButtonLabel}
+      onClick={isPlaying ? onStopClick : onPlayClick}
+      sx={{
+        alignSelf: "center",
+        width: 72,
+        height: 72,
+      }}
+    >
+      {isPlaying ? (
+        <StopIcon sx={{ fontSize: 32 }} />
+      ) : (
+        <PlayArrowIcon sx={[flipForRtl, { fontSize: 32 }]} />
+      )}
+    </Fab>
   );
 }


### PR DESCRIPTION
Removes the hover tooltips from the message bar's **backspace** and **play/stop** buttons. The `aria-label`s stay, so screen-reader users are unaffected.

## Changes
- **backspace** ([backspace-button.tsx](src/features/board/message/backspace-button.tsx)): unwrap the `Tooltip`; keep the `Box`, which is the positioning context for the long-press progress ring.
- **play** ([play-button.tsx](src/features/board/message/play-button.tsx)): the `Box` wrapper only existed to anchor the `Tooltip` over a disabled `Fab`, so collapse it and move `alignSelf` onto the `Fab`.
- Remove the now-orphaned `messageBackspaceTooltip` key from all 35 locale files (it was tooltip-only). `messagePlay` / `messageStop` / `messageBackspace` and the long-press hint remain in use as labels.

## Notes
- Both icons are conventional (backspace glyph, play/stop FAB), so dropping the hover hint is reasonable — accessibility is preserved via `aria-label`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)