### PR TITLE
chore: bump react-router and react eslint plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "react": "^19.2.7",
         "react-aria": "^3.50.0",
         "react-dom": "^19.2.7",
-        "react-router": "^8.0.0",
+        "react-router": "^8.0.1",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -44,11 +44,11 @@
         "babel-plugin-react-compiler": "^1.0.0",
         "eslint": "^10.5.0",
         "eslint-config-prettier": "^10.1.8",
-        "eslint-plugin-react-dom": "^5.9.0",
+        "eslint-plugin-react-dom": "^5.9.1",
         "eslint-plugin-react-hooks": "^7.1.1",
-        "eslint-plugin-react-jsx": "^5.9.0",
+        "eslint-plugin-react-jsx": "^5.9.1",
         "eslint-plugin-react-refresh": "^0.5.3",
-        "eslint-plugin-react-x": "^5.9.0",
+        "eslint-plugin-react-x": "^5.9.1",
         "globals": "^17.6.0",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.7",
@@ -1856,15 +1856,15 @@
       }
     },
     "node_modules/@eslint-react/ast": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/ast/-/ast-5.9.0.tgz",
-      "integrity": "sha512-D5DmbsEGYYmHOC2J68BRC2iJhYsD4K0x8mllgB08SeSQ0T/nP2BRogg/ohn5ZeRMb87ZDqN6NtGR7G7qTwgOSw==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/ast/-/ast-5.9.1.tgz",
+      "integrity": "sha512-PEBHBKxuKGrseO828u5/HFo89TdOa946q5veEjdDR+BjxlMuxhZxIqHkPyoS93dh6E+9mkZkcDerSGY5nCsm8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "^8.61.0",
-        "@typescript-eslint/typescript-estree": "^8.61.0",
-        "@typescript-eslint/utils": "^8.61.0",
+        "@typescript-eslint/types": "^8.61.1",
+        "@typescript-eslint/typescript-estree": "^8.61.1",
+        "@typescript-eslint/utils": "^8.61.1",
         "string-ts": "^2.3.1"
       },
       "engines": {
@@ -1876,20 +1876,20 @@
       }
     },
     "node_modules/@eslint-react/core": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/core/-/core-5.9.0.tgz",
-      "integrity": "sha512-GzARSlLTJT3FY9sUO9bYLoFtgiuUoNKzVv68oJkjAIembiu/6s1vyjs/I/1PEt+pEU6eu5hPjKHJXzd4boSDmQ==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/core/-/core-5.9.1.tgz",
+      "integrity": "sha512-CQ7ZQCRoqaHSBxld2zzfvjPBWuH0R6Op9FvCq+Nfennv/k6gbecA7IV47SlaXC7TKVB7zxiiwD3kD8ftaL8+xA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.9.0",
-        "@eslint-react/eslint": "5.9.0",
-        "@eslint-react/jsx": "5.9.0",
-        "@eslint-react/shared": "5.9.0",
-        "@eslint-react/var": "5.9.0",
-        "@typescript-eslint/scope-manager": "^8.61.0",
-        "@typescript-eslint/types": "^8.61.0",
-        "@typescript-eslint/utils": "^8.61.0",
+        "@eslint-react/ast": "5.9.1",
+        "@eslint-react/eslint": "5.9.1",
+        "@eslint-react/jsx": "5.9.1",
+        "@eslint-react/shared": "5.9.1",
+        "@eslint-react/var": "5.9.1",
+        "@typescript-eslint/scope-manager": "^8.61.1",
+        "@typescript-eslint/types": "^8.61.1",
+        "@typescript-eslint/utils": "^8.61.1",
         "ts-pattern": "^5.9.0"
       },
       "engines": {
@@ -1901,13 +1901,13 @@
       }
     },
     "node_modules/@eslint-react/eslint": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/eslint/-/eslint-5.9.0.tgz",
-      "integrity": "sha512-PEJPNXLjzlpdq2A4+9XlVdYziZPGq7wM+PB8jtmUzurQuZ8dqfCoBiQNuu+8TYMPGet1lUjHhijCO8MM9mEfrg==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/eslint/-/eslint-5.9.1.tgz",
+      "integrity": "sha512-YJVfj1Z0+uaYI+KmdNDQpLT8KceLRjf8UH3gd/fJJ+Ye3jBuS5sXDxBBoG74OF61/mtTugrc9aBCes4hlouwBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^8.61.0"
+        "@typescript-eslint/utils": "^8.61.1"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -1918,18 +1918,18 @@
       }
     },
     "node_modules/@eslint-react/jsx": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/jsx/-/jsx-5.9.0.tgz",
-      "integrity": "sha512-dc6hBagLgCt+CSkWSJjbyPDGGcs/J9qHTdymMQrw51bO+DIztQpuy42E42EjOdxWcaw3U0eUtu330nZEcKqGMw==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/jsx/-/jsx-5.9.1.tgz",
+      "integrity": "sha512-rZVIWotHLOYdbsmBEMJCQlu2gUeHcU8dYa7EkhWPwuh3p1q1ydV+Jfn4whJwHVb/mTI8zy4957RnFbGGWVLa6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.9.0",
-        "@eslint-react/eslint": "5.9.0",
-        "@eslint-react/shared": "5.9.0",
-        "@eslint-react/var": "5.9.0",
-        "@typescript-eslint/types": "^8.61.0",
-        "@typescript-eslint/utils": "^8.61.0",
+        "@eslint-react/ast": "5.9.1",
+        "@eslint-react/eslint": "5.9.1",
+        "@eslint-react/shared": "5.9.1",
+        "@eslint-react/var": "5.9.1",
+        "@typescript-eslint/types": "^8.61.1",
+        "@typescript-eslint/utils": "^8.61.1",
         "ts-pattern": "^5.9.0"
       },
       "engines": {
@@ -1941,14 +1941,14 @@
       }
     },
     "node_modules/@eslint-react/shared": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/shared/-/shared-5.9.0.tgz",
-      "integrity": "sha512-Ln255YTTUSlONr+e0Lu1wi2X9fTuOlNNJNXTz6PYaNZFAwCNWdlhkzFL8HdIBgPiWPUKrt+OMuah8o0xVoHswA==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/shared/-/shared-5.9.1.tgz",
+      "integrity": "sha512-6VBZo5KTlyUrn27aW6u6nqVvX9igWxzQX0vVNCv/ObnCA6ElOn1TBC9ENwRoK73FJ86PcT25PWyz1LJRgwnefw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/eslint": "5.9.0",
-        "@typescript-eslint/utils": "^8.61.0",
+        "@eslint-react/eslint": "5.9.1",
+        "@typescript-eslint/utils": "^8.61.1",
         "ts-pattern": "^5.9.0",
         "zod": "^3.25.0 || ^4.0.0"
       },
@@ -1961,17 +1961,17 @@
       }
     },
     "node_modules/@eslint-react/var": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/var/-/var-5.9.0.tgz",
-      "integrity": "sha512-vNz4y4eFKRYetihXiiZueGgClsyTFhR3kltMDPwoZyJaERdkyeoUylY09OnWakJFitao1+s2eBkSVuFqA8dqrA==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/var/-/var-5.9.1.tgz",
+      "integrity": "sha512-s+hb4H+6CzFsL2E6Yw6/c3bzSFfNc2XNOP2Q60k4G05VCbUew30Aqcf0Ehiac5wgGmpDZ9/9wkJiNanW2M1viA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.9.0",
-        "@eslint-react/eslint": "5.9.0",
-        "@typescript-eslint/scope-manager": "^8.61.0",
-        "@typescript-eslint/types": "^8.61.0",
-        "@typescript-eslint/utils": "^8.61.0",
+        "@eslint-react/ast": "5.9.1",
+        "@eslint-react/eslint": "5.9.1",
+        "@typescript-eslint/scope-manager": "^8.61.1",
+        "@typescript-eslint/types": "^8.61.1",
+        "@typescript-eslint/utils": "^8.61.1",
         "ts-pattern": "^5.9.0"
       },
       "engines": {
@@ -5284,18 +5284,18 @@
       }
     },
     "node_modules/eslint-plugin-react-dom": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-dom/-/eslint-plugin-react-dom-5.9.0.tgz",
-      "integrity": "sha512-gBlV304swaW2S0MqVFkQhii0C+KAy2WmxFtVtho39h5GzWdjKjNIxdUdOPQvLAFd7B1/lkbJflqGQKf6sjWGTg==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-dom/-/eslint-plugin-react-dom-5.9.1.tgz",
+      "integrity": "sha512-e0NpfKZOOvdTkYQEDJT7qLKoTX4jAjH8/qcCuOrp8zqX1LMKPrKgPe8DXGyXG5T+Bt4b81/ZQ/s3S2zkJLFuNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.9.0",
-        "@eslint-react/eslint": "5.9.0",
-        "@eslint-react/jsx": "5.9.0",
-        "@eslint-react/shared": "5.9.0",
-        "@typescript-eslint/types": "^8.61.0",
-        "@typescript-eslint/utils": "^8.61.0",
+        "@eslint-react/ast": "5.9.1",
+        "@eslint-react/eslint": "5.9.1",
+        "@eslint-react/jsx": "5.9.1",
+        "@eslint-react/shared": "5.9.1",
+        "@typescript-eslint/types": "^8.61.1",
+        "@typescript-eslint/utils": "^8.61.1",
         "compare-versions": "^6.1.1"
       },
       "engines": {
@@ -5327,19 +5327,19 @@
       }
     },
     "node_modules/eslint-plugin-react-jsx": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-jsx/-/eslint-plugin-react-jsx-5.9.0.tgz",
-      "integrity": "sha512-K/8RtAb8GDuhoIsR+Feo5Cr57Ts1N2juekocxk9TuF3azx2bCOuHiuU/rqMStMWi5oLTPrg2XqquD2LeS7x6iQ==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-jsx/-/eslint-plugin-react-jsx-5.9.1.tgz",
+      "integrity": "sha512-zzhCRbuXFiGMhvCrjpcwKsob0Gos8o7d28EnhGw28YapHXx1KYt0fzUDuWDoRZ2bhYhlDHzeU+l+jEgemPpaaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.9.0",
-        "@eslint-react/core": "5.9.0",
-        "@eslint-react/eslint": "5.9.0",
-        "@eslint-react/jsx": "5.9.0",
-        "@eslint-react/shared": "5.9.0",
-        "@typescript-eslint/types": "^8.61.0",
-        "@typescript-eslint/utils": "^8.61.0"
+        "@eslint-react/ast": "5.9.1",
+        "@eslint-react/core": "5.9.1",
+        "@eslint-react/eslint": "5.9.1",
+        "@eslint-react/jsx": "5.9.1",
+        "@eslint-react/shared": "5.9.1",
+        "@typescript-eslint/types": "^8.61.1",
+        "@typescript-eslint/utils": "^8.61.1"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -5360,23 +5360,23 @@
       }
     },
     "node_modules/eslint-plugin-react-x": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-x/-/eslint-plugin-react-x-5.9.0.tgz",
-      "integrity": "sha512-urgjMTtZpUzhkFBbQqp4+vdFhQmSkgeLnpq1h/2gemnzKjiMpDa9cCbo1vhjHnYQLzU6YRbxJ1hhqVv+9nXbjw==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-x/-/eslint-plugin-react-x-5.9.1.tgz",
+      "integrity": "sha512-0GwMpLdYx3HWMbDd1vqNr9VImkq34x/lQaLch2qDQmPOmi1DULL3yndl347wFhH4SbE6OUoJV2z0KCA72qnv5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "5.9.0",
-        "@eslint-react/core": "5.9.0",
-        "@eslint-react/eslint": "5.9.0",
-        "@eslint-react/jsx": "5.9.0",
-        "@eslint-react/shared": "5.9.0",
-        "@eslint-react/var": "5.9.0",
-        "@typescript-eslint/scope-manager": "^8.61.0",
-        "@typescript-eslint/type-utils": "^8.61.0",
-        "@typescript-eslint/types": "^8.61.0",
-        "@typescript-eslint/typescript-estree": "^8.61.0",
-        "@typescript-eslint/utils": "^8.61.0",
+        "@eslint-react/ast": "5.9.1",
+        "@eslint-react/core": "5.9.1",
+        "@eslint-react/eslint": "5.9.1",
+        "@eslint-react/jsx": "5.9.1",
+        "@eslint-react/shared": "5.9.1",
+        "@eslint-react/var": "5.9.1",
+        "@typescript-eslint/scope-manager": "^8.61.1",
+        "@typescript-eslint/type-utils": "^8.61.1",
+        "@typescript-eslint/types": "^8.61.1",
+        "@typescript-eslint/typescript-estree": "^8.61.1",
+        "@typescript-eslint/utils": "^8.61.1",
         "compare-versions": "^6.1.1",
         "string-ts": "^2.3.1",
         "ts-api-utils": "^2.5.0",
@@ -7949,9 +7949,9 @@
       "license": "MIT"
     },
     "node_modules/react-router": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.0.0.tgz",
-      "integrity": "sha512-AyS7LUn9M3g2/IBJDJNpWqElaQjPVBHGgMsdLGee6B2JLwP9STSpRwN8N4SauOeFTb0X5ZN0wxa1Iek78jF8Iw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.0.1.tgz",
+      "integrity": "sha512-5EL/fANovVUhRK50NLS8RYfX0BxrimoKsHWUPPy8v5UEl8i6vzF7e4POo3u+AhPItDwccUAJjMfIOmydxBJmQw==",
       "license": "MIT",
       "dependencies": {
         "cookie-es": "^3.1.1"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react": "^19.2.7",
     "react-aria": "^3.50.0",
     "react-dom": "^19.2.7",
-    "react-router": "^8.0.0",
+    "react-router": "^8.0.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -63,11 +63,11 @@
     "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "^10.5.0",
     "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-react-dom": "^5.9.0",
+    "eslint-plugin-react-dom": "^5.9.1",
     "eslint-plugin-react-hooks": "^7.1.1",
-    "eslint-plugin-react-jsx": "^5.9.0",
+    "eslint-plugin-react-jsx": "^5.9.1",
     "eslint-plugin-react-refresh": "^0.5.3",
-    "eslint-plugin-react-x": "^5.9.0",
+    "eslint-plugin-react-x": "^5.9.1",
     "globals": "^17.6.0",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.7",


### PR DESCRIPTION
Patch-level dependency bumps.

## Changes
- `react-router` `^8.0.0` → `^8.0.1`
- `eslint-plugin-react-dom` `^5.9.0` → `^5.9.1`
- `eslint-plugin-react-jsx` `^5.9.0` → `^5.9.1`
- `eslint-plugin-react-x` `^5.9.0` → `^5.9.1`

## Verification
- `npm run lint` ✅ (the three eslint-plugin-react-* bumps are the lint toolchain)
- `tsc -b` ✅
- `npm run build` ✅
- `npm test` ✅ — 451 tests across 67 files

`npm audit`: 0 vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)