### PR TITLE
feat: reset board scroll to start when home is tapped at home

### DIFF
--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -1,12 +1,13 @@
 import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import type { Theme } from "@mui/material/styles";
+import { useRef } from "react";
 import { m } from "@paraglide/messages.js";
 import { useLanguage } from "@shared/language/use-language";
 import { usePlaybackConfig } from "@shared/playback/playback-store";
 import { createButtonActivation } from "./activation/button-activation";
 import { getNavigationTargetId } from "./board-button";
-import { Grid, type GridItemProps } from "./grid/grid";
+import { Grid, type GridHandle, type GridItemProps } from "./grid/grid";
 import { useBoardKeyboard } from "./keyboard/use-board-keyboard";
 import { MessageBar } from "./message/message-bar";
 import { useMessagePlayback } from "./message/playback/use-message-playback";
@@ -51,6 +52,16 @@ export function BoardViewer({ board }: BoardViewerProps) {
 
   const keyboard = useBoardKeyboard({ message, playback });
 
+  const gridRef = useRef<GridHandle>(null);
+
+  const handleHomeClick = () => {
+    if (navigation.isOnHome) {
+      gridRef.current?.scrollToStart();
+    } else {
+      navigation.goHome();
+    }
+  };
+
   const renderTile = (button: BoardButton, props: GridItemProps) => (
     <Tile
       key={button.id}
@@ -85,7 +96,7 @@ export function BoardViewer({ board }: BoardViewerProps) {
           canGoBack={navigation.canGoBack}
           canGoHome={navigation.canGoHome}
           onBackClick={navigation.goBack}
-          onHomeClick={navigation.goHome}
+          onHomeClick={handleHomeClick}
         />
 
         {suggestions.isSupported && (
@@ -110,6 +121,7 @@ export function BoardViewer({ board }: BoardViewerProps) {
           order={board.grid.order}
           renderItem={renderTile}
           dir={direction}
+          ref={gridRef}
         />
       </Box>
     </Stack>

--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -1,7 +1,8 @@
 import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import type { Theme } from "@mui/material/styles";
-import type { ReactNode } from "react";
+import { useImperativeHandle, useRef } from "react";
+import type { ReactNode, Ref } from "react";
 import { useGridKeyboard } from "./use-grid-keyboard";
 
 const MIN_CELL_SIZE = "96px";
@@ -13,6 +14,10 @@ export interface GridItemProps {
   tabIndex: number;
 }
 
+export interface GridHandle {
+  scrollToStart: () => void;
+}
+
 export interface GridProps<TItem extends { id: string }> {
   ariaLabel?: string;
   items: readonly TItem[];
@@ -22,6 +27,7 @@ export interface GridProps<TItem extends { id: string }> {
   renderItem: (item: TItem, props: GridItemProps) => ReactNode;
   dir?: "ltr" | "rtl";
   gap?: number;
+  ref?: Ref<GridHandle>;
 }
 
 export function Grid<TItem extends { id: string }>({
@@ -33,6 +39,7 @@ export function Grid<TItem extends { id: string }>({
   renderItem,
   dir = "ltr",
   gap = 1,
+  ref,
 }: GridProps<TItem>) {
   const grid = buildGrid(items, rows, columns, order);
   const { rootRef, rootProps, activeCell } = useGridKeyboard({
@@ -40,8 +47,20 @@ export function Grid<TItem extends { id: string }>({
     dir,
   });
 
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  useImperativeHandle(
+    ref,
+    () => ({
+      scrollToStart() {
+        scrollContainerRef.current?.scrollTo({ top: 0, left: 0 });
+      },
+    }),
+    [],
+  );
+
   return (
     <Box
+      ref={scrollContainerRef}
       dir={dir}
       sx={(theme) => ({
         height: "100%",

--- a/src/features/board/navigation/use-board-navigation.ts
+++ b/src/features/board/navigation/use-board-navigation.ts
@@ -11,6 +11,7 @@ export interface BoardRouteParams {
 export interface UseBoardNavigationReturn {
   canGoBack: boolean;
   canGoHome: boolean;
+  isOnHome: boolean;
   goToBoard: (id: string) => void;
   goBack: () => void;
   goHome: () => void;
@@ -43,6 +44,7 @@ export function useBoardNavigation(): UseBoardNavigationReturn {
 
   const canGoBack = backStack.length > 0;
   const canGoHome = Boolean(rootBoardId);
+  const isOnHome = rootBoardId !== undefined && boardId === rootBoardId;
 
   function goToBoard(id: string) {
     if (!setId || !id || id === boardId) {
@@ -76,6 +78,7 @@ export function useBoardNavigation(): UseBoardNavigationReturn {
   return {
     canGoBack,
     canGoHome,
+    isOnHome,
     goToBoard,
     goBack,
     goHome,


### PR DESCRIPTION
Tapping the home button while already on the root board now scrolls the grid back to its start position (top-left), instead of doing nothing.

## How
- `Grid` exposes a `scrollToStart()` imperative handle (via `ref`), so it owns its own scroll mechanics rather than leaking the scroll container.
- `useBoardNavigation` exposes `isOnHome` (guarded against the loading-state `undefined === undefined` case).
- `BoardViewer` branches on home click: already home → `scrollToStart()`, otherwise navigate home as before.

`scrollTo({ top: 0, left: 0 })` lands exactly on the first scroll-snap point and resolves to the inline-start in both LTR and RTL on the app's modern targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)