### PR TITLE
fix: prevent the play button from shrinking in the message bar

### DIFF
--- a/src/features/board/message/play-button.tsx
+++ b/src/features/board/message/play-button.tsx
@@ -26,9 +26,10 @@ export function PlayButton({
       aria-label={playButtonLabel}
       onClick={isPlaying ? onStopClick : onPlayClick}
       sx={{
-        alignSelf: "center",
         width: 72,
         height: 72,
+        flexShrink: 0,
+        alignSelf: "center",
       }}
     >
       {isPlaying ? (


### PR DESCRIPTION
The play button is a fixed 72×72 FAB. In the message bar's flex row it could be compressed by sibling content; `flexShrink: 0` pins its size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)