### PR TITLE
fix: repair board-activation test stub and rename isOnHome to isHome

### DIFF
--- a/src/features/board/activation/button-activation.test.ts
+++ b/src/features/board/activation/button-activation.test.ts
@@ -32,6 +32,7 @@ function createNavigationStub(): UseBoardNavigationReturn {
   return {
     canGoBack: false,
     canGoHome: true,
+    isHome: false,
     goToBoard: vi.fn(),
     goBack: vi.fn(),
     goHome: vi.fn(),

--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -55,7 +55,7 @@ export function BoardViewer({ board }: BoardViewerProps) {
   const gridRef = useRef<GridHandle>(null);
 
   const handleHomeClick = () => {
-    if (navigation.isOnHome) {
+    if (navigation.isHome) {
       gridRef.current?.scrollToStart();
     } else {
       navigation.goHome();

--- a/src/features/board/navigation/use-board-navigation.ts
+++ b/src/features/board/navigation/use-board-navigation.ts
@@ -11,7 +11,7 @@ export interface BoardRouteParams {
 export interface UseBoardNavigationReturn {
   canGoBack: boolean;
   canGoHome: boolean;
-  isOnHome: boolean;
+  isHome: boolean;
   goToBoard: (id: string) => void;
   goBack: () => void;
   goHome: () => void;
@@ -44,7 +44,7 @@ export function useBoardNavigation(): UseBoardNavigationReturn {
 
   const canGoBack = backStack.length > 0;
   const canGoHome = Boolean(rootBoardId);
-  const isOnHome = rootBoardId !== undefined && boardId === rootBoardId;
+  const isHome = rootBoardId !== undefined && boardId === rootBoardId;
 
   function goToBoard(id: string) {
     if (!setId || !id || id === boardId) {
@@ -78,7 +78,7 @@ export function useBoardNavigation(): UseBoardNavigationReturn {
   return {
     canGoBack,
     canGoHome,
-    isOnHome,
+    isHome,
     goToBoard,
     goBack,
     goHome,


### PR DESCRIPTION
## What

- **Fixes the broken build on `main`.** The navigation stub in `button-activation.test.ts` was missing the `isOnHome` property added to `UseBoardNavigationReturn` in #603. Vitest doesn't typecheck at runtime, so the suite stayed green while the build's `tsc` step failed after merge.
- **Renames `isOnHome` → `isHome`.** "On home" elides the noun and isn't idiomatic English (you're "on the home *board*", not "on home"). `isHome` parallels the natural idiom and completes the bare-`Home` family alongside `goHome` / `canGoHome`.

## Sites touched

- `use-board-navigation.ts` — interface field, computed value, return
- `board-viewer.tsx` — consumer
- `button-activation.test.ts` — stub (also the missing-property fix)

Build and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)