### PR TITLE
refactor: centralize rounded corners into the theme

### DIFF
--- a/src/app/onboarding/onboarding-dialog.tsx
+++ b/src/app/onboarding/onboarding-dialog.tsx
@@ -121,13 +121,7 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
       </DialogContent>
 
       <DialogActions sx={{ px: 3, pb: 3 }}>
-        <Button
-          onClick={onClose}
-          variant="contained"
-          fullWidth
-          size="large"
-          sx={{ borderRadius: 6 }}
-        >
+        <Button onClick={onClose} variant="contained" fullWidth size="large">
           {m.onboardingContinue()}
         </Button>
       </DialogActions>

--- a/src/features/board/board-sets/board-set-library.tsx
+++ b/src/features/board/board-sets/board-set-library.tsx
@@ -1,7 +1,11 @@
 import LibraryAddOutlinedIcon from "@mui/icons-material/LibraryAddOutlined";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import Stack from "@mui/material/Stack";
+import List from "@mui/material/List";
+import ListItem from "@mui/material/ListItem";
+import ListItemButton from "@mui/material/ListItemButton";
+import ListItemIcon from "@mui/material/ListItemIcon";
+import ListItemText from "@mui/material/ListItemText";
 import { m } from "@paraglide/messages.js";
 import { EmptyState } from "@shared/components/empty-state";
 import { LoadingState } from "@shared/components/loading-state";
@@ -83,23 +87,16 @@ export function BoardSetLibrary({
 
   return (
     <>
-      <Stack
-        direction="row"
-        sx={{
-          alignItems: "center",
-          justifyContent: "flex-start",
-          px: 2,
-          pt: 1,
-        }}
-      >
-        <Button
-          variant="text"
-          startIcon={<LibraryAddOutlinedIcon />}
-          onClick={() => void pickAndImportBoardFiles()}
-        >
-          {m.libraryImportBoards()}
-        </Button>
-      </Stack>
+      <List sx={{ px: 1, mb: 2 }}>
+        <ListItem disablePadding>
+          <ListItemButton onClick={() => void pickAndImportBoardFiles()}>
+            <ListItemIcon>
+              <LibraryAddOutlinedIcon />
+            </ListItemIcon>
+            <ListItemText primary={m.libraryImportBoards()} />
+          </ListItemButton>
+        </ListItem>
+      </List>
 
       <BoardSetList
         boardSets={boardSets}

--- a/src/features/board/board-sets/board-set-list.tsx
+++ b/src/features/board/board-sets/board-set-list.tsx
@@ -113,7 +113,6 @@ export function BoardSetList({
               <ListItemButton
                 selected={boardSet.setId === selectedSetId}
                 onClick={() => onSelect(boardSet)}
-                sx={{ borderRadius: 6 }}
               >
                 <ListItemText
                   primary={

--- a/src/shared/theme/theme-provider.tsx
+++ b/src/shared/theme/theme-provider.tsx
@@ -76,6 +76,20 @@ const themeOptions = {
         }),
       },
     },
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 24,
+        },
+      },
+    },
+    MuiListItemButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 24,
+        },
+      },
+    },
   },
 } satisfies ThemeOptions;
 


### PR DESCRIPTION
## What

Centralizes button corner rounding into the MUI theme instead of repeating `borderRadius` overrides at each call site.

- Add `MuiButton` and `MuiListItemButton` `styleOverrides` with `borderRadius: 24` in the theme.
- Drop the per-component `borderRadius` `sx` overrides that duplicated this (onboarding continue button, board set list item).
- Restyle the import-boards action in the board set library as a `ListItemButton` so it matches the set list visually.

## Why

A single theme-level source of truth for corner radius — no more drift between call sites, and the import action reads consistently with the list it sits above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)