### PR TITLE
feat: add a "Boards" subheader to the board set list

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "المكتبة فارغة",
   "libraryEmptyDescription": "استورد لوحات تواصل للبدء.",
   "libraryImportBoards": "استيراد لوحات",
+  "libraryBoards": "لوحات",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "Библиотеката е празна",
   "libraryEmptyDescription": "Импортирайте комуникационни дъски, за да започнете.",
   "libraryImportBoards": "Импортиране на дъски",
+  "libraryBoards": "Дъски",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "লাইব্রেরি খালি",
   "libraryEmptyDescription": "শুরু করতে যোগাযোগ বোর্ড আমদানি করুন।",
   "libraryImportBoards": "বোর্ড আমদানি করুন",
+  "libraryBoards": "বোর্ড",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "Knihovna je prázdná",
   "libraryEmptyDescription": "Začněte importem komunikačních tabulek.",
   "libraryImportBoards": "Importovat tabulky",
+  "libraryBoards": "Tabulky",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/da.json
+++ b/messages/da.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "Biblioteket er tomt",
   "libraryEmptyDescription": "Importér kommunikationstavler for at komme i gang.",
   "libraryImportBoards": "Importér tavler",
+  "libraryBoards": "Tavler",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/de.json
+++ b/messages/de.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "Die Bibliothek ist leer",
   "libraryEmptyDescription": "Importiere Kommunikationstafeln, um loszulegen.",
   "libraryImportBoards": "Tafeln importieren",
+  "libraryBoards": "Tafeln",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/el.json
+++ b/messages/el.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "Η βιβλιοθήκη είναι κενή",
   "libraryEmptyDescription": "Εισαγάγετε πίνακες επικοινωνίας για να ξεκινήσετε.",
   "libraryImportBoards": "Εισαγωγή πινάκων",
+  "libraryBoards": "Πίνακες",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/en.json
+++ b/messages/en.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import communication boards to get started.",
   "libraryImportBoards": "Import boards",
+  "libraryBoards": "Boards",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/es.json
+++ b/messages/es.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "La biblioteca está vacía",
   "libraryEmptyDescription": "Importa tableros de comunicación para empezar.",
   "libraryImportBoards": "Importar tableros",
+  "libraryBoards": "Tableros",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "Kirjasto on tyhjä",
   "libraryEmptyDescription": "Tuo kommunikointitauluja päästäksesi alkuun.",
   "libraryImportBoards": "Tuo tauluja",
+  "libraryBoards": "Taulut",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "La bibliothèque est vide",
   "libraryEmptyDescription": "Importez des tableaux de communication pour commencer.",
   "libraryImportBoards": "Importer des tableaux",
+  "libraryBoards": "Tableaux",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/he.json
+++ b/messages/he.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "הספרייה ריקה",
   "libraryEmptyDescription": "כדי להתחיל, יש לייבא לוחות תקשורת.",
   "libraryImportBoards": "ייבוא לוחות",
+  "libraryBoards": "לוחות",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "लाइब्रेरी खाली है",
   "libraryEmptyDescription": "शुरू करने के लिए संचार बोर्ड आयात करें।",
   "libraryImportBoards": "बोर्ड आयात करें",
+  "libraryBoards": "बोर्ड",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "Knjižnica je prazna",
   "libraryEmptyDescription": "Za početak uvezite komunikacijske ploče.",
   "libraryImportBoards": "Uvezi ploče",
+  "libraryBoards": "Ploče",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "A könyvtár üres",
   "libraryEmptyDescription": "Az induláshoz importálj kommunikációs táblákat.",
   "libraryImportBoards": "Táblák importálása",
+  "libraryBoards": "Táblák",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/id.json
+++ b/messages/id.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "Pustaka kosong",
   "libraryEmptyDescription": "Impor papan komunikasi untuk memulai.",
   "libraryImportBoards": "Impor papan",
+  "libraryBoards": "Papan",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/it.json
+++ b/messages/it.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "La libreria è vuota",
   "libraryEmptyDescription": "Importa tabelle di comunicazione per iniziare.",
   "libraryImportBoards": "Importa tabelle",
+  "libraryBoards": "Tabelle",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "ライブラリは空です",
   "libraryEmptyDescription": "コミュニケーションボードをインポートして始めましょう。",
   "libraryImportBoards": "ボードをインポート",
+  "libraryBoards": "ボード",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "ಗ್ರಂಥಾಲಯ ಖಾಲಿಯಾಗಿದೆ",
   "libraryEmptyDescription": "ಪ್ರಾರಂಭಿಸಲು ಸಂವಹನ ಬೋರ್ಡ್‌ಗಳನ್ನು ಆಮದು ಮಾಡಿ.",
   "libraryImportBoards": "ಬೋರ್ಡ್‌ಗಳನ್ನು ಆಮದು ಮಾಡಿ",
+  "libraryBoards": "ಬೋರ್ಡ್‌ಗಳು",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "라이브러리가 비어 있습니다",
   "libraryEmptyDescription": "의사소통 보드를 가져와 시작하세요.",
   "libraryImportBoards": "보드 가져오기",
+  "libraryBoards": "보드",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "De bibliotheek is leeg",
   "libraryEmptyDescription": "Importeer communicatieborden om te beginnen.",
   "libraryImportBoards": "Borden importeren",
+  "libraryBoards": "Borden",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "Biblioteka jest pusta",
   "libraryEmptyDescription": "Zaimportuj tablice komunikacyjne, aby rozpocząć.",
   "libraryImportBoards": "Importuj tablice",
+  "libraryBoards": "Tablice",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "A biblioteca está vazia",
   "libraryEmptyDescription": "Importe pranchas de comunicação para começar.",
   "libraryImportBoards": "Importar pranchas",
+  "libraryBoards": "Pranchas",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "Biblioteca este goală",
   "libraryEmptyDescription": "Importă table de comunicare pentru a începe.",
   "libraryImportBoards": "Importă table",
+  "libraryBoards": "Table",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "Библиотека пуста",
   "libraryEmptyDescription": "Импортируйте коммуникационные доски, чтобы начать.",
   "libraryImportBoards": "Импортировать доски",
+  "libraryBoards": "Доски",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "Knižnica je prázdna",
   "libraryEmptyDescription": "Začnite importovaním komunikačných tabuliek.",
   "libraryImportBoards": "Importovať tabuľky",
+  "libraryBoards": "Tabuľky",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "Knjižnica je prazna",
   "libraryEmptyDescription": "Za začetek uvozite komunikacijske table.",
   "libraryImportBoards": "Uvozi table",
+  "libraryBoards": "Table",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "Biblioteket är tomt",
   "libraryEmptyDescription": "Importera kommunikationstavlor för att komma igång.",
   "libraryImportBoards": "Importera tavlor",
+  "libraryBoards": "Tavlor",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "நூலகம் காலியாக உள்ளது",
   "libraryEmptyDescription": "தொடங்க தொடர்பு பலகைகளை இறக்குமதி செய்யுங்கள்.",
   "libraryImportBoards": "பலகைகளை இறக்குமதி செய்",
+  "libraryBoards": "பலகைகள்",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/te.json
+++ b/messages/te.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "లైబ్రరీ ఖాళీగా ఉంది",
   "libraryEmptyDescription": "ప్రారంభించడానికి సంభాషణ బోర్డులను దిగుమతి చేయండి.",
   "libraryImportBoards": "బోర్డులను దిగుమతి చేయి",
+  "libraryBoards": "బోర్డులు",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/th.json
+++ b/messages/th.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "คลังว่างเปล่า",
   "libraryEmptyDescription": "นำเข้าบอร์ดสื่อสารเพื่อเริ่มต้น",
   "libraryImportBoards": "นำเข้าบอร์ด",
+  "libraryBoards": "บอร์ด",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "Kitaplık boş",
   "libraryEmptyDescription": "Başlamak için iletişim panoları içe aktarın.",
   "libraryImportBoards": "Panoları içe aktar",
+  "libraryBoards": "Panolar",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "Бібліотека порожня",
   "libraryEmptyDescription": "Імпортуйте комунікаційні дошки, щоб почати.",
   "libraryImportBoards": "Імпортувати дошки",
+  "libraryBoards": "Дошки",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "Thư viện trống",
   "libraryEmptyDescription": "Nhập các bảng giao tiếp để bắt đầu.",
   "libraryImportBoards": "Nhập bảng",
+  "libraryBoards": "Bảng",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -9,6 +9,7 @@
   "libraryEmptyTitle": "板库为空",
   "libraryEmptyDescription": "导入沟通板即可开始。",
   "libraryImportBoards": "导入沟通板",
+  "libraryBoards": "沟通板",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/src/features/board/board-sets/board-set-list.tsx
+++ b/src/features/board/board-sets/board-set-list.tsx
@@ -8,6 +8,7 @@ import ListItem from "@mui/material/ListItem";
 import ListItemButton from "@mui/material/ListItemButton";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
+import ListSubheader from "@mui/material/ListSubheader";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import Tooltip from "@mui/material/Tooltip";
@@ -68,6 +69,12 @@ export function BoardSetList({
   return (
     <>
       <List
+        aria-labelledby="board-set-list-subheader"
+        subheader={
+          <ListSubheader id="board-set-list-subheader">
+            {m.libraryBoards()}
+          </ListSubheader>
+        }
         sx={(theme) => ({
           px: 1,
           "@media (hover: hover)": {


### PR DESCRIPTION
## What

Adds a "Boards" section heading above the board set list.

- Render a `ListSubheader` via MUI's built-in `subheader` prop on the `List`, wired with `aria-labelledby` for accessibility.
- Add a `libraryBoards` message key across all 35 locales, using each locale's own term for "boards" in nominative-plural form (e.g. Greek `Πίνακες` rather than the genitive `πινάκων` from "Import boards"; Turkish `Panolar` rather than accusative `Panoları`).

## Why

Labels the list of imported board sets so it reads as a distinct section beneath the import action. The subheader only renders when at least one board set exists (the empty case shows `EmptyState`), so it never sits over an empty list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)