### PR TITLE
fix: wrap the board set list in a navigation landmark

### DIFF
--- a/src/features/board/board-sets/board-set-list.tsx
+++ b/src/features/board/board-sets/board-set-list.tsx
@@ -68,77 +68,78 @@ export function BoardSetList({
 
   return (
     <>
-      <List
-        aria-labelledby="board-set-list-subheader"
-        subheader={
-          <ListSubheader id="board-set-list-subheader">
-            {m.libraryBoards()}
-          </ListSubheader>
-        }
-        sx={(theme) => ({
-          px: 1,
-          "@media (hover: hover)": {
-            [theme.breakpoints.up("md")]: {
-              "& .MuiListItemSecondaryAction-root": {
-                opacity: 0,
-                pointerEvents: "none",
-                transition: theme.transitions.create("opacity", {
-                  duration: theme.transitions.duration.shortest,
-                }),
+      <Box component="nav" aria-labelledby="board-set-list-subheader">
+        <List
+          subheader={
+            <ListSubheader id="board-set-list-subheader">
+              {m.libraryBoards()}
+            </ListSubheader>
+          }
+          sx={(theme) => ({
+            px: 1,
+            "@media (hover: hover)": {
+              [theme.breakpoints.up("md")]: {
+                "& .MuiListItemSecondaryAction-root": {
+                  opacity: 0,
+                  pointerEvents: "none",
+                  transition: theme.transitions.create("opacity", {
+                    duration: theme.transitions.duration.shortest,
+                  }),
+                },
+                "& .MuiListItem-root:is(:hover, :focus-within, [data-menu-open]) .MuiListItemSecondaryAction-root":
+                  { opacity: 1, pointerEvents: "auto" },
               },
-              "& .MuiListItem-root:is(:hover, :focus-within, [data-menu-open]) .MuiListItemSecondaryAction-root":
-                { opacity: 1, pointerEvents: "auto" },
             },
-          },
-        })}
-      >
-        {boardSets.map((boardSet) => {
-          const isMenuOpen = activeMenuSetId === boardSet.setId;
+          })}
+        >
+          {boardSets.map((boardSet) => {
+            const isMenuOpen = activeMenuSetId === boardSet.setId;
 
-          return (
-            <ListItem
-              disablePadding
-              key={boardSet.setId}
-              data-menu-open={isMenuOpen || undefined}
-              secondaryAction={
-                <Tooltip title={m.libraryMoreOptions()}>
-                  <IconButton
-                    edge="end"
-                    aria-label={m.libraryMoreOptionsFor({
-                      name: boardSet.name,
-                    })}
-                    aria-controls={isMenuOpen ? "board-set-menu" : undefined}
-                    aria-haspopup="menu"
-                    aria-expanded={isMenuOpen ? "true" : undefined}
-                    onClick={(event) => handleMenuOpen(event, boardSet)}
-                  >
-                    <MoreVertIcon />
-                  </IconButton>
-                </Tooltip>
-              }
-            >
-              <ListItemButton
-                selected={boardSet.setId === selectedSetId}
-                onClick={() => onSelect(boardSet)}
-              >
-                <ListItemText
-                  primary={
-                    <Box
-                      sx={{
-                        whiteSpace: "nowrap",
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                      }}
+            return (
+              <ListItem
+                disablePadding
+                key={boardSet.setId}
+                data-menu-open={isMenuOpen || undefined}
+                secondaryAction={
+                  <Tooltip title={m.libraryMoreOptions()}>
+                    <IconButton
+                      edge="end"
+                      aria-label={m.libraryMoreOptionsFor({
+                        name: boardSet.name,
+                      })}
+                      aria-controls={isMenuOpen ? "board-set-menu" : undefined}
+                      aria-haspopup="menu"
+                      aria-expanded={isMenuOpen ? "true" : undefined}
+                      onClick={(event) => handleMenuOpen(event, boardSet)}
                     >
-                      {boardSet.name}
-                    </Box>
-                  }
-                />
-              </ListItemButton>
-            </ListItem>
-          );
-        })}
-      </List>
+                      <MoreVertIcon />
+                    </IconButton>
+                  </Tooltip>
+                }
+              >
+                <ListItemButton
+                  selected={boardSet.setId === selectedSetId}
+                  onClick={() => onSelect(boardSet)}
+                >
+                  <ListItemText
+                    primary={
+                      <Box
+                        sx={{
+                          whiteSpace: "nowrap",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                        }}
+                      >
+                        {boardSet.name}
+                      </Box>
+                    }
+                  />
+                </ListItemButton>
+              </ListItem>
+            );
+          })}
+        </List>
+      </Box>
 
       <Menu
         id="board-set-menu"


### PR DESCRIPTION
## Problem

Commit #607 added a `ListSubheader` ("Boards") to the board set list, which broke the a11y test in `board-set-library.test.tsx` with an axe `region` violation: *"All page content should be contained by landmarks."*

axe's region rule descends the tree and exempts buttons and landmarks — so the `ListItemButton` board rows and the "Import boards" button were never flagged. The new subheader is static text with no role and no enclosing landmark, so it counted as content outside any landmark.

This was a **real defect, not just a test artifact** — it would fire in production too. The `library-drawer` a11y test only passed because it renders the empty state and never shows the subheader.

## Fix

Wrap the `<List>` in a `navigation` landmark labeled by the existing subheader.

A separate `<Box component="nav">` is used rather than `<List component="nav">` — the latter would turn the `<ul>` into a `<nav>`, orphaning the `<li>` rows and stripping the list semantics. The wrapper keeps the `ul`/`li` intact while adding a properly-labeled landmark.

The subheader's accessible name lives on the landmark alone, not duplicated onto the list.

## Testing

- `board-set-library.test.tsx` (previously failing) ✅
- `board-set-list.test.tsx` ✅
- `library-drawer.test.tsx` ✅
- lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)