### PR TITLE
chore: bump version to 1.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aac-board-ai",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aac-board-ai",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aac-board-ai",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.12.0",
   "license": "MIT",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release **v1.12.0** — bumps `package.json` + `package-lock.json` from 1.11.0.

## Highlights since v1.11.0

**Features**
- Paginated board scrolling with whole-row/column fit (#598), and fit whole columns to the screen at any width (#597)
- Instant persistent library drawer + descriptive board icon (#600)
- Reset board scroll to start when home is tapped at home (#603)
- "Boards" subheader on the board set list (#607)
- Source code link in the library drawer footer (#593, centered in #594)

**Fixes & polish**
- Wrap the board set list in a navigation landmark (#608)
- Prevent the play button from shrinking in the message bar (#604)
- Repair board-activation test stub; rename `isOnHome` → `isHome` (#605)
- Restore the 3px focus outline with offset (#599)
- Drop tooltips from backspace/play buttons (#601)

**Refactors / chores**
- Centralize rounded corners into the theme (#606)
- Remove `onActiveSetDeleted` from `BoardSetLibrary` (#595)
- Bump react-router, react-aria 3.50.0, paraglide-js 2.20.0, react eslint plugins (#592, #602)
- Refine Hebrew wording for `aiBuiltInSupport` (#596)

After merge, tag the squashed bump commit on `main` with a signed annotated `v1.12.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)