### PR TITLE
refactor: consistency pass across app/features/shared + test-suite cleanup

### DIFF
--- a/src/app/layouts/app-header.tsx
+++ b/src/app/layouts/app-header.tsx
@@ -9,15 +9,15 @@ import { m } from "@paraglide/messages.js";
 import { usePageTitle } from "./page-title-store";
 
 export interface AppHeaderProps {
+  libraryButtonHidden?: boolean;
   onLibraryClick: () => void;
   onSettingsClick: () => void;
-  libraryButtonHidden?: boolean;
 }
 
 export function AppHeader({
+  libraryButtonHidden = false,
   onLibraryClick,
   onSettingsClick,
-  libraryButtonHidden = false,
 }: AppHeaderProps) {
   const pageTitle = usePageTitle();
 

--- a/src/app/library/library-drawer.tsx
+++ b/src/app/library/library-drawer.tsx
@@ -87,7 +87,7 @@ export function LibraryDrawer({
         })}
       >
         <BoardSetLibrary
-          activeSetId={activeSetId}
+          selectedSetId={activeSetId}
           onSelect={(boardSet) => {
             void navigate(boardSetPath(boardSet));
             closeOnNavigate?.();

--- a/src/app/routing/loaders/board-set-index-loader.ts
+++ b/src/app/routing/loaders/board-set-index-loader.ts
@@ -6,11 +6,11 @@ export async function boardSetIndexLoader({
   params,
 }: LoaderFunctionArgs): Promise<Response> {
   const { setId } = params;
-  const set = setId ? await getBoardSet(setId) : undefined;
+  const boardSet = setId ? await getBoardSet(setId) : undefined;
 
-  if (!set) {
+  if (!boardSet) {
     throw data(m.errorBoardSetNotFound(), { status: 404 });
   }
 
-  return redirect(boardSetPath(set));
+  return redirect(boardSetPath(boardSet));
 }

--- a/src/app/routing/loaders/root-index-loader.ts
+++ b/src/app/routing/loaders/root-index-loader.ts
@@ -14,9 +14,9 @@ async function resolveInitialRedirectPath(
     return boardSetPath(await importBoardFromUrl(boardUrl));
   }
 
-  const [existing] = await getBoardSets();
-  if (existing) {
-    return boardSetPath(existing);
+  const [boardSet] = await getBoardSets();
+  if (boardSet) {
+    return boardSetPath(boardSet);
   }
 
   return boardSetPath(await importBoardFromUrl(DEFAULT_BOARD_URL));

--- a/src/app/settings/ai-settings.tsx
+++ b/src/app/settings/ai-settings.tsx
@@ -27,48 +27,6 @@ import {
   type Status,
 } from "@shayc/react-built-in-ai";
 
-function statusLabel(status: Status, progress: number) {
-  switch (status) {
-    case "ready":
-      return m.aiStatusAvailable();
-    case "downloading":
-      return m.aiStatusDownloading({
-        progress: Math.round(progress * 100),
-      });
-    case "downloadable":
-      return m.aiStatusDownloadRequired();
-    case "idle":
-    case "unavailable":
-    case "error":
-    case "unsupported":
-      return m.aiStatusUnavailable();
-    default:
-      return status satisfies never;
-  }
-}
-
-function statusIcon(status: Status, progress: number) {
-  const title = statusLabel(status, progress);
-  switch (status) {
-    case "ready":
-      return (
-        <CheckCircleIcon color="success" fontSize="small" titleAccess={title} />
-      );
-    case "downloading":
-    case "downloadable":
-      return (
-        <DownloadingIcon color="action" fontSize="small" titleAccess={title} />
-      );
-    case "idle":
-    case "unavailable":
-    case "error":
-    case "unsupported":
-      return <CancelIcon color="error" fontSize="small" titleAccess={title} />;
-    default:
-      return status satisfies never;
-  }
-}
-
 export function AISettings() {
   const sharedContext = useAISharedContext();
   const { language } = useLanguage();
@@ -149,4 +107,46 @@ export function AISettings() {
       </Stack>
     </Stack>
   );
+}
+
+function statusLabel(status: Status, progress: number) {
+  switch (status) {
+    case "ready":
+      return m.aiStatusAvailable();
+    case "downloading":
+      return m.aiStatusDownloading({
+        progress: Math.round(progress * 100),
+      });
+    case "downloadable":
+      return m.aiStatusDownloadRequired();
+    case "idle":
+    case "unavailable":
+    case "error":
+    case "unsupported":
+      return m.aiStatusUnavailable();
+    default:
+      return status satisfies never;
+  }
+}
+
+function statusIcon(status: Status, progress: number) {
+  const title = statusLabel(status, progress);
+  switch (status) {
+    case "ready":
+      return (
+        <CheckCircleIcon color="success" fontSize="small" titleAccess={title} />
+      );
+    case "downloading":
+    case "downloadable":
+      return (
+        <DownloadingIcon color="action" fontSize="small" titleAccess={title} />
+      );
+    case "idle":
+    case "unavailable":
+    case "error":
+    case "unsupported":
+      return <CancelIcon color="error" fontSize="small" titleAccess={title} />;
+    default:
+      return status satisfies never;
+  }
 }

--- a/src/features/board/activation/button-activation.test.ts
+++ b/src/features/board/activation/button-activation.test.ts
@@ -82,21 +82,6 @@ describe("createButtonActivation", () => {
     expect(audio.play).not.toHaveBeenCalled();
   });
 
-  test("navigates when loadBoard.id is set even if actions are also present", async () => {
-    const { activation, message, playback, navigation } = setup();
-
-    await activation.activateButton({
-      id: "btn",
-      label: "Folder",
-      loadBoard: { id: "child-board" },
-      actions: [{ kind: "space" }],
-    });
-
-    expect(navigation.goToBoard).toHaveBeenCalledWith("child-board");
-    expect(message.addSpace).not.toHaveBeenCalled();
-    expect(playback.play).not.toHaveBeenCalled();
-  });
-
   test("runs each action in order for an actions array", async () => {
     const callOrder: string[] = [];
     const message = createMessageStub();

--- a/src/features/board/board-sets/board-set-info-dialog.tsx
+++ b/src/features/board/board-sets/board-set-info-dialog.tsx
@@ -15,29 +15,6 @@ export interface BoardSetInfoDialogProps {
   onClose: () => void;
 }
 
-function buildChipLabels(boardSet: BoardSetRecord): string[] {
-  const labels: string[] = [];
-
-  if (boardSet.gridRows && boardSet.gridColumns) {
-    labels.push(
-      m.libraryGridDimensions({
-        rows: boardSet.gridRows,
-        columns: boardSet.gridColumns,
-      }),
-    );
-  }
-
-  if (boardSet.locale) {
-    labels.push(getEnglishLanguageName(boardSet.locale));
-  }
-
-  if (boardSet.license) {
-    labels.push(boardSet.license);
-  }
-
-  return labels;
-}
-
 export function BoardSetInfoDialog({
   boardSet,
   onClose,
@@ -87,4 +64,27 @@ export function BoardSetInfoDialog({
       </DialogActions>
     </Dialog>
   );
+}
+
+function buildChipLabels(boardSet: BoardSetRecord): string[] {
+  const labels: string[] = [];
+
+  if (boardSet.gridRows && boardSet.gridColumns) {
+    labels.push(
+      m.libraryGridDimensions({
+        rows: boardSet.gridRows,
+        columns: boardSet.gridColumns,
+      }),
+    );
+  }
+
+  if (boardSet.locale) {
+    labels.push(getEnglishLanguageName(boardSet.locale));
+  }
+
+  if (boardSet.license) {
+    labels.push(boardSet.license);
+  }
+
+  return labels;
 }

--- a/src/features/board/board-sets/board-set-library.tsx
+++ b/src/features/board/board-sets/board-set-library.tsx
@@ -20,13 +20,13 @@ import { deleteBoardSet } from "./board-sets-store";
 import { useBoardSets } from "./use-board-sets";
 
 export interface BoardSetLibraryProps {
+  selectedSetId?: string;
   onSelect: (boardSet: BoardSetRecord) => void;
-  activeSetId?: string;
 }
 
 export function BoardSetLibrary({
+  selectedSetId,
   onSelect,
-  activeSetId,
 }: BoardSetLibraryProps) {
   const { boardSets, isLoading } = useBoardSets();
   const { pickAndImportBoardFiles } = useImportBoardFiles();
@@ -100,7 +100,7 @@ export function BoardSetLibrary({
 
       <BoardSetList
         boardSets={boardSets}
-        selectedSetId={activeSetId}
+        selectedSetId={selectedSetId}
         onSelect={onSelect}
         onDelete={setDeleteTarget}
         onInfo={setInfoTarget}

--- a/src/features/board/grid/use-grid-keyboard.ts
+++ b/src/features/board/grid/use-grid-keyboard.ts
@@ -82,7 +82,7 @@ export function useGridKeyboard({
     },
   });
 
-  const onFocus = (event: FocusEvent<HTMLElement>) => {
+  const handleFocus = (event: FocusEvent<HTMLElement>) => {
     const position = cellOf(event.target);
     if (position) {
       rememberCell(position);
@@ -116,7 +116,11 @@ export function useGridKeyboard({
     ? rememberedCell
     : findFirstNonEmptyCell(grid);
 
-  return { rootRef, rootProps: { ...keyboardProps, onFocus }, activeCell };
+  return {
+    rootRef,
+    rootProps: { ...keyboardProps, onFocus: handleFocus },
+    activeCell,
+  };
 }
 
 function findFirstNonEmptyCell(grid: readonly (readonly unknown[])[]): Cell {

--- a/src/features/board/message/message-bar.tsx
+++ b/src/features/board/message/message-bar.tsx
@@ -15,21 +15,6 @@ export interface MessageBarProps {
   onStopClick: () => void;
 }
 
-function scrollElementIntoView(
-  element: Element | undefined,
-  inline: ScrollLogicalPosition,
-): () => void {
-  if (!element) {
-    return () => undefined;
-  }
-
-  const frameId = requestAnimationFrame(() => {
-    element.scrollIntoView({ block: "nearest", inline, behavior: "instant" });
-  });
-
-  return () => cancelAnimationFrame(frameId);
-}
-
 export function MessageBar({
   parts,
   activePartId,
@@ -119,4 +104,19 @@ export function MessageBar({
       </Stack>
     </Stack>
   );
+}
+
+function scrollElementIntoView(
+  element: Element | undefined,
+  inline: ScrollLogicalPosition,
+): () => void {
+  if (!element) {
+    return () => undefined;
+  }
+
+  const frameId = requestAnimationFrame(() => {
+    element.scrollIntoView({ block: "nearest", inline, behavior: "instant" });
+  });
+
+  return () => cancelAnimationFrame(frameId);
 }

--- a/src/features/board/message/message-bar.tsx
+++ b/src/features/board/message/message-bar.tsx
@@ -84,7 +84,7 @@ export function MessageBar({
         <Stack
           ref={scrollContainerRef}
           direction="row"
-          sx={{ flexGrow: 1, padding: 2, gap: 1, overflow: "auto" }}
+          sx={{ flexGrow: 1, p: 2, gap: 1, overflow: "auto" }}
         >
           {parts.map((part) => {
             const isActive = part.id === activePartId;

--- a/src/features/board/message/play-button.test.tsx
+++ b/src/features/board/message/play-button.test.tsx
@@ -39,22 +39,6 @@ describe("PlayButton", () => {
     expect(handlers.onPlayClick).not.toHaveBeenCalled();
   });
 
-  test("changes label when isPlaying state changes", async () => {
-    const handlers = createHandlers();
-
-    const screen = await render(<PlayButton isPlaying={false} {...handlers} />);
-
-    await expect
-      .element(screen.getByRole("button", { name: "Play message" }))
-      .toBeVisible();
-
-    await screen.rerender(<PlayButton isPlaying={true} {...handlers} />);
-
-    await expect
-      .element(screen.getByRole("button", { name: "Stop" }))
-      .toBeVisible();
-  });
-
   describe("RTL icon mirroring", () => {
     test("play arrow icon is flipped in RTL", async () => {
       const theme = createTheme({ direction: "rtl" });

--- a/src/features/board/message/playback/use-message-playback.test.ts
+++ b/src/features/board/message/playback/use-message-playback.test.ts
@@ -82,16 +82,6 @@ describe("useMessagePlayback", () => {
     expect(audio.play).not.toHaveBeenCalled();
   });
 
-  test("prefers vocalization over label when both are present", async () => {
-    const parts: MessagePart[] = [{ id: "1", label: "I", vocalization: "eye" }];
-
-    const { result } = await renderHook(() => useMessagePlayback(parts));
-
-    await result.current.play();
-
-    expect(speech.speak.mock.calls[0][0].text).toBe("eye");
-  });
-
   test("reports isPlaying true during playback and false after it resolves", async () => {
     let resolveSpeak: (() => void) | undefined;
     speech.speak.mockImplementationOnce((utterance) => {

--- a/src/features/board/message/use-message.test.ts
+++ b/src/features/board/message/use-message.test.ts
@@ -91,16 +91,6 @@ describe("useMessage", () => {
     expect(result.current.text).toBe("hello");
   });
 
-  test("splits a text string into individual word parts", async () => {
-    const { result, rerender } = await renderHook(() => useMessage());
-
-    result.current.setFromText("I want water");
-    await rerender();
-
-    expect(result.current.parts).toHaveLength(3);
-    expect(result.current.text).toBe("I want water");
-  });
-
   test("keeps trailing punctuation attached to its word for TTS prosody", async () => {
     const { result, rerender } = await renderHook(() => useMessage());
 

--- a/src/features/board/navigation/use-board-navigation.ts
+++ b/src/features/board/navigation/use-board-navigation.ts
@@ -38,7 +38,9 @@ export function useBoardNavigation(): UseBoardNavigationReturn {
 
   const { setId, boardId } = useParams<BoardRouteParams>();
   const { boardSets } = useBoardSets();
-  const rootBoardId = boardSets.find((set) => set.setId === setId)?.rootBoardId;
+  const rootBoardId = boardSets.find(
+    (boardSet) => boardSet.setId === setId,
+  )?.rootBoardId;
 
   const backStack = readBackStack(location.state);
 

--- a/src/features/board/obf/obf-to-board.test.ts
+++ b/src/features/board/obf/obf-to-board.test.ts
@@ -343,45 +343,6 @@ describe("obfToBoard", () => {
       expect(board.buttons[0]?.soundSrc).toBe("sounds/snd-1.mp3");
     });
 
-    test("prefers path over url when data is absent", () => {
-      const obfBoard: OBFBoard = {
-        format: "open-board-0.1",
-        id: "board-path-fallback",
-        buttons: [
-          {
-            id: "btn-1",
-            label: "Media",
-            image_id: "img-1",
-            sound_id: "snd-1",
-          },
-        ],
-        grid: {
-          rows: 1,
-          columns: 1,
-          order: [["btn-1"]],
-        },
-        images: [
-          {
-            id: "img-1",
-            path: "images/img-1.png",
-            url: "https://example.com/img.png",
-          },
-        ],
-        sounds: [
-          {
-            id: "snd-1",
-            path: "sounds/snd-1.mp3",
-            url: "https://example.com/snd.mp3",
-          },
-        ],
-      };
-
-      const board = obfToBoard(obfBoard);
-
-      expect(board.buttons[0]?.imageSrc).toBe("images/img-1.png");
-      expect(board.buttons[0]?.soundSrc).toBe("sounds/snd-1.mp3");
-    });
-
     test("falls back to url when no data/path is available", () => {
       const obfBoard: OBFBoard = {
         format: "open-board-0.1",

--- a/src/features/board/suggestions/to-phrases.ts
+++ b/src/features/board/suggestions/to-phrases.ts
@@ -1,13 +1,5 @@
 const UNDERSCORED_WORD = /\b[A-Za-z]+_[A-Za-z]+\b/;
 
-function isClean(phrase: string): boolean {
-  return !UNDERSCORED_WORD.test(phrase) && !phrase.includes('"');
-}
-
-function normalize(phrase: string): string {
-  return phrase.trim().toLowerCase();
-}
-
 export function toPhrases(
   text: string,
   candidates: readonly (string | undefined)[],
@@ -25,4 +17,12 @@ export function toPhrases(
     seen.add(key);
     return true;
   });
+}
+
+function isClean(phrase: string): boolean {
+  return !UNDERSCORED_WORD.test(phrase) && !phrase.includes('"');
+}
+
+function normalize(phrase: string): string {
+  return phrase.trim().toLowerCase();
 }

--- a/src/features/board/suggestions/use-suggestions.test.ts
+++ b/src/features/board/suggestions/use-suggestions.test.ts
@@ -61,17 +61,6 @@ describe("useSuggestions", () => {
     });
   });
 
-  test("dedupes identical proofread and rewrite outputs", async () => {
-    stubProofreader(() => makeProofreadResult("Hello."));
-    stubRewriter(() => "Hello.");
-
-    const { result } = await renderSuggestions("helo");
-
-    await vi.waitFor(() => {
-      expect(result.current.phrases).toEqual(["Hello."]);
-    });
-  });
-
   test("dedupes proofread and rewrite outputs that differ only in case", async () => {
     stubProofreader(() => makeProofreadResult("My movies"));
     stubRewriter(() => "my movies");
@@ -91,20 +80,6 @@ describe("useSuggestions", () => {
 
     await vi.waitFor(() => {
       expect(result.current.phrases).toEqual(["Something different."]);
-    });
-  });
-
-  test.each([
-    ["underscored tokens", "raw_token", "I want food."],
-    ["double quotes", 'he said "hi"', "no quotes here"],
-  ])("filters out a candidate with %s", async (_label, rejected, accepted) => {
-    stubProofreader(() => makeProofreadResult(rejected));
-    stubRewriter(() => accepted);
-
-    const { result } = await renderSuggestions("seed");
-
-    await vi.waitFor(() => {
-      expect(result.current.phrases).toEqual([accepted]);
     });
   });
 

--- a/src/features/board/translation/resolve-translated-board.test.ts
+++ b/src/features/board/translation/resolve-translated-board.test.ts
@@ -132,17 +132,6 @@ describe("resolveTranslatedBoard", () => {
     expect(result).toBe(board);
   });
 
-  test("falls back to the source board when the navigation is aborted", async () => {
-    const board = makeBoard();
-    stubTranslator(() =>
-      Promise.reject(new DOMException("Aborted", "AbortError")),
-    );
-
-    const result = await resolveTranslatedBoard("set-1", board, "es");
-
-    expect(result).toBe(board);
-  });
-
   test("falls back even on unexpected errors so the board always renders", async () => {
     const board = makeBoard();
     stubTranslator(() => {

--- a/src/shared/components/external-link.tsx
+++ b/src/shared/components/external-link.tsx
@@ -1,6 +1,8 @@
 import Link, { type LinkProps } from "@mui/material/Link";
 
-export function ExternalLink(props: Omit<LinkProps, "target" | "rel">) {
+export type ExternalLinkProps = Omit<LinkProps, "target" | "rel">;
+
+export function ExternalLink(props: ExternalLinkProps) {
   return (
     <Link
       {...props}

--- a/src/shared/hooks/use-latest-async.test.ts
+++ b/src/shared/hooks/use-latest-async.test.ts
@@ -3,18 +3,6 @@ import { renderHook } from "vitest-browser-react";
 import { useLatestAsync } from "./use-latest-async";
 
 describe("useLatestAsync", () => {
-  test("returns the value once the fetch resolves", async () => {
-    const { result } = await renderHook(() =>
-      useLatestAsync({
-        enabled: true,
-        deps: ["a"],
-        fetch: () => Promise.resolve("value-a"),
-      }),
-    );
-
-    await vi.waitFor(() => expect(result.current.value).toBe("value-a"));
-  });
-
   test("stands down without fetching when not enabled", async () => {
     const fetch = vi.fn(() => Promise.resolve("value"));
 

--- a/src/shared/snackbar/snackbar-provider.tsx
+++ b/src/shared/snackbar/snackbar-provider.tsx
@@ -32,40 +32,6 @@ const initialState: SnackbarState = {
   open: false,
 };
 
-function snackbarReducer(
-  state: SnackbarState,
-  action: SnackbarAction,
-): SnackbarState {
-  switch (action.type) {
-    case "show": {
-      if (state.current) {
-        return {
-          ...state,
-          queue: [...state.queue, action.message],
-          open: false,
-        };
-      }
-
-      return { ...state, current: action.message, open: true };
-    }
-
-    case "close":
-      return { ...state, open: false };
-
-    case "exited": {
-      if (state.queue.length > 0) {
-        return {
-          current: state.queue[0],
-          queue: state.queue.slice(1),
-          open: true,
-        };
-      }
-
-      return { ...state, current: undefined };
-    }
-  }
-}
-
 export interface SnackbarProviderProps {
   children: ReactNode;
 }
@@ -131,4 +97,38 @@ export function SnackbarProvider({ children }: SnackbarProviderProps) {
       </Snackbar>
     </SnackbarContext>
   );
+}
+
+function snackbarReducer(
+  state: SnackbarState,
+  action: SnackbarAction,
+): SnackbarState {
+  switch (action.type) {
+    case "show": {
+      if (state.current) {
+        return {
+          ...state,
+          queue: [...state.queue, action.message],
+          open: false,
+        };
+      }
+
+      return { ...state, current: action.message, open: true };
+    }
+
+    case "close":
+      return { ...state, open: false };
+
+    case "exited": {
+      if (state.queue.length > 0) {
+        return {
+          current: state.queue[0],
+          queue: state.queue.slice(1),
+          open: true,
+        };
+      }
+
+      return { ...state, current: undefined };
+    }
+  }
 }


### PR DESCRIPTION
A focused consistency/polish pass over `src/app`, `src/features`, and `src/shared`, plus a verified test-suite cleanup. No behavior changes.

## Commits
- **Naming & structure** (`1122112`) — align prop ordering (data-then-callbacks), rename `BoardSetRecord` values to `boardSet`, `activeSetId` → `selectedSetId`, internal `onFocus` → `handleFocus`, spacing shorthand. Driven by a 5-dimension multi-agent review.
- **ExternalLinkProps** (`e5e8e8b`) — name + export the one shared component props type that was anonymous.
- **Public-first ordering** (`be91db3`) — components/modules lead with their named export; private helper functions hoisted below.
- **Test cleanup** (`cd16c13`) — remove 9 redundant/superseded test cases.

## Test cleanup detail
Audited all 67 suites (each in isolation), synthesized cross-suite overlaps, and ran an adversarial verifier per candidate — which **rejected 26 of 41** proposals to protect coverage (e.g. sole-asserter speech paths, resolver branches not actually covered elsewhere). One workflow "safe to remove" was additionally overridden by hand (`app-shell` onboarding — its dialog-dismissal assertion isn't covered by the app-routes integration test, so it was kept).

Removed only cases whose behavior stays covered by an equal-or-better keeper:
| Suite | Removed | Keeper |
|---|---|---|
| button-activation | navigate-precedence | resolver `toEqual([{navigate}])` |
| play-button | label-toggle | the two click tests (label-per-state) |
| use-message-playback | vocalization-over-label | plan-playback unit test |
| use-message | base word-split | punctuation-split tests (superset) |
| obf-to-board | path-over-url | precedence test (shared resolver branch) |
| use-suggestions | underscore/quote filter + identical-output dedup | to-phrases unit tests |
| resolve-translated-board | AbortError fallback | mid-failure test (undiscriminated catch) |
| use-latest-async | basic resolve | pending-lifecycle test (superset) |

## Verification
- 96 tests pass across the 8 affected suites; lint + prettier clean on every touched file.
- `tsc --noEmit` clean throughout the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)