### PR TITLE
test: assert speak() abort actually cancels the in-progress utterance

### DIFF
--- a/src/shared/speech/speech-store.cancellation.test.ts
+++ b/src/shared/speech/speech-store.cancellation.test.ts
@@ -34,14 +34,15 @@ describe("speak() under cancellation", () => {
     expect(speakSpy).not.toHaveBeenCalled();
   });
 
-  test("resolves and cancels the utterance when the signal aborts", async () => {
+  test("resolves and cancels the in-progress utterance when the signal aborts", async () => {
     const controller = new AbortController();
     const promise = speak("hello", { signal: controller.signal });
 
+    const cancelsBeforeAbort = cancelSpy.mock.calls.length;
     controller.abort();
+    expect(cancelSpy.mock.calls.length).toBeGreaterThan(cancelsBeforeAbort);
 
     await expect(promise).resolves.toBeUndefined();
-    expect(cancelSpy).toHaveBeenCalled();
   });
 
   test("stops reporting boundaries once the signal aborts", () => {


### PR DESCRIPTION
Follow-up to #610's audit. The `speak() under cancellation` suite had an assertion that looked like it verified abort→cancel but didn't.

## Problem
[`resolves and cancels the utterance when the signal aborts`](src/shared/speech/speech-store.cancellation.test.ts) ended with `expect(cancelSpy).toHaveBeenCalled()`. But `speak()` calls `synthesis.cancel()` **unconditionally before speaking** (the barge-in "clear the queue" step), so the spy already had a call before `controller.abort()` ever fired. The assertion passed regardless of whether aborting cancelled anything — vacuous w.r.t. the test's stated intent.

## Fix
Assert the cancel **count increases across the abort**, isolating the abort-triggered cancel from the pre-speak one (delta form, so it's robust to how many times the queue is cleared up front). Renamed to "in-progress" to match what it now verifies.

## Proof it now bites
Mutation check: removing the abort handler's `synthesis.cancel()` makes this test **fail** (`expected 1 to be greater than 1`), where the old `toHaveBeenCalled()` would have stayed green. Source untouched in this PR; 6/6 green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)