### PR TITLE
docs: review follow-up corrections to architecture.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 - Lint specific files: `npm run lint -- <files>`
 - Build (includes typecheck): `npm run build`
 - Playwright browsers (required for `npm test` / CI): `npx playwright install --with-deps`
-- CI (Node 24) runs install → Playwright install → lint → test → build.
+- CI (Node 24) runs install → Playwright install → lint → test:coverage → build (CI enforces coverage floors; `npm test` runs the same suite without them).
 - Pre-commit: `lint-staged` runs ESLint `--fix` + Prettier on staged files.
 
 ## Project Structure

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -161,7 +161,7 @@ hyperlinked, so a moved file never breaks this table.
 | `src/features/board/storage/`                                            | **The only reader/writer of IndexedDB.** `boards-db.ts` (idb) + `board-hydration.ts` (blobs → object URLs).                 |
 | `src/features/board/board-sets/`                                         | Board-set catalog (an external store with cross-tab sync) + delete/info dialogs.                                            |
 | `src/features/board/suggestions/`                                        | AI grammar + tone suggestions (Proofreader + Rewriter). Search `useSuggestions`.                                            |
-| `src/features/board/translation/`                                        | Board translation (Translator) + in-memory/IndexedDB cache. Search `resolveTranslatedBoard`.                                |
+| `src/features/board/translation/`                                        | Board translation (Translator), cached in the board's IndexedDB strings. Search `resolveTranslatedBoard`.                   |
 | `src/shared/speech/`                                                     | Web Speech API TTS wrapper, voice catalog store, voice↔language sync.                                                       |
 | `src/shared/language/`                                                   | The one language model: UI/board/TTS language context + persisted store.                                                    |
 | `src/shared/theme/`                                                      | MUI/Emotion theme, light/dark, RTL, theme-color meta.                                                                       |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -233,11 +233,12 @@ Rules that constrain every file but are visible in none — several are _absence
   memoization; manual hooks are a rare escape hatch, not the default.
 - **Theme values have a single source** (`theme-colors.ts`), shared into `index.html`
   by a Vite plugin; light/dark is a class toggled _pre-paint_ to avoid a flash.
-- **Board media object URLs have a single owner** — the hydration registry in
-  `board-hydration.ts`. A visible board's URLs are never revoked out from under it: a
-  load superseded mid-flight (rapid navigation) discards its own URLs instead of
-  replacing the live ones. The lifecycle lives in the loader because data mode has no
-  component unmount to hook into.
+- **Board media object URLs have a single owner** — a module-level registry in
+  `board-hydration.ts`, not the loader. A visible board's URLs are never revoked out
+  from under it: a load superseded mid-flight (rapid navigation) discards its own URLs
+  instead of replacing the live ones. The registry is a global because data mode has no
+  component unmount to hook into; it stays safe only because the loader is its sole,
+  serially-invoked caller — an assumption held by a comment, not the types.
 
 ## Boundaries
 


### PR DESCRIPTION
## Summary

Documentation-only follow-ups from review. No code changes.

- **AGENTS.md**: clarify CI runs `test:coverage` (enforced coverage floors), while `npm test` runs the same suite without them.
- **docs/architecture.md**: correct the translation-cache description — board translations are cached in the board's IndexedDB strings, not a separate in-memory/IndexedDB cache.
- **docs/architecture.md**: correct the object-URL lifecycle ownership — the single owner is a module-level registry in `board-hydration.ts` (not the loader), safe only because the loader is its sole serially-invoked caller, an assumption held by a comment rather than the types.

## Test plan

Docs only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)