### PR TITLE
feat: keep composed message selectable, lock UI chrome from selection

### DIFF
--- a/src/features/board/message/message-bar.tsx
+++ b/src/features/board/message/message-bar.tsx
@@ -69,7 +69,13 @@ export function MessageBar({
         <Stack
           ref={scrollContainerRef}
           direction="row"
-          sx={{ flexGrow: 1, p: 2, gap: 1, overflow: "auto" }}
+          sx={{
+            flexGrow: 1,
+            p: 2,
+            gap: 1,
+            overflow: "auto",
+            userSelect: "text",
+          }}
         >
           {parts.map((part) => {
             const isActive = part.id === activePartId;

--- a/src/shared/theme/theme-provider.tsx
+++ b/src/shared/theme/theme-provider.tsx
@@ -44,6 +44,9 @@ const themeOptions = {
         html: {
           overscrollBehaviorY: "none",
         },
+        body: {
+          userSelect: "none",
+        },
       },
     },
     MuiAppBar: {


### PR DESCRIPTION
## What

- Set `userSelect: "none"` on `body` so dragging over labels/controls no longer highlights UI chrome text.
- Re-enable `userSelect: "text"` on the message bar so the composed sentence stays selectable and copyable.

## Why

In an AAC app the boards are the input surface; accidental text selection of UI labels is noise, while the composed message is content the user may legitimately want to select or copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)