### PR TITLE
feat: add info tooltip to built-in AI support heading

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "مثل: ساخر، مهذّب.",
   "aiCustomInstructionsHelper": "خصّص اقتراحات الذكاء الاصطناعي.",
   "aiBuiltInSupport": "دعم الذكاء الاصطناعي المدمج",
+  "aiBuiltInSupportHelp": "يتطلب إصدار سطح المكتب من Google Chrome أو Microsoft Edge مع تفعيل العلامات التجريبية.",
   "aiStatusAvailable": "متاح",
   "aiStatusUnavailable": "غير متاح",
   "aiStatusDownloading": "جارٍ التنزيل… {progress}%",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "напр. Саркастичен, Учтив.",
   "aiCustomInstructionsHelper": "Персонализирайте предложенията на ИИ.",
   "aiBuiltInSupport": "Вградена поддръжка на ИИ",
+  "aiBuiltInSupportHelp": "Изисква настолната версия на Google Chrome или Microsoft Edge с включени експериментални флагове.",
   "aiStatusAvailable": "Налично",
   "aiStatusUnavailable": "Не е налично",
   "aiStatusDownloading": "Изтегляне… {progress}%",

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "যেমন, ব্যঙ্গাত্মক, ভদ্র।",
   "aiCustomInstructionsHelper": "AI পরামর্শ ব্যক্তিগতকৃত করুন।",
   "aiBuiltInSupport": "অন্তর্নির্মিত AI সমর্থন",
+  "aiBuiltInSupportHelp": "পরীক্ষামূলক ফ্ল্যাগ সক্ষম করা ডেস্কটপ Google Chrome বা Microsoft Edge প্রয়োজন।",
   "aiStatusAvailable": "উপলব্ধ",
   "aiStatusUnavailable": "অনুপলব্ধ",
   "aiStatusDownloading": "ডাউনলোড হচ্ছে… {progress}%",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "např. Sarkastický, Zdvořilý.",
   "aiCustomInstructionsHelper": "Přizpůsobte si návrhy AI.",
   "aiBuiltInSupport": "Vestavěná podpora AI",
+  "aiBuiltInSupportHelp": "Vyžaduje desktopový Google Chrome nebo Microsoft Edge se zapnutými experimentálními příznaky.",
   "aiStatusAvailable": "K dispozici",
   "aiStatusUnavailable": "Není k dispozici",
   "aiStatusDownloading": "Stahování… {progress} %",

--- a/messages/da.json
+++ b/messages/da.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "f.eks. Sarkastisk, Høflig.",
   "aiCustomInstructionsHelper": "Tilpas AI-forslagene.",
   "aiBuiltInSupport": "Indbygget AI-understøttelse",
+  "aiBuiltInSupportHelp": "Kræver Google Chrome eller Microsoft Edge på computer med eksperimentelle flag aktiveret.",
   "aiStatusAvailable": "Tilgængelig",
   "aiStatusUnavailable": "Ikke tilgængelig",
   "aiStatusDownloading": "Downloader… {progress}%",

--- a/messages/de.json
+++ b/messages/de.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "z. B. Sarkastisch, Höflich.",
   "aiCustomInstructionsHelper": "Personalisiere die KI-Vorschläge.",
   "aiBuiltInSupport": "Integrierte KI-Unterstützung",
+  "aiBuiltInSupportHelp": "Erfordert die Desktop-Version von Google Chrome oder Microsoft Edge mit aktivierten experimentellen Flags.",
   "aiStatusAvailable": "Verfügbar",
   "aiStatusUnavailable": "Nicht verfügbar",
   "aiStatusDownloading": "Wird heruntergeladen… {progress}%",

--- a/messages/el.json
+++ b/messages/el.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "π.χ. Σαρκαστικό, Ευγενικό.",
   "aiCustomInstructionsHelper": "Εξατομικεύστε τις προτάσεις του AI.",
   "aiBuiltInSupport": "Ενσωματωμένη υποστήριξη AI",
+  "aiBuiltInSupportHelp": "Απαιτεί την έκδοση υπολογιστή του Google Chrome ή του Microsoft Edge με ενεργοποιημένες πειραματικές σημαίες.",
   "aiStatusAvailable": "Διαθέσιμο",
   "aiStatusUnavailable": "Μη διαθέσιμο",
   "aiStatusDownloading": "Λήψη… {progress}%",

--- a/messages/en.json
+++ b/messages/en.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "e.g., Sarcastic, Polite.",
   "aiCustomInstructionsHelper": "Personalize AI suggestions.",
   "aiBuiltInSupport": "Built-in AI support",
+  "aiBuiltInSupportHelp": "Requires desktop Google Chrome or Microsoft Edge with experimental flags enabled.",
   "aiStatusAvailable": "Available",
   "aiStatusUnavailable": "Unavailable",
   "aiStatusDownloading": "Downloading… {progress}%",

--- a/messages/es.json
+++ b/messages/es.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "p. ej., Sarcástico, Educado.",
   "aiCustomInstructionsHelper": "Personaliza las sugerencias de IA.",
   "aiBuiltInSupport": "Compatibilidad con IA integrada",
+  "aiBuiltInSupportHelp": "Requiere Google Chrome o Microsoft Edge para escritorio con indicadores experimentales habilitados.",
   "aiStatusAvailable": "Disponible",
   "aiStatusUnavailable": "No disponible",
   "aiStatusDownloading": "Descargando… {progress}%",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "esim. Sarkastinen, Kohtelias.",
   "aiCustomInstructionsHelper": "Mukauta tekoälyn ehdotuksia.",
   "aiBuiltInSupport": "Sisäänrakennettu tekoälytuki",
+  "aiBuiltInSupportHelp": "Vaatii Google Chromen tai Microsoft Edgen työpöytäversion, jossa kokeelliset liput ovat käytössä.",
   "aiStatusAvailable": "Saatavilla",
   "aiStatusUnavailable": "Ei saatavilla",
   "aiStatusDownloading": "Ladataan… {progress} %",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "p. ex. Sarcastique, Poli.",
   "aiCustomInstructionsHelper": "Personnalisez les suggestions de l'IA.",
   "aiBuiltInSupport": "Prise en charge de l'IA intégrée",
+  "aiBuiltInSupportHelp": "Nécessite la version de bureau de Google Chrome ou Microsoft Edge avec les indicateurs expérimentaux activés.",
   "aiStatusAvailable": "Disponible",
   "aiStatusUnavailable": "Indisponible",
   "aiStatusDownloading": "Téléchargement… {progress} %",

--- a/messages/he.json
+++ b/messages/he.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "למשל: ציני, מנומס.",
   "aiCustomInstructionsHelper": "התאמה אישית של הצעות ה-AI.",
   "aiBuiltInSupport": "תמיכה ב-AI מובנה",
+  "aiBuiltInSupportHelp": "נדרשת גרסת שולחן העבודה של Google Chrome או Microsoft Edge עם דגלים ניסיוניים מופעלים.",
   "aiStatusAvailable": "זמין",
   "aiStatusUnavailable": "לא זמין",
   "aiStatusDownloading": "בהורדה… {progress}%",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "जैसे, व्यंग्यात्मक, विनम्र।",
   "aiCustomInstructionsHelper": "AI सुझावों को वैयक्तिकृत करें।",
   "aiBuiltInSupport": "अंतर्निहित AI समर्थन",
+  "aiBuiltInSupportHelp": "डेस्कटॉप Google Chrome या Microsoft Edge आवश्यक है, जिसमें प्रायोगिक फ़्लैग सक्षम हों।",
   "aiStatusAvailable": "उपलब्ध",
   "aiStatusUnavailable": "अनुपलब्ध",
   "aiStatusDownloading": "डाउनलोड हो रहा है… {progress}%",

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "npr. Sarkastičan, Pristojan.",
   "aiCustomInstructionsHelper": "Prilagodite prijedloge umjetne inteligencije.",
   "aiBuiltInSupport": "Ugrađena podrška za umjetnu inteligenciju",
+  "aiBuiltInSupportHelp": "Zahtijeva stolnu verziju preglednika Google Chrome ili Microsoft Edge s omogućenim eksperimentalnim zastavicama.",
   "aiStatusAvailable": "Dostupno",
   "aiStatusUnavailable": "Nedostupno",
   "aiStatusDownloading": "Preuzimanje… {progress} %",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "pl. Szarkasztikus, Udvarias.",
   "aiCustomInstructionsHelper": "Személyre szabhatod az MI-javaslatokat.",
   "aiBuiltInSupport": "Beépített MI-támogatás",
+  "aiBuiltInSupportHelp": "Az asztali Google Chrome vagy Microsoft Edge szükséges, engedélyezett kísérleti jelzőkkel.",
   "aiStatusAvailable": "Elérhető",
   "aiStatusUnavailable": "Nem érhető el",
   "aiStatusDownloading": "Letöltés… {progress}%",

--- a/messages/id.json
+++ b/messages/id.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "mis. Sarkastis, Sopan.",
   "aiCustomInstructionsHelper": "Personalisasikan saran AI.",
   "aiBuiltInSupport": "Dukungan AI bawaan",
+  "aiBuiltInSupportHelp": "Memerlukan Google Chrome atau Microsoft Edge versi desktop dengan flag eksperimental diaktifkan.",
   "aiStatusAvailable": "Tersedia",
   "aiStatusUnavailable": "Tidak tersedia",
   "aiStatusDownloading": "Mengunduh… {progress}%",

--- a/messages/it.json
+++ b/messages/it.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "ad es. Sarcastico, Cortese.",
   "aiCustomInstructionsHelper": "Personalizza i suggerimenti dell'IA.",
   "aiBuiltInSupport": "Supporto IA integrata",
+  "aiBuiltInSupportHelp": "Richiede Google Chrome o Microsoft Edge per desktop con i flag sperimentali abilitati.",
   "aiStatusAvailable": "Disponibile",
   "aiStatusUnavailable": "Non disponibile",
   "aiStatusDownloading": "Download… {progress}%",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "例：皮肉っぽく、丁寧に。",
   "aiCustomInstructionsHelper": "AI の提案をカスタマイズします。",
   "aiBuiltInSupport": "組み込み AI のサポート",
+  "aiBuiltInSupportHelp": "デスクトップ版の Google Chrome または Microsoft Edge で試験運用版のフラグを有効にする必要があります。",
   "aiStatusAvailable": "利用可能",
   "aiStatusUnavailable": "利用不可",
   "aiStatusDownloading": "ダウンロード中… {progress}%",

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "ಉದಾ., ವ್ಯಂಗ್ಯ, ಸಭ್ಯ.",
   "aiCustomInstructionsHelper": "AI ಸಲಹೆಗಳನ್ನು ವೈಯಕ್ತೀಕರಿಸಿ.",
   "aiBuiltInSupport": "ಅಂತರ್ನಿರ್ಮಿತ AI ಬೆಂಬಲ",
+  "aiBuiltInSupportHelp": "ಡೆಸ್ಕ್‌ಟಾಪ್ Google Chrome ಅಥವಾ Microsoft Edge ಅಗತ್ಯವಿದೆ, ಪ್ರಾಯೋಗಿಕ ಫ್ಲ್ಯಾಗ್‌ಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿರಬೇಕು.",
   "aiStatusAvailable": "ಲಭ್ಯವಿದೆ",
   "aiStatusUnavailable": "ಲಭ್ಯವಿಲ್ಲ",
   "aiStatusDownloading": "ಡೌನ್‌ಲೋಡ್ ಆಗುತ್ತಿದೆ… {progress}%",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "예: 냉소적으로, 공손하게.",
   "aiCustomInstructionsHelper": "AI 제안을 개인화하세요.",
   "aiBuiltInSupport": "내장 AI 지원",
+  "aiBuiltInSupportHelp": "데스크톱용 Google Chrome 또는 Microsoft Edge에서 실험용 플래그를 사용 설정해야 합니다.",
   "aiStatusAvailable": "사용 가능",
   "aiStatusUnavailable": "사용 불가",
   "aiStatusDownloading": "다운로드 중… {progress}%",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "bijv. Sarcastisch, Beleefd.",
   "aiCustomInstructionsHelper": "Personaliseer de AI-suggesties.",
   "aiBuiltInSupport": "Ingebouwde AI-ondersteuning",
+  "aiBuiltInSupportHelp": "Vereist de desktopversie van Google Chrome of Microsoft Edge met experimentele vlaggen ingeschakeld.",
   "aiStatusAvailable": "Beschikbaar",
   "aiStatusUnavailable": "Niet beschikbaar",
   "aiStatusDownloading": "Downloaden… {progress}%",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "np. Sarkastyczny, Uprzejmy.",
   "aiCustomInstructionsHelper": "Spersonalizuj sugestie AI.",
   "aiBuiltInSupport": "Wbudowana obsługa AI",
+  "aiBuiltInSupportHelp": "Wymaga przeglądarki Google Chrome lub Microsoft Edge na komputery z włączonymi flagami eksperymentalnymi.",
   "aiStatusAvailable": "Dostępne",
   "aiStatusUnavailable": "Niedostępne",
   "aiStatusDownloading": "Pobieranie… {progress}%",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "ex.: Sarcástico, Educado.",
   "aiCustomInstructionsHelper": "Personalize as sugestões da IA.",
   "aiBuiltInSupport": "Suporte a IA integrada",
+  "aiBuiltInSupportHelp": "Requer o Google Chrome ou Microsoft Edge para computador com sinalizadores experimentais ativados.",
   "aiStatusAvailable": "Disponível",
   "aiStatusUnavailable": "Indisponível",
   "aiStatusDownloading": "Baixando… {progress}%",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "ex. Sarcastic, Politicos.",
   "aiCustomInstructionsHelper": "Personalizează sugestiile AI.",
   "aiBuiltInSupport": "Suport AI integrat",
+  "aiBuiltInSupportHelp": "Necesită versiunea desktop a Google Chrome sau Microsoft Edge cu indicatoarele experimentale activate.",
   "aiStatusAvailable": "Disponibil",
   "aiStatusUnavailable": "Indisponibil",
   "aiStatusDownloading": "Se descarcă… {progress}%",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "напр. Саркастичный, Вежливый.",
   "aiCustomInstructionsHelper": "Персонализируйте предложения ИИ.",
   "aiBuiltInSupport": "Встроенная поддержка ИИ",
+  "aiBuiltInSupportHelp": "Требуется настольная версия Google Chrome или Microsoft Edge с включёнными экспериментальными флагами.",
   "aiStatusAvailable": "Доступно",
   "aiStatusUnavailable": "Недоступно",
   "aiStatusDownloading": "Загрузка… {progress}%",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "napr. Sarkastický, Zdvorilý.",
   "aiCustomInstructionsHelper": "Prispôsobte si návrhy AI.",
   "aiBuiltInSupport": "Vstavaná podpora AI",
+  "aiBuiltInSupportHelp": "Vyžaduje počítačovú verziu Google Chrome alebo Microsoft Edge so zapnutými experimentálnymi príznakmi.",
   "aiStatusAvailable": "K dispozícii",
   "aiStatusUnavailable": "Nie je k dispozícii",
   "aiStatusDownloading": "Sťahovanie… {progress} %",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "npr. Sarkastičen, Vljuden.",
   "aiCustomInstructionsHelper": "Prilagodite predloge UI.",
   "aiBuiltInSupport": "Vgrajena podpora za UI",
+  "aiBuiltInSupportHelp": "Zahteva namizno različico Google Chrome ali Microsoft Edge z omogočenimi eksperimentalnimi zastavicami.",
   "aiStatusAvailable": "Na voljo",
   "aiStatusUnavailable": "Ni na voljo",
   "aiStatusDownloading": "Prenašanje… {progress} %",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "t.ex. Sarkastisk, Artig.",
   "aiCustomInstructionsHelper": "Anpassa AI-förslagen.",
   "aiBuiltInSupport": "Inbyggt AI-stöd",
+  "aiBuiltInSupportHelp": "Kräver Google Chrome eller Microsoft Edge på datorn med experimentella flaggor aktiverade.",
   "aiStatusAvailable": "Tillgänglig",
   "aiStatusUnavailable": "Inte tillgänglig",
   "aiStatusDownloading": "Laddar ner… {progress}%",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "எ.கா., கிண்டலான, பணிவான.",
   "aiCustomInstructionsHelper": "AI பரிந்துரைகளைத் தனிப்பயனாக்கு.",
   "aiBuiltInSupport": "உள்ளமைந்த AI ஆதரவு",
+  "aiBuiltInSupportHelp": "சோதனை ஃபிளாக்குகள் இயக்கப்பட்ட டெஸ்க்டாப் Google Chrome அல்லது Microsoft Edge தேவை.",
   "aiStatusAvailable": "கிடைக்கிறது",
   "aiStatusUnavailable": "கிடைக்கவில்லை",
   "aiStatusDownloading": "பதிவிறக்கப்படுகிறது… {progress}%",

--- a/messages/te.json
+++ b/messages/te.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "ఉదా., వ్యంగ్యంగా, మర్యాదగా.",
   "aiCustomInstructionsHelper": "AI సూచనలను వ్యక్తిగతీకరించండి.",
   "aiBuiltInSupport": "అంతర్నిర్మిత AI మద్దతు",
+  "aiBuiltInSupportHelp": "ప్రయోగాత్మక ఫ్లాగ్‌లు ప్రారంభించిన డెస్క్‌టాప్ Google Chrome లేదా Microsoft Edge అవసరం.",
   "aiStatusAvailable": "అందుబాటులో ఉంది",
   "aiStatusUnavailable": "అందుబాటులో లేదు",
   "aiStatusDownloading": "డౌన్‌లోడ్ అవుతోంది… {progress}%",

--- a/messages/th.json
+++ b/messages/th.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "เช่น ประชดประชัน สุภาพ",
   "aiCustomInstructionsHelper": "ปรับแต่งคำแนะนำของ AI ให้เป็นส่วนตัว",
   "aiBuiltInSupport": "การรองรับ AI ในตัว",
+  "aiBuiltInSupportHelp": "ต้องใช้ Google Chrome หรือ Microsoft Edge บนเดสก์ท็อปโดยเปิดใช้งานแฟล็กทดลอง",
   "aiStatusAvailable": "พร้อมใช้งาน",
   "aiStatusUnavailable": "ไม่พร้อมใช้งาน",
   "aiStatusDownloading": "กำลังดาวน์โหลด… {progress}%",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "ör. Alaycı, Kibar.",
   "aiCustomInstructionsHelper": "Yapay zeka önerilerini kişiselleştirin.",
   "aiBuiltInSupport": "Yerleşik yapay zeka desteği",
+  "aiBuiltInSupportHelp": "Masaüstü Google Chrome veya Microsoft Edge'de deneysel işaretlerin etkinleştirilmesi gerekir.",
   "aiStatusAvailable": "Kullanılabilir",
   "aiStatusUnavailable": "Kullanılamıyor",
   "aiStatusDownloading": "İndiriliyor… %{progress}",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "напр. Саркастичний, Ввічливий.",
   "aiCustomInstructionsHelper": "Персоналізуйте пропозиції ШІ.",
   "aiBuiltInSupport": "Вбудована підтримка ШІ",
+  "aiBuiltInSupportHelp": "Потрібна настільна версія Google Chrome або Microsoft Edge з увімкненими експериментальними прапорцями.",
   "aiStatusAvailable": "Доступно",
   "aiStatusUnavailable": "Недоступно",
   "aiStatusDownloading": "Завантаження… {progress}%",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "ví dụ: Châm biếm, Lịch sự.",
   "aiCustomInstructionsHelper": "Cá nhân hóa gợi ý của AI.",
   "aiBuiltInSupport": "Hỗ trợ AI tích hợp",
+  "aiBuiltInSupportHelp": "Yêu cầu Google Chrome hoặc Microsoft Edge phiên bản máy tính với cờ thử nghiệm được bật.",
   "aiStatusAvailable": "Khả dụng",
   "aiStatusUnavailable": "Không khả dụng",
   "aiStatusDownloading": "Đang tải xuống… {progress}%",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -77,6 +77,7 @@
   "aiCustomInstructionsPlaceholder": "例如：讽刺、礼貌。",
   "aiCustomInstructionsHelper": "个性化 AI 建议。",
   "aiBuiltInSupport": "内置 AI 支持",
+  "aiBuiltInSupportHelp": "需要桌面版 Google Chrome 或 Microsoft Edge 并启用实验性标志。",
   "aiStatusAvailable": "可用",
   "aiStatusUnavailable": "不可用",
   "aiStatusDownloading": "正在下载… {progress}%",

--- a/src/app/settings/ai-settings.tsx
+++ b/src/app/settings/ai-settings.tsx
@@ -1,13 +1,16 @@
 import CancelIcon from "@mui/icons-material/Cancel";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import DownloadingIcon from "@mui/icons-material/Downloading";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import Button from "@mui/material/Button";
+import IconButton from "@mui/material/IconButton";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
 import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
+import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
 import {
@@ -26,8 +29,10 @@ import {
   useRewriter,
   type Status,
 } from "@shayc/react-built-in-ai";
+import { useState } from "react";
 
 export function AISettings() {
+  const [helpOpen, setHelpOpen] = useState(false);
   const sharedContext = useAISharedContext();
   const { language } = useLanguage();
   const proofreader = useProofreader(proofreaderLanguageOptions(language));
@@ -76,9 +81,26 @@ export function AISettings() {
       )}
 
       <Stack spacing={1}>
-        <Typography variant="body2" sx={{ color: "text.secondary" }}>
-          {m.aiBuiltInSupport()}
-        </Typography>
+        <Stack direction="row" spacing={0.5} sx={{ alignItems: "center" }}>
+          <Typography variant="body2" sx={{ color: "text.secondary" }}>
+            {m.aiBuiltInSupport()}
+          </Typography>
+
+          <Tooltip
+            title={m.aiBuiltInSupportHelp()}
+            open={helpOpen}
+            onOpen={() => setHelpOpen(true)}
+            onClose={() => setHelpOpen(false)}
+          >
+            <IconButton
+              aria-label={m.aiBuiltInSupportHelp()}
+              size="small"
+              onClick={() => setHelpOpen(true)}
+            >
+              <InfoOutlinedIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Stack>
 
         <List dense>
           {capabilities.map(({ title, status, progress, onDownload }) => (


### PR DESCRIPTION
Adds an info icon button beside the **Built-in AI support** heading in AI settings.

## Why
The built-in AI features only work in desktop Chrome/Edge with experimental flags enabled — there was no in-app hint explaining why the capabilities show as unavailable elsewhere.

## What
- Info `IconButton` + controlled `Tooltip`. A **tap** opens it on touch devices (where the default 1500ms long-press is undiscoverable), while hover and keyboard focus work as before. The tooltip text doubles as the button's accessible name.
- New `aiBuiltInSupportHelp` message added across all 35 locales:
  > Requires desktop Google Chrome or Microsoft Edge with experimental flags enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)