### PR TITLE
feat: snap the board grid per page instead of per cell

### DIFF
--- a/src/features/board/grid/grid.test.tsx
+++ b/src/features/board/grid/grid.test.tsx
@@ -1073,4 +1073,92 @@ describe("Grid", () => {
       expect(overflows).toBe(true);
     });
   });
+
+  describe("page snapping", () => {
+    const PAD = 16;
+    const GAP = 8;
+    const MIN_CELL = 96;
+
+    const visibleCount = (extent: number, count: number) =>
+      Math.min(
+        count,
+        Math.max(1, Math.floor((extent - 2 * PAD + GAP) / (MIN_CELL + GAP))),
+      );
+
+    const cellPitch = (extent: number, count: number) => {
+      const visible = visibleCount(extent, count);
+
+      return (extent - 2 * PAD - (visible - 1) * GAP) / visible + GAP;
+    };
+
+    const renderLine = async (
+      style: { width: string; height: string },
+      rows: number,
+      columns: number,
+    ) => {
+      const items = Array.from({ length: rows * columns }, (_, i) => ({
+        id: String(i + 1),
+        label: `Item ${i + 1}`,
+      }));
+
+      const screen = await render(
+        <>
+          <CssBaseline />
+          <div style={style}>
+            <Grid
+              rows={rows}
+              columns={columns}
+              items={items}
+              renderItem={(item, props) => (
+                <button {...props}>{item.label}</button>
+              )}
+            />
+          </div>
+        </>,
+      );
+
+      return screen
+        .getByRole("grid")
+        .element()
+        .querySelectorAll<HTMLElement>("[role='gridcell']");
+    };
+
+    test("pulls each column back to its page's leading edge", async () => {
+      const width = 1000;
+      const columns = 20;
+      const cells = await renderLine(
+        { width: `${width}px`, height: "400px" },
+        1,
+        columns,
+      );
+      const visible = visibleCount(width, columns);
+      const pitch = cellPitch(width, columns);
+      const marginLeft = (col: number) =>
+        parseFloat(getComputedStyle(cells[col]).scrollMarginLeft);
+
+      expect(marginLeft(0)).toBeLessThan(1);
+      expect(marginLeft(visible)).toBeLessThan(1);
+      expect(Math.abs(marginLeft(1) - pitch)).toBeLessThan(1.5);
+      expect(Math.abs(marginLeft(visible + 1) - pitch)).toBeLessThan(1.5);
+    });
+
+    test("pulls each row back to its page's leading edge", async () => {
+      const height = 1000;
+      const rows = 20;
+      const cells = await renderLine(
+        { width: "400px", height: `${height}px` },
+        rows,
+        1,
+      );
+      const visible = visibleCount(height, rows);
+      const pitch = cellPitch(height, rows);
+      const marginTop = (row: number) =>
+        parseFloat(getComputedStyle(cells[row]).scrollMarginTop);
+
+      expect(marginTop(0)).toBeLessThan(1);
+      expect(marginTop(visible)).toBeLessThan(1);
+      expect(Math.abs(marginTop(1) - pitch)).toBeLessThan(1.5);
+      expect(Math.abs(marginTop(visible + 1) - pitch)).toBeLessThan(1.5);
+    });
+  });
 });

--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -114,12 +114,26 @@ export function Grid<TItem extends { id: string }>({
                   role="gridcell"
                   aria-rowindex={rowIndex + 1}
                   aria-colindex={colIndex + 1}
-                  sx={{
+                  sx={(theme) => ({
                     flex: 1,
                     minWidth: "var(--cell-width)",
                     minHeight: MIN_CELL_SIZE,
                     scrollSnapAlign: "start",
-                  }}
+                    scrollMarginBlockStart: pageOffset(
+                      theme,
+                      rowIndex,
+                      "--visible-rows",
+                      "--cell-height",
+                      gap,
+                    ),
+                    scrollMarginInlineStart: pageOffset(
+                      theme,
+                      colIndex,
+                      "--visible-cols",
+                      "--cell-width",
+                      gap,
+                    ),
+                  })}
                 >
                   {item &&
                     renderItem(item, {
@@ -162,6 +176,16 @@ function buildGrid<TItem extends { id: string }>(
       return items[index];
     }),
   );
+}
+
+function pageOffset(
+  theme: Theme,
+  index: number,
+  countVar: string,
+  cellSizeVar: string,
+  gap: number,
+): string {
+  return `calc(mod(${index}, var(${countVar})) * (var(${cellSizeVar}) + ${theme.spacing(gap)}))`;
 }
 
 function visibleTracks(


### PR DESCRIPTION
## What

Changes the board grid's scroll snapping from **per cell** to **per page** (one screenful = visible cols × visible rows).

## How

Every cell keeps `scroll-snap-align: start`, but each cell's snap position is pulled back to its page's leading edge with a logical `scroll-margin`:

```
scroll-margin-inline-start: calc(mod(colIndex, var(--visible-cols)) × (var(--cell-width) + gap))
scroll-margin-block-start:  calc(mod(rowIndex, var(--visible-rows)) × (var(--cell-height) + gap))
```

A cell sits `index mod visible` cells into its page; that margin cancels the offset, so every cell in a page snaps to the same scroll position — leaving page boundaries as the only resting points.

It's pure CSS:
- No `ResizeObserver` / state / `@property` — `mod()` recomputes when `--visible-cols/rows` change on resize or rotate.
- Correct on first paint (no fallback flash).
- RTL-correct via logical `inline-start` / `block-start`.
- Same browser-support tier as the `round()` the grid already relies on.

## Verification

Two real-browser tests assert the computed `scroll-margin` px: page-start cells get ~0, interior cells get pulled back exactly one cell-pitch, and the modulo wraps across pages. `39/39` grid tests pass; lint + types clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)