### PR TITLE
feat: stop board grid scroll at one page per swipe

### DIFF
--- a/src/features/board/grid/grid.test.tsx
+++ b/src/features/board/grid/grid.test.tsx
@@ -1140,6 +1140,7 @@ describe("Grid", () => {
       expect(marginLeft(visible)).toBeLessThan(1);
       expect(Math.abs(marginLeft(1) - pitch)).toBeLessThan(1.5);
       expect(Math.abs(marginLeft(visible + 1) - pitch)).toBeLessThan(1.5);
+      expect(getComputedStyle(cells[0]).scrollSnapStop).toBe("always");
     });
 
     test("pulls each row back to its page's leading edge", async () => {

--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -119,6 +119,7 @@ export function Grid<TItem extends { id: string }>({
                     minWidth: "var(--cell-width)",
                     minHeight: MIN_CELL_SIZE,
                     scrollSnapAlign: "start",
+                    scrollSnapStop: "always",
                     scrollMarginBlockStart: pageOffset(
                       theme,
                       rowIndex,


### PR DESCRIPTION
## What

Adds `scroll-snap-stop: always` to the board grid cells so a flick can't skip past page boundaries — each scroll gesture lands on the next page, in both axes.

Follow-up to #620 (per-page snapping). With every cell's snap position resolving to its page's leading edge, `scroll-snap-stop: always` makes each page boundary a hard stop, giving one-page-per-swipe. Calmer for AAC use, where flinging across several pages at once is disorienting.

## Verification

Existing page-snapping test extended to assert the computed `scroll-snap-stop` is `always`. `39/39` grid tests pass; lint + types clean. The fling *feel* (single property, can't be unit-tested) was checked manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)