### PR TITLE
feat: darken the whole tile on hover and press, not just its background

### DIFF
--- a/src/features/board/tile/tile.tsx
+++ b/src/features/board/tile/tile.tsx
@@ -24,11 +24,6 @@ export function Tile({
   tabIndex,
   onClick,
 }: TileProps) {
-  const darkened = (percent: number) =>
-    backgroundColor
-      ? `color-mix(in srgb, ${backgroundColor}, black ${percent}%)`
-      : undefined;
-
   return (
     <Button
       tabIndex={tabIndex}
@@ -51,13 +46,13 @@ export function Tile({
           ? getReadableTextColor(backgroundColor)
           : "inherit",
         backgroundColor,
-        transition: theme.transitions.create("background-color", {
+        transition: theme.transitions.create("filter", {
           duration: theme.transitions.duration.short,
         }),
         "@media (hover: hover)": {
-          "&:hover": { backgroundColor: darkened(20) },
+          "&:hover": { filter: "brightness(0.8)" },
         },
-        "&:active": { backgroundColor: darkened(30) },
+        "&:active": { filter: "brightness(0.7)" },
         "&:focus-visible": {
           outline: `3px solid ${
             theme.vars


### PR DESCRIPTION
## Problem

Tile hover/press feedback used `color-mix(... black 20%/30%)` on the tile's `backgroundColor`. Opaque pictograms — those without transparent backgrounds — paint right over that, so the darkening only showed in the thin 4px padding/border ring and was invisible on the image itself.

## Fix

Apply `filter: brightness()` to the whole Button instead. It darkens the background **and** the image uniformly, regardless of whether the pictogram is transparent.

- `brightness(0.8)` on hover, `brightness(0.7)` on active — equivalent intensity to the old 20%/30% black mix, so colored-background tiles feel the same; the change just extends the darkening over the pictogram.
- Transition target switched from `background-color` to `filter`.
- Drops the now-unused `darkened()` helper.

`filter` + `brightness()` is Baseline "widely available" (unprefixed across Chrome/Firefox/Safari/Edge since ~2016), so support is a non-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)