### PR TITLE
chore: split vendors into stable build chunks

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -98,6 +98,28 @@ export default defineConfig({
       "stylis",
     ],
   },
+  build: {
+    rolldownOptions: {
+      output: {
+        codeSplitting: {
+          groups: [
+            {
+              name: "react",
+              test: /node_modules\/(react|react-dom|scheduler)\//,
+              priority: 30,
+            },
+            {
+              name: "mui",
+              test: /node_modules\/(@mui|@emotion|stylis)\//,
+              priority: 20,
+            },
+            { name: "shayc", test: /node_modules\/@shayc\//, priority: 20 },
+            { name: "vendor", test: /node_modules\//, priority: 10 },
+          ],
+        },
+      },
+    },
+  },
   test: {
     setupFiles: ["./src/shared/testing/global-setup.ts"],
     restoreMocks: true,


### PR DESCRIPTION
## What

Add manual Rolldown chunk groups (`react`, `mui`, `shayc`, `vendor`) to `vite.config.ts`, splitting the single ~1 MB entry chunk into stable, separately-hashed chunks.

## Why

The app shipped as one eager chunk, so **any** code change re-precached the full ~330 kB (gzip) blob in the service worker on every deploy. Splitting by **size × change-cadence** keeps the heavy, rarely-changing dependencies cached independently of app edits:

| chunk | gzip | cadence |
|---|---|---|
| `mui` (MUI + emotion + stylis) | 112 kB | occasional dep bumps |
| `index` (app + Paraglide) | 86 kB | every app edit |
| `react` (react + react-dom + scheduler) | 60 kB | rare |
| `vendor` (zod, react-router, idb, mrmime, react-aria) | 41 kB | rare |
| `shayc` (`@shayc/open-board-format` + `react-built-in-ai`) | 27 kB | frequent — actively versioned |

Isolating `@shayc/*` (~43% of the old vendor weight) means a first-party lib bump no longer invalidates stable third-party code. react-aria stays folded into `vendor` — too small to earn its own chunk.

Total gzip is unchanged (~326 kB); this is purely cache-stability and parallel-download, not a byte reduction. Cold-load first paint is unaffected by design. Also clears the 500 kB `chunkSizeWarningLimit` warning honestly (no single chunk over 500 kB).

## Verification

- `npm run build` — passes, no chunk-size warning
- `tsc -b` clean, `eslint` clean
- All five chunks `modulepreload`-ed in `index.html`, so no request-waterfall regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)