### PR TITLE
feat: rounded dialog corners and roomier action rows

### DIFF
--- a/src/app/onboarding/onboarding-dialog.tsx
+++ b/src/app/onboarding/onboarding-dialog.tsx
@@ -62,7 +62,6 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
       slotProps={{
         paper: {
           sx: {
-            borderRadius: fullScreen ? 0 : 6,
             p: 1,
           },
         },

--- a/src/shared/theme/theme-provider.tsx
+++ b/src/shared/theme/theme-provider.tsx
@@ -79,6 +79,13 @@ const themeOptions = {
         }),
       },
     },
+    MuiDialog: {
+      styleOverrides: {
+        paper: ({ ownerState }) => ({
+          ...(!ownerState.fullScreen && { borderRadius: 32 }),
+        }),
+      },
+    },
     MuiButton: {
       styleOverrides: {
         root: {

--- a/src/shared/theme/theme-provider.tsx
+++ b/src/shared/theme/theme-provider.tsx
@@ -86,6 +86,13 @@ const themeOptions = {
         }),
       },
     },
+    MuiDialogActions: {
+      styleOverrides: {
+        root: {
+          padding: 16,
+        },
+      },
+    },
     MuiButton: {
       styleOverrides: {
         root: {


### PR DESCRIPTION
## What

Two global MUI theme overrides for dialogs:

- **`MuiDialog`** — windowed dialogs get a 32px paper radius, gated on `!ownerState.fullScreen` so MUI's built-in `borderRadius: 0` still applies in full-screen mode.
- **`MuiDialogActions`** — action rows get 16px padding instead of MUI's default 8px.

Also drops onboarding's now-redundant per-dialog `borderRadius` hardcode (`fullScreen ? 0 : 6`) so every dialog inherits the single theme default.

## Why

Centralizes dialog shape/spacing in the theme instead of per-dialog `sx` overrides, so all three dialogs (delete, info, onboarding) stay visually consistent.

## Verification

- `tsc -b` clean, `eslint` clean
- Onboarding corners go 6 → 32 to match the rest; full-screen dialogs stay square

🤖 Generated with [Claude Code](https://claude.com/claude-code)