### PR TITLE
fix: shift content column with logical margin for RTL

### DIFF
--- a/src/app/layouts/content-column.tsx
+++ b/src/app/layouts/content-column.tsx
@@ -17,8 +17,7 @@ export function ContentColumn({
         display: "flex",
         flexDirection: "column",
         flexGrow: 1,
-        width: shifted ? `calc(100% - ${LIBRARY_DRAWER_WIDTH})` : "100%",
-        marginLeft: shifted ? LIBRARY_DRAWER_WIDTH : 0,
+        marginInlineStart: shifted ? LIBRARY_DRAWER_WIDTH : 0,
       }}
     >
       {children}


### PR DESCRIPTION
## What

In `ContentColumn`, replace `width: calc(100% - drawerWidth)` + `marginLeft` with a single `marginInlineStart`.

## Why

- **RTL correctness**: `marginInlineStart` resolves to the right edge in RTL (Hebrew/Arabic) and the left in LTR, so the persistent library drawer pushes content the correct way in both directions. `marginLeft` always pushed from the left.
- **Simplification**: the explicit `width` calc was redundant — `ContentColumn` is a flex child with `flexGrow: 1`, so it already fills the space left by the drawer's margin.

## Verification

- `tsc -b` clean, `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)