### PR TITLE
Revert "fix: shift content column with logical margin for RTL (#626)"

### DIFF
--- a/src/app/layouts/content-column.tsx
+++ b/src/app/layouts/content-column.tsx
@@ -17,7 +17,8 @@ export function ContentColumn({
         display: "flex",
         flexDirection: "column",
         flexGrow: 1,
-        marginInlineStart: shifted ? LIBRARY_DRAWER_WIDTH : 0,
+        width: shifted ? `calc(100% - ${LIBRARY_DRAWER_WIDTH})` : "100%",
+        marginLeft: shifted ? LIBRARY_DRAWER_WIDTH : 0,
       }}
     >
       {children}


### PR DESCRIPTION
Reverts #626.

Restores `ContentColumn` to the `width: calc(100% - drawerWidth)` + `marginLeft` approach, undoing the `marginInlineStart` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)