### PR TITLE
perf: render app shell before route data loads

### DIFF
--- a/src/app/onboarding/onboarding-dialog.tsx
+++ b/src/app/onboarding/onboarding-dialog.tsx
@@ -119,7 +119,7 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
         </List>
       </DialogContent>
 
-      <DialogActions sx={{ px: 3, pb: 3 }}>
+      <DialogActions>
         <Button onClick={onClose} variant="contained" fullWidth size="large">
           {m.onboardingContinue()}
         </Button>

--- a/src/app/routing/app-routes.tsx
+++ b/src/app/routing/app-routes.tsx
@@ -10,10 +10,10 @@ import type { RouteObject } from "react-router";
 export const appRoutes: RouteObject[] = [
   {
     Component: AppShell,
-    HydrateFallback: LoadingState,
     children: [
       {
         ErrorBoundary: RouteErrorBoundary,
+        HydrateFallback: LoadingState,
         children: [
           { index: true, loader: rootIndexLoader },
           {


### PR DESCRIPTION
## What

Move `HydrateFallback` from the **root** route down onto the pathless `ErrorBoundary` layout route in `app-routes.tsx`.

## Why

On a first visit, React Router's root `HydrateFallback` replaced the entire app with a full-screen spinner until every matched loader resolved — and on a first visit that chain includes downloading + unzipping + parsing + writing the 9 MB starter board into IndexedDB. The onboarding dialog lives inside `AppShell`, so it couldn't appear until all of that finished.

## How

With the fallback on the pathless layout route (the common ancestor of every loader-bearing child, but *below* `AppShell`), `_renderMatches` keeps `AppShell` mounted and scopes the spinner to the `<Outlet>`. `AppShell` — and the onboarding dialog it renders — now paint on the first commit, with the starter-board import running behind the dialog backdrop. `renderFallback` stays true across the full first-visit redirect chain (`index → board-set → board`), so `AppShell` mounts once and stays mounted.

Returning users also get the app chrome instantly instead of a full-screen spinner.

Also drops the explicit `DialogActions` padding in the onboarding dialog so it uses the theme default.

## Verification

- `npm run lint` — clean
- `npm test -- app-routes app-shell` — 3 passed (first-run dismiss-onboarding-then-grid, empty-database starter import, and shell onboarding dismiss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)