### PR TITLE
chore: bump version to 1.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aac-board-ai",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aac-board-ai",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aac-board-ai",
   "private": true,
-  "version": "1.12.0",
+  "version": "1.13.0",
   "license": "MIT",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release bump for `v1.13.0`.

Highlights since `v1.12.0`:
- Faster first launch — app shell and onboarding appear immediately instead of behind a full-screen spinner while the starter board imports (#628)
- Paginated grid swiping — the grid snaps a full page at a time and settles on exactly one page (#620, #621)
- Whole-tile press/hover feedback (#622)
- Composed message stays selectable while UI chrome is locked from selection (#618)
- Rounded dialog corners and roomier action rows (#625)
- Built-in AI support tooltip (#619)

Plus build/dependency and docs maintenance. The RTL content-column fix (#626) was reverted (#627), so it is intentionally not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)