### PR TITLE
style: increase board layout padding

### DIFF
--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -90,7 +90,7 @@ export function BoardViewer({ board }: BoardViewerProps) {
       <Stack
         direction="row"
         spacing={2}
-        sx={{ justifyContent: "space-between", px: 2 }}
+        sx={{ justifyContent: "space-between", px: 3 }}
       >
         <NavButtons
           canGoBack={navigation.canGoBack}

--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -6,7 +6,7 @@ import type { ReactNode, Ref } from "react";
 import { useGridKeyboard } from "./use-grid-keyboard";
 
 const MIN_CELL_SIZE = "96px";
-const PADDING = 2;
+const PADDING = 3;
 
 type GridOrder = readonly (readonly (string | null)[])[];
 

--- a/src/features/board/message/message-bar.tsx
+++ b/src/features/board/message/message-bar.tsx
@@ -50,7 +50,7 @@ export function MessageBar({
   }, [activePartId, parts]);
 
   return (
-    <Stack direction="row" sx={{ p: 2 }}>
+    <Stack direction="row" sx={{ p: 3 }}>
       <Stack
         direction="row"
         sx={[


### PR DESCRIPTION
## Summary

Bump padding from spacing `2` (16px) to `3` (24px) in three spots of the board view for more breathing room:

- `grid.tsx` — `PADDING` constant
- `message-bar.tsx` — outer `Stack` padding
- `board-viewer.tsx` — nav toolbar row horizontal padding

## Test plan
- `npm run lint` — clean
- CI build green