### PR TITLE
style: snap board grid vertically per row

### DIFF
--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -120,13 +120,6 @@ export function Grid<TItem extends { id: string }>({
                     minHeight: MIN_CELL_SIZE,
                     scrollSnapAlign: "start",
                     scrollSnapStop: "always",
-                    scrollMarginBlockStart: pageOffset(
-                      theme,
-                      rowIndex,
-                      "--visible-rows",
-                      "--cell-height",
-                      gap,
-                    ),
                     scrollMarginInlineStart: pageOffset(
                       theme,
                       colIndex,


### PR DESCRIPTION
Horizontal scrolling still pages by full screens; vertical now rests on each grid row instead of per page.

## What changed
Dropped the block-axis page-offset scroll margin (`scrollMarginBlockStart`) on each grid cell. With `scrollSnapType: both mandatory` and `scrollSnapAlign: start` left intact, each row's top edge becomes a vertical snap point, while the inline (horizontal) axis keeps its `mod()`-based per-page snapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)