### PR TITLE
test: fix grid tests for 24px padding and per-row vertical snap

### DIFF
--- a/src/features/board/grid/grid.test.tsx
+++ b/src/features/board/grid/grid.test.tsx
@@ -901,7 +901,7 @@ describe("Grid", () => {
   });
 
   describe("responsive column sizing", () => {
-    const PAD = 16;
+    const PAD = 24;
     const GAP = 8;
     const MIN_CELL = 96;
 
@@ -988,7 +988,7 @@ describe("Grid", () => {
   });
 
   describe("responsive row sizing", () => {
-    const PAD = 16;
+    const PAD = 24;
     const GAP = 8;
     const MIN_CELL = 96;
 
@@ -1074,8 +1074,8 @@ describe("Grid", () => {
     });
   });
 
-  describe("page snapping", () => {
-    const PAD = 16;
+  describe("scroll snapping", () => {
+    const PAD = 24;
     const GAP = 8;
     const MIN_CELL = 96;
 
@@ -1143,7 +1143,7 @@ describe("Grid", () => {
       expect(getComputedStyle(cells[0]).scrollSnapStop).toBe("always");
     });
 
-    test("pulls each row back to its page's leading edge", async () => {
+    test("snaps to each row's top with no per-page vertical offset", async () => {
       const height = 1000;
       const rows = 20;
       const cells = await renderLine(
@@ -1152,14 +1152,13 @@ describe("Grid", () => {
         1,
       );
       const visible = visibleCount(height, rows);
-      const pitch = cellPitch(height, rows);
       const marginTop = (row: number) =>
         parseFloat(getComputedStyle(cells[row]).scrollMarginTop);
 
-      expect(marginTop(0)).toBeLessThan(1);
-      expect(marginTop(visible)).toBeLessThan(1);
-      expect(Math.abs(marginTop(1) - pitch)).toBeLessThan(1.5);
-      expect(Math.abs(marginTop(visible + 1) - pitch)).toBeLessThan(1.5);
+      for (const row of [0, 1, visible, visible + 1]) {
+        expect(marginTop(row)).toBeLessThan(1);
+      }
+      expect(getComputedStyle(cells[1]).scrollSnapStop).toBe("always");
     });
   });
 });


### PR DESCRIPTION
Repairs 8 failing tests in `grid.test.tsx`, from two separate causes.

## Cause 1 — padding bump (#632)
[#632](https://github.com/shayc/aac-board-ai/pull/632) moved grid `PADDING` from spacing `2` (16px) to `3` (24px), but the responsive-sizing and snapping tests hardcoded `PAD = 16`. Their cell-size and page-offset math stopped matching the component → 6 sizing tests + 2 snapping tests failed. Bumped `PAD` to `24` in all three describe blocks.

## Cause 2 — per-row vertical snap (#633)
[#633](https://github.com/shayc/aac-board-ai/pull/633) dropped the block-axis page-offset margin so the grid snaps vertically per row instead of per page. The old `pulls each row back to its page's leading edge` test asserted a per-page `scroll-margin-top` pitch that no longer exists. Rewrote it to assert every row snaps to its own top (`scroll-margin-top ≈ 0`) and remains a mandatory snap stop.

All 39 grid tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)