### PR TITLE
copy: shorten onboarding privacy description + bold title

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "ترجمة",
   "onboardingTranslationDescription": "ترجم اللوحات محليًا للتواصل بعدة لغات.",
   "onboardingPrivacyTitle": "خصوصية ودون اتصال",
-  "onboardingPrivacyDescription": "تعمل الميزات الأساسية بالكامل على جهازك دون أي تتبّع للبيانات أو اعتماد على السحابة.",
+  "onboardingPrivacyDescription": "يعمل بالكامل على جهازك دون أي تتبّع للبيانات أو اعتماد على السحابة.",
   "onboardingContinue": "متابعة",
   "errorGenericTitle": "حدث خطأ ما",
   "errorGoHome": "الانتقال إلى الرئيسية",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Превод",
   "onboardingTranslationDescription": "Превеждайте дъските локално, за да общувате на няколко езика.",
   "onboardingPrivacyTitle": "Поверителност и офлайн",
-  "onboardingPrivacyDescription": "Основните функции работят изцяло на вашето устройство, без проследяване на данни и без зависимост от облака.",
+  "onboardingPrivacyDescription": "Работи изцяло на вашето устройство, без проследяване на данни и без зависимост от облака.",
   "onboardingContinue": "Продължаване",
   "errorGenericTitle": "Нещо се обърка",
   "errorGoHome": "Към началото",

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "অনুবাদ",
   "onboardingTranslationDescription": "একাধিক ভাষায় যোগাযোগ করতে বোর্ড স্থানীয়ভাবে অনুবাদ করুন।",
   "onboardingPrivacyTitle": "ব্যক্তিগত ও অফলাইন",
-  "onboardingPrivacyDescription": "মূল বৈশিষ্ট্যগুলো সম্পূর্ণরূপে আপনার ডিভাইসে চলে, কোনো ডেটা ট্র্যাকিং ছাড়াই এবং ক্লাউডের ওপর নির্ভরতা ছাড়াই।",
+  "onboardingPrivacyDescription": "সম্পূর্ণরূপে আপনার ডিভাইসে চলে, কোনো ডেটা ট্র্যাকিং ছাড়াই এবং ক্লাউডের ওপর নির্ভরতা ছাড়াই।",
   "onboardingContinue": "চালিয়ে যান",
   "errorGenericTitle": "কিছু একটা ভুল হয়েছে",
   "errorGoHome": "হোমে যান",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Překlad",
   "onboardingTranslationDescription": "Překládejte tabulky lokálně, abyste komunikovali ve více jazycích.",
   "onboardingPrivacyTitle": "Soukromé a offline",
-  "onboardingPrivacyDescription": "Hlavní funkce běží zcela ve vašem zařízení, bez sledování dat a bez závislosti na cloudu.",
+  "onboardingPrivacyDescription": "Běží zcela ve vašem zařízení, bez sledování dat a bez závislosti na cloudu.",
   "onboardingContinue": "Pokračovat",
   "errorGenericTitle": "Něco se pokazilo",
   "errorGoHome": "Přejít domů",

--- a/messages/da.json
+++ b/messages/da.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Oversættelse",
   "onboardingTranslationDescription": "Oversæt tavler lokalt, så du kan kommunikere på flere sprog.",
   "onboardingPrivacyTitle": "Privat og offline",
-  "onboardingPrivacyDescription": "Kernefunktioner kører helt på din enhed, uden datasporing og uden afhængighed af skyen.",
+  "onboardingPrivacyDescription": "Kører helt på din enhed, uden datasporing og uden afhængighed af skyen.",
   "onboardingContinue": "Fortsæt",
   "errorGenericTitle": "Noget gik galt",
   "errorGoHome": "Gå til start",

--- a/messages/de.json
+++ b/messages/de.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Übersetzung",
   "onboardingTranslationDescription": "Übersetze Tafeln lokal, um in mehreren Sprachen zu kommunizieren.",
   "onboardingPrivacyTitle": "Privat & offline",
-  "onboardingPrivacyDescription": "Kernfunktionen laufen vollständig auf deinem Gerät – ohne Datenverfolgung und ohne Cloud-Abhängigkeiten.",
+  "onboardingPrivacyDescription": "Läuft vollständig auf deinem Gerät – ohne Datenverfolgung und ohne Cloud-Abhängigkeiten.",
   "onboardingContinue": "Weiter",
   "errorGenericTitle": "Etwas ist schiefgelaufen",
   "errorGoHome": "Zur Startseite",

--- a/messages/el.json
+++ b/messages/el.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Μετάφραση",
   "onboardingTranslationDescription": "Μεταφράστε τους πίνακες τοπικά, για να επικοινωνείτε σε πολλές γλώσσες.",
   "onboardingPrivacyTitle": "Ιδιωτικό και εκτός σύνδεσης",
-  "onboardingPrivacyDescription": "Οι βασικές λειτουργίες εκτελούνται εξ ολοκλήρου στη συσκευή σας, χωρίς παρακολούθηση δεδομένων και χωρίς εξάρτηση από το cloud.",
+  "onboardingPrivacyDescription": "Εκτελείται εξ ολοκλήρου στη συσκευή σας, χωρίς παρακολούθηση δεδομένων και χωρίς εξάρτηση από το cloud.",
   "onboardingContinue": "Συνέχεια",
   "errorGenericTitle": "Κάτι πήγε στραβά",
   "errorGoHome": "Μετάβαση στην αρχική",

--- a/messages/en.json
+++ b/messages/en.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Translation",
   "onboardingTranslationDescription": "Translate boards locally to communicate in multiple languages.",
   "onboardingPrivacyTitle": "Private & Offline",
-  "onboardingPrivacyDescription": "Core features run entirely on your device with zero data tracking and no cloud dependencies.",
+  "onboardingPrivacyDescription": "Runs entirely on your device with zero data tracking and no cloud dependencies.",
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",

--- a/messages/es.json
+++ b/messages/es.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Traducción",
   "onboardingTranslationDescription": "Traduce los tableros localmente para comunicarte en varios idiomas.",
   "onboardingPrivacyTitle": "Privado y sin conexión",
-  "onboardingPrivacyDescription": "Las funciones principales se ejecutan por completo en tu dispositivo, sin rastreo de datos ni dependencia de la nube.",
+  "onboardingPrivacyDescription": "Se ejecuta por completo en tu dispositivo, sin rastreo de datos ni dependencia de la nube.",
   "onboardingContinue": "Continuar",
   "errorGenericTitle": "Algo salió mal",
   "errorGoHome": "Ir al inicio",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Käännös",
   "onboardingTranslationDescription": "Käännä taulut paikallisesti, jotta voit viestiä useilla kielillä.",
   "onboardingPrivacyTitle": "Yksityinen ja offline",
-  "onboardingPrivacyDescription": "Ydintoiminnot toimivat kokonaan laitteellasi ilman tietojen seurantaa ja ilman pilviriippuvuutta.",
+  "onboardingPrivacyDescription": "Toimii kokonaan laitteellasi ilman tietojen seurantaa ja ilman pilviriippuvuutta.",
   "onboardingContinue": "Jatka",
   "errorGenericTitle": "Jokin meni pieleen",
   "errorGoHome": "Siirry etusivulle",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Traduction",
   "onboardingTranslationDescription": "Traduisez les tableaux localement pour communiquer en plusieurs langues.",
   "onboardingPrivacyTitle": "Privé et hors ligne",
-  "onboardingPrivacyDescription": "Les fonctions essentielles s'exécutent entièrement sur votre appareil, sans suivi des données ni dépendance au cloud.",
+  "onboardingPrivacyDescription": "Fonctionne entièrement sur votre appareil, sans suivi des données ni dépendance au cloud.",
   "onboardingContinue": "Continuer",
   "errorGenericTitle": "Une erreur s'est produite",
   "errorGoHome": "Aller à l'accueil",

--- a/messages/he.json
+++ b/messages/he.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "תרגום",
   "onboardingTranslationDescription": "תרגמו את הלוחות באופן מקומי כדי לתקשר במספר שפות.",
   "onboardingPrivacyTitle": "פרטי ולא מקוון",
-  "onboardingPrivacyDescription": "התכונות המרכזיות פועלות כולן על המכשיר שלך, ללא מעקב אחר נתונים וללא תלות בענן.",
+  "onboardingPrivacyDescription": "פועל לחלוטין על המכשיר שלך, ללא מעקב אחר נתונים וללא תלות בענן.",
   "onboardingContinue": "המשך",
   "errorGenericTitle": "משהו השתבש",
   "errorGoHome": "חזרה לעמוד הבית",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "अनुवाद",
   "onboardingTranslationDescription": "कई भाषाओं में संवाद करने के लिए बोर्ड का स्थानीय रूप से अनुवाद करें।",
   "onboardingPrivacyTitle": "निजी और ऑफ़लाइन",
-  "onboardingPrivacyDescription": "मुख्य सुविधाएँ पूरी तरह आपके डिवाइस पर चलती हैं, बिना किसी डेटा ट्रैकिंग और बिना क्लाउड पर निर्भरता के।",
+  "onboardingPrivacyDescription": "पूरी तरह आपके डिवाइस पर चलता है, बिना किसी डेटा ट्रैकिंग और बिना क्लाउड पर निर्भरता के।",
   "onboardingContinue": "जारी रखें",
   "errorGenericTitle": "कुछ गलत हो गया",
   "errorGoHome": "होम पर जाएँ",

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Prijevod",
   "onboardingTranslationDescription": "Prevodite ploče lokalno kako biste komunicirali na više jezika.",
   "onboardingPrivacyTitle": "Privatno i izvanmrežno",
-  "onboardingPrivacyDescription": "Osnovne značajke rade u potpunosti na vašem uređaju, bez praćenja podataka i bez ovisnosti o oblaku.",
+  "onboardingPrivacyDescription": "Radi u potpunosti na vašem uređaju, bez praćenja podataka i bez ovisnosti o oblaku.",
   "onboardingContinue": "Nastavi",
   "errorGenericTitle": "Nešto je pošlo po zlu",
   "errorGoHome": "Idi na početnu",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Fordítás",
   "onboardingTranslationDescription": "Fordítsd le a táblákat helyben, hogy több nyelven kommunikálhass.",
   "onboardingPrivacyTitle": "Privát és offline",
-  "onboardingPrivacyDescription": "Az alapfunkciók teljes egészében az eszközödön futnak, adatkövetés nélkül és felhőfüggőség nélkül.",
+  "onboardingPrivacyDescription": "Teljes egészében az eszközödön fut, adatkövetés nélkül és felhőfüggőség nélkül.",
   "onboardingContinue": "Folytatás",
   "errorGenericTitle": "Hiba történt",
   "errorGoHome": "Ugrás a kezdőlapra",

--- a/messages/id.json
+++ b/messages/id.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Terjemahan",
   "onboardingTranslationDescription": "Terjemahkan papan secara lokal untuk berkomunikasi dalam berbagai bahasa.",
   "onboardingPrivacyTitle": "Privat & offline",
-  "onboardingPrivacyDescription": "Fitur inti berjalan sepenuhnya di perangkat Anda, tanpa pelacakan data dan tanpa ketergantungan cloud.",
+  "onboardingPrivacyDescription": "Berjalan sepenuhnya di perangkat Anda, tanpa pelacakan data dan tanpa ketergantungan cloud.",
   "onboardingContinue": "Lanjutkan",
   "errorGenericTitle": "Terjadi kesalahan",
   "errorGoHome": "Ke beranda",

--- a/messages/it.json
+++ b/messages/it.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Traduzione",
   "onboardingTranslationDescription": "Traduci le tabelle localmente per comunicare in più lingue.",
   "onboardingPrivacyTitle": "Privato e offline",
-  "onboardingPrivacyDescription": "Le funzioni principali vengono eseguite interamente sul tuo dispositivo, senza tracciamento dei dati né dipendenza dal cloud.",
+  "onboardingPrivacyDescription": "Funziona interamente sul tuo dispositivo, senza tracciamento dei dati né dipendenza dal cloud.",
   "onboardingContinue": "Continua",
   "errorGenericTitle": "Qualcosa è andato storto",
   "errorGoHome": "Vai alla home",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "翻訳",
   "onboardingTranslationDescription": "ボードをデバイス上で翻訳し、複数の言語でコミュニケーションできます。",
   "onboardingPrivacyTitle": "プライベート＆オフライン",
-  "onboardingPrivacyDescription": "主要機能はすべてお使いのデバイス上で動作し、データの追跡やクラウドへの依存は一切ありません。",
+  "onboardingPrivacyDescription": "すべてお使いのデバイス上で動作し、データの追跡やクラウドへの依存は一切ありません。",
   "onboardingContinue": "続ける",
   "errorGenericTitle": "問題が発生しました",
   "errorGoHome": "ホームに戻る",

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "ಅನುವಾದ",
   "onboardingTranslationDescription": "ಬಹು ಭಾಷೆಗಳಲ್ಲಿ ಸಂವಹನ ನಡೆಸಲು ಬೋರ್ಡ್‌ಗಳನ್ನು ಸ್ಥಳೀಯವಾಗಿ ಅನುವಾದಿಸಿ.",
   "onboardingPrivacyTitle": "ಖಾಸಗಿ ಮತ್ತು ಆಫ್‌ಲೈನ್",
-  "onboardingPrivacyDescription": "ಮುಖ್ಯ ವೈಶಿಷ್ಟ್ಯಗಳು ಸಂಪೂರ್ಣವಾಗಿ ನಿಮ್ಮ ಸಾಧನದಲ್ಲಿ ಕಾರ್ಯನಿರ್ವಹಿಸುತ್ತವೆ, ಯಾವುದೇ ಡೇಟಾ ಟ್ರ್ಯಾಕಿಂಗ್ ಇಲ್ಲದೆ ಮತ್ತು ಕ್ಲೌಡ್ ಅವಲಂಬನೆ ಇಲ್ಲದೆ.",
+  "onboardingPrivacyDescription": "ಸಂಪೂರ್ಣವಾಗಿ ನಿಮ್ಮ ಸಾಧನದಲ್ಲಿ ಕಾರ್ಯನಿರ್ವಹಿಸುತ್ತದೆ, ಯಾವುದೇ ಡೇಟಾ ಟ್ರ್ಯಾಕಿಂಗ್ ಇಲ್ಲದೆ ಮತ್ತು ಕ್ಲೌಡ್ ಅವಲಂಬನೆ ಇಲ್ಲದೆ.",
   "onboardingContinue": "ಮುಂದುವರಿಸಿ",
   "errorGenericTitle": "ಏನೋ ತಪ್ಪಾಗಿದೆ",
   "errorGoHome": "ಮುಖಪುಟಕ್ಕೆ ಹೋಗಿ",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "번역",
   "onboardingTranslationDescription": "보드를 기기에서 번역하여 여러 언어로 소통하세요.",
   "onboardingPrivacyTitle": "비공개 및 오프라인",
-  "onboardingPrivacyDescription": "핵심 기능이 전적으로 기기에서 실행되며, 데이터 추적이 전혀 없고 클라우드에 의존하지 않습니다.",
+  "onboardingPrivacyDescription": "전적으로 기기에서 실행되며, 데이터 추적이 전혀 없고 클라우드에 의존하지 않습니다.",
   "onboardingContinue": "계속",
   "errorGenericTitle": "문제가 발생했습니다",
   "errorGoHome": "홈으로",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Vertaling",
   "onboardingTranslationDescription": "Vertaal borden lokaal om in meerdere talen te communiceren.",
   "onboardingPrivacyTitle": "Privé en offline",
-  "onboardingPrivacyDescription": "Kernfuncties draaien volledig op je apparaat, zonder gegevens te volgen en zonder afhankelijkheid van de cloud.",
+  "onboardingPrivacyDescription": "Draait volledig op je apparaat, zonder gegevens te volgen en zonder afhankelijkheid van de cloud.",
   "onboardingContinue": "Doorgaan",
   "errorGenericTitle": "Er is iets misgegaan",
   "errorGoHome": "Naar start",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Tłumaczenie",
   "onboardingTranslationDescription": "Tłumacz tablice lokalnie, aby porozumiewać się w wielu językach.",
   "onboardingPrivacyTitle": "Prywatnie i offline",
-  "onboardingPrivacyDescription": "Główne funkcje działają w całości na Twoim urządzeniu, bez śledzenia danych i bez zależności od chmury.",
+  "onboardingPrivacyDescription": "Działa w całości na Twoim urządzeniu, bez śledzenia danych i bez zależności od chmury.",
   "onboardingContinue": "Kontynuuj",
   "errorGenericTitle": "Coś poszło nie tak",
   "errorGoHome": "Przejdź do strony głównej",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Tradução",
   "onboardingTranslationDescription": "Traduza as pranchas localmente para se comunicar em vários idiomas.",
   "onboardingPrivacyTitle": "Privado e offline",
-  "onboardingPrivacyDescription": "Os recursos principais funcionam inteiramente no seu dispositivo, sem rastreamento de dados nem dependência da nuvem.",
+  "onboardingPrivacyDescription": "Funciona inteiramente no seu dispositivo, sem rastreamento de dados nem dependência da nuvem.",
   "onboardingContinue": "Continuar",
   "errorGenericTitle": "Algo deu errado",
   "errorGoHome": "Ir para o início",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Traducere",
   "onboardingTranslationDescription": "Tradu tablele local pentru a comunica în mai multe limbi.",
   "onboardingPrivacyTitle": "Privat și offline",
-  "onboardingPrivacyDescription": "Funcțiile principale rulează în întregime pe dispozitivul tău, fără urmărirea datelor și fără dependență de cloud.",
+  "onboardingPrivacyDescription": "Rulează în întregime pe dispozitivul tău, fără urmărirea datelor și fără dependență de cloud.",
   "onboardingContinue": "Continuă",
   "errorGenericTitle": "Ceva nu a mers bine",
   "errorGoHome": "Mergi la pagina principală",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Перевод",
   "onboardingTranslationDescription": "Переводите доски локально, чтобы общаться на нескольких языках.",
   "onboardingPrivacyTitle": "Приватно и офлайн",
-  "onboardingPrivacyDescription": "Основные функции работают полностью на вашем устройстве, без отслеживания данных и без зависимости от облака.",
+  "onboardingPrivacyDescription": "Работает полностью на вашем устройстве, без отслеживания данных и без зависимости от облака.",
   "onboardingContinue": "Продолжить",
   "errorGenericTitle": "Что-то пошло не так",
   "errorGoHome": "На главную",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Preklad",
   "onboardingTranslationDescription": "Prekladajte tabuľky lokálne, aby ste komunikovali vo viacerých jazykoch.",
   "onboardingPrivacyTitle": "Súkromné a offline",
-  "onboardingPrivacyDescription": "Hlavné funkcie bežia úplne vo vašom zariadení, bez sledovania údajov a bez závislosti od cloudu.",
+  "onboardingPrivacyDescription": "Beží úplne vo vašom zariadení, bez sledovania údajov a bez závislosti od cloudu.",
   "onboardingContinue": "Pokračovať",
   "errorGenericTitle": "Niečo sa pokazilo",
   "errorGoHome": "Prejsť domov",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Prevajanje",
   "onboardingTranslationDescription": "Prevajajte table lokalno za komunikacijo v več jezikih.",
   "onboardingPrivacyTitle": "Zasebno in brez povezave",
-  "onboardingPrivacyDescription": "Osnovne funkcije delujejo v celoti v vaši napravi, brez sledenja podatkom in brez odvisnosti od oblaka.",
+  "onboardingPrivacyDescription": "Deluje v celoti v vaši napravi, brez sledenja podatkom in brez odvisnosti od oblaka.",
   "onboardingContinue": "Nadaljuj",
   "errorGenericTitle": "Nekaj je šlo narobe",
   "errorGoHome": "Pojdi domov",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Översättning",
   "onboardingTranslationDescription": "Översätt tavlor lokalt för att kommunicera på flera språk.",
   "onboardingPrivacyTitle": "Privat och offline",
-  "onboardingPrivacyDescription": "Kärnfunktioner körs helt på din enhet, utan dataspårning och utan molnberoende.",
+  "onboardingPrivacyDescription": "Körs helt på din enhet, utan dataspårning och utan molnberoende.",
   "onboardingContinue": "Fortsätt",
   "errorGenericTitle": "Något gick fel",
   "errorGoHome": "Till startsidan",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "மொழிபெயர்ப்பு",
   "onboardingTranslationDescription": "பல மொழிகளில் தொடர்புகொள்ள பலகைகளை சாதனத்திலேயே மொழிபெயர்க்கவும்.",
   "onboardingPrivacyTitle": "தனிப்பட்டது மற்றும் ஆஃப்லைன்",
-  "onboardingPrivacyDescription": "முக்கிய அம்சங்கள் முழுவதுமாக உங்கள் சாதனத்தில் இயங்குகின்றன, எந்த தரவுக் கண்காணிப்பும் இல்லாமல், கிளவுட் சார்பும் இல்லாமல்.",
+  "onboardingPrivacyDescription": "முழுவதுமாக உங்கள் சாதனத்தில் இயங்குகிறது, எந்த தரவுக் கண்காணிப்பும் இல்லாமல், கிளவுட் சார்பும் இல்லாமல்.",
   "onboardingContinue": "தொடரவும்",
   "errorGenericTitle": "ஏதோ தவறு நடந்தது",
   "errorGoHome": "முகப்புக்குச் செல்",

--- a/messages/te.json
+++ b/messages/te.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "అనువాదం",
   "onboardingTranslationDescription": "అనేక భాషల్లో సంభాషించేందుకు బోర్డులను స్థానికంగా అనువదించండి.",
   "onboardingPrivacyTitle": "ప్రైవేట్ & ఆఫ్‌లైన్",
-  "onboardingPrivacyDescription": "ముఖ్య ఫీచర్లు పూర్తిగా మీ పరికరంలోనే పనిచేస్తాయి, ఎలాంటి డేటా ట్రాకింగ్ లేకుండా, క్లౌడ్ ఆధారపడటం లేకుండా.",
+  "onboardingPrivacyDescription": "పూర్తిగా మీ పరికరంలోనే పనిచేస్తుంది, ఎలాంటి డేటా ట్రాకింగ్ లేకుండా, క్లౌడ్ ఆధారపడటం లేకుండా.",
   "onboardingContinue": "కొనసాగించు",
   "errorGenericTitle": "ఏదో తప్పు జరిగింది",
   "errorGoHome": "హోమ్‌కు వెళ్లు",

--- a/messages/th.json
+++ b/messages/th.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "การแปล",
   "onboardingTranslationDescription": "แปลบอร์ดในเครื่อง เพื่อสื่อสารได้หลายภาษา",
   "onboardingPrivacyTitle": "ส่วนตัวและออฟไลน์",
-  "onboardingPrivacyDescription": "ฟีเจอร์หลักทำงานบนอุปกรณ์ของคุณทั้งหมด ไม่มีการติดตามข้อมูลและไม่ต้องพึ่งพาคลาวด์",
+  "onboardingPrivacyDescription": "ทำงานบนอุปกรณ์ของคุณทั้งหมด ไม่มีการติดตามข้อมูลและไม่ต้องพึ่งพาคลาวด์",
   "onboardingContinue": "ดำเนินการต่อ",
   "errorGenericTitle": "เกิดข้อผิดพลาดบางอย่าง",
   "errorGoHome": "ไปที่หน้าแรก",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Çeviri",
   "onboardingTranslationDescription": "Birden fazla dilde iletişim kurmak için panoları yerel olarak çevirin.",
   "onboardingPrivacyTitle": "Gizli ve çevrimdışı",
-  "onboardingPrivacyDescription": "Temel özellikler tamamen cihazınızda çalışır; veri takibi olmadan ve buluta bağımlılık olmadan.",
+  "onboardingPrivacyDescription": "Tamamen cihazınızda çalışır; veri takibi olmadan ve buluta bağımlılık olmadan.",
   "onboardingContinue": "Devam et",
   "errorGenericTitle": "Bir şeyler ters gitti",
   "errorGoHome": "Ana sayfaya git",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Переклад",
   "onboardingTranslationDescription": "Перекладайте дошки локально, щоб спілкуватися кількома мовами.",
   "onboardingPrivacyTitle": "Приватно й офлайн",
-  "onboardingPrivacyDescription": "Основні функції працюють повністю на вашому пристрої, без відстеження даних і без залежності від хмари.",
+  "onboardingPrivacyDescription": "Працює повністю на вашому пристрої, без відстеження даних і без залежності від хмари.",
   "onboardingContinue": "Продовжити",
   "errorGenericTitle": "Щось пішло не так",
   "errorGoHome": "На головну",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "Dịch thuật",
   "onboardingTranslationDescription": "Dịch bảng ngay trên thiết bị để giao tiếp bằng nhiều ngôn ngữ.",
   "onboardingPrivacyTitle": "Riêng tư & ngoại tuyến",
-  "onboardingPrivacyDescription": "Các tính năng cốt lõi chạy hoàn toàn trên thiết bị của bạn, không theo dõi dữ liệu và không phụ thuộc vào đám mây.",
+  "onboardingPrivacyDescription": "Chạy hoàn toàn trên thiết bị của bạn, không theo dõi dữ liệu và không phụ thuộc vào đám mây.",
   "onboardingContinue": "Tiếp tục",
   "errorGenericTitle": "Đã xảy ra lỗi",
   "errorGoHome": "Về trang chủ",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -104,7 +104,7 @@
   "onboardingTranslationTitle": "翻译",
   "onboardingTranslationDescription": "在本地翻译沟通板，以使用多种语言交流。",
   "onboardingPrivacyTitle": "私密且离线",
-  "onboardingPrivacyDescription": "核心功能完全在你的设备上运行，零数据追踪，也不依赖云端。",
+  "onboardingPrivacyDescription": "完全在你的设备上运行，零数据追踪，也不依赖云端。",
   "onboardingContinue": "继续",
   "errorGenericTitle": "出了点问题",
   "errorGoHome": "返回主页",

--- a/src/app/onboarding/onboarding-dialog.tsx
+++ b/src/app/onboarding/onboarding-dialog.tsx
@@ -85,6 +85,7 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
         id="onboarding-dialog-title"
         variant="h4"
         sx={{
+          fontWeight: "bold",
           textAlign: "center",
         }}
       >


### PR DESCRIPTION
## Summary
- Shortened the onboarding privacy description by dropping the "Core features" subject: now reads **"Runs entirely on your device with zero data tracking and no cloud dependencies."**
- Re-translated the string across all 34 other locales (third-person singular, implied subject = the app).
- Bolded the onboarding dialog title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)