### PR TITLE
style: refine message bar and pictogram layout

### DIFF
--- a/src/features/board/message/message-bar.tsx
+++ b/src/features/board/message/message-bar.tsx
@@ -55,10 +55,8 @@ export function MessageBar({
         direction="row"
         sx={[
           {
-            height: 104,
             flexGrow: 1,
             gap: 2,
-            paddingInlineEnd: 2,
             borderRadius: 16,
             overflow: "hidden",
             bgcolor: "grey.200",
@@ -71,10 +69,10 @@ export function MessageBar({
           direction="row"
           sx={{
             flexGrow: 1,
-            p: 2,
-            gap: 1,
+            alignItems: "center",
+            py: 1,
+            px: 2,
             overflow: "auto",
-            userSelect: "text",
           }}
         >
           {parts.map((part) => {
@@ -85,8 +83,9 @@ export function MessageBar({
                 key={part.id}
                 direction="row"
                 sx={(theme) => ({
+                  p: 1,
                   borderRadius: 4,
-                  outlineOffset: 2,
+                  outlineOffset: -2,
                   outline: isActive
                     ? `2px solid ${theme.vars?.palette.primary.main ?? theme.palette.primary.main}`
                     : "none",

--- a/src/features/board/message/play-button.tsx
+++ b/src/features/board/message/play-button.tsx
@@ -29,6 +29,7 @@ export function PlayButton({
         width: 72,
         height: 72,
         flexShrink: 0,
+        m: 2,
         alignSelf: "center",
       }}
     >

--- a/src/features/board/pictogram/pictogram.tsx
+++ b/src/features/board/pictogram/pictogram.tsx
@@ -18,7 +18,14 @@ export function Pictogram({ src, label }: PictogramProps) {
       }}
     >
       {src && (
-        <Box sx={{ flexGrow: 1, position: "relative", minWidth: "64px" }}>
+        <Box
+          sx={{
+            height: "58px",
+            aspectRatio: "1 / 1",
+            flexGrow: 1,
+            position: "relative",
+          }}
+        >
           <Box
             component="img"
             src={src}
@@ -37,7 +44,12 @@ export function Pictogram({ src, label }: PictogramProps) {
       )}
 
       {label && (
-        <Typography component="span" variant={src ? "body2" : "h5"} noWrap>
+        <Typography
+          noWrap
+          component="span"
+          variant={src ? "body2" : "h5"}
+          sx={{ lineHeight: 1 }}
+        >
           {label}
         </Typography>
       )}

--- a/src/features/board/tile/tile.tsx
+++ b/src/features/board/tile/tile.tsx
@@ -35,7 +35,7 @@ export function Tile({
         display: "grid",
         alignItems: "stretch",
         justifyContent: "stretch",
-        padding: "4px 4px 0 4px",
+        p: 1,
         border: `4px solid ${borderColor ?? backgroundColor ?? "transparent"}`,
         borderRadius: 4,
         overflow: "hidden",


### PR DESCRIPTION
Layout refinements to the board message bar and the shared pictogram.

## Changes
- **Message bar** ([message-bar.tsx](src/features/board/message/message-bar.tsx)): content-driven height (drops the fixed `104px`), vertically centered pictograms, and the active-part outline inset within new per-part padding (`outlineOffset: -2`).
- **Play button** ([play-button.tsx](src/features/board/message/play-button.tsx)): `m: 2` now establishes the bar's height (`72 + 2×16 = 104`) now that the fixed height is gone.
- **Pictogram** ([pictogram.tsx](src/features/board/pictogram/pictogram.tsx)): square `58px` image area (`aspectRatio: 1/1`) and tighter label `lineHeight: 1`. Shared by tiles and the message bar.
- **Tile** ([tile.tsx](src/features/board/tile/tile.tsx)): padding switched to the `p: 1` theme spacing unit.

## Notes
- `userSelect: "text"` was removed from the message scroll container.
- `Pictogram` is shared with board tiles — the square `58px`/`lineHeight: 1` changes affect both surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)