### PR TITLE
Simplify board grid: per-cell proximity snapping + forwarded ref

### DIFF
--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -7,7 +7,7 @@ import { useLanguage } from "@shared/language/use-language";
 import { usePlaybackConfig } from "@shared/playback/playback-store";
 import { createButtonActivation } from "./activation/button-activation";
 import { getNavigationTargetId } from "./board-button";
-import { Grid, type GridHandle, type GridItemProps } from "./grid/grid";
+import { Grid, type GridItemProps } from "./grid/grid";
 import { useBoardKeyboard } from "./keyboard/use-board-keyboard";
 import { MessageBar } from "./message/message-bar";
 import { useMessagePlayback } from "./message/playback/use-message-playback";
@@ -52,11 +52,11 @@ export function BoardViewer({ board }: BoardViewerProps) {
 
   const keyboard = useBoardKeyboard({ message, playback });
 
-  const gridRef = useRef<GridHandle>(null);
+  const gridRef = useRef<HTMLDivElement>(null);
 
   const handleHomeClick = () => {
     if (navigation.isHome) {
-      gridRef.current?.scrollToStart();
+      gridRef.current?.scrollTo({ top: 0, left: 0 });
     } else {
       navigation.goHome();
     }

--- a/src/features/board/grid/grid.test.tsx
+++ b/src/features/board/grid/grid.test.tsx
@@ -1021,22 +1021,6 @@ describe("Grid", () => {
   });
 
   describe("scroll snapping", () => {
-    const PAD = 24;
-    const GAP = 8;
-    const MIN_CELL = 96;
-
-    const visibleCount = (extent: number, count: number) =>
-      Math.min(
-        count,
-        Math.max(1, Math.floor((extent - 2 * PAD + GAP) / (MIN_CELL + GAP))),
-      );
-
-    const cellPitch = (extent: number, count: number) => {
-      const visible = visibleCount(extent, count);
-
-      return (extent - 2 * PAD - (visible - 1) * GAP) / visible + GAP;
-    };
-
     const renderLine = async (
       style: { width: string; height: string },
       rows: number,
@@ -1076,27 +1060,27 @@ describe("Grid", () => {
       };
     };
 
-    test("pulls each column back to its page's leading edge, vertical free", async () => {
-      const width = 1000;
-      const columns = 20;
+    test("configures both-axis proximity snapping, cells aligned to start", async () => {
       const { container, cells } = await renderLine(
-        { width: `${width}px`, height: "400px" },
+        { width: "1000px", height: "400px" },
         1,
-        columns,
+        20,
       );
-      const visible = visibleCount(width, columns);
-      const pitch = cellPitch(width, columns);
-      const marginLeft = (col: number) =>
-        parseFloat(getComputedStyle(cells[col]).scrollMarginLeft);
 
-      expect(marginLeft(0)).toBeLessThan(1);
-      expect(marginLeft(visible)).toBeLessThan(1);
-      expect(Math.abs(marginLeft(1) - pitch)).toBeLessThan(1.5);
-      expect(Math.abs(marginLeft(visible + 1) - pitch)).toBeLessThan(1.5);
-      expect(getComputedStyle(container).scrollSnapType).toBe(
-        "inline mandatory",
+      expect(getComputedStyle(container).scrollSnapType).toBe("both");
+      expect(getComputedStyle(cells[1]).scrollSnapAlign).toBe("start");
+    });
+
+    test("snaps per cell, not per page (no scroll-margin offset)", async () => {
+      const { cells } = await renderLine(
+        { width: "1000px", height: "400px" },
+        1,
+        20,
       );
-      expect(getComputedStyle(cells[1]).scrollSnapAlign).toBe("none start");
+
+      expect(
+        parseFloat(getComputedStyle(cells[5]).scrollMarginLeft),
+      ).toBeLessThan(1);
     });
   });
 });

--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -1,7 +1,6 @@
 import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import type { Theme } from "@mui/material/styles";
-import { useImperativeHandle, useRef } from "react";
 import type { ReactNode, Ref } from "react";
 import { useGridKeyboard } from "./use-grid-keyboard";
 
@@ -14,10 +13,6 @@ export interface GridItemProps {
   tabIndex: number;
 }
 
-export interface GridHandle {
-  scrollToStart: () => void;
-}
-
 export interface GridProps<TItem extends { id: string }> {
   ariaLabel?: string;
   items: readonly TItem[];
@@ -27,7 +22,7 @@ export interface GridProps<TItem extends { id: string }> {
   renderItem: (item: TItem, props: GridItemProps) => ReactNode;
   dir?: "ltr" | "rtl";
   gap?: number;
-  ref?: Ref<GridHandle>;
+  ref?: Ref<HTMLDivElement>;
 }
 
 export function Grid<TItem extends { id: string }>({
@@ -47,20 +42,9 @@ export function Grid<TItem extends { id: string }>({
     dir,
   });
 
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-  useImperativeHandle(
-    ref,
-    () => ({
-      scrollToStart() {
-        scrollContainerRef.current?.scrollTo({ top: 0, left: 0 });
-      },
-    }),
-    [],
-  );
-
   return (
     <Box
-      ref={scrollContainerRef}
+      ref={ref}
       dir={dir}
       sx={(theme) => ({
         height: "100%",

--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -66,7 +66,7 @@ export function Grid<TItem extends { id: string }>({
         height: "100%",
         overflow: "auto",
         containerType: "size",
-        scrollSnapType: "inline mandatory",
+        scrollSnapType: "both proximity",
         scrollPadding: theme.spacing(PADDING),
       })}
     >
@@ -114,20 +114,12 @@ export function Grid<TItem extends { id: string }>({
                   role="gridcell"
                   aria-rowindex={rowIndex + 1}
                   aria-colindex={colIndex + 1}
-                  sx={(theme) => ({
+                  sx={{
                     flex: 1,
                     minWidth: "var(--cell-width)",
                     minHeight: MIN_CELL_SIZE,
-                    scrollSnapAlign: "none start",
-                    scrollSnapStop: "always",
-                    scrollMarginInlineStart: pageOffset(
-                      theme,
-                      colIndex,
-                      "--visible-cols",
-                      "--cell-width",
-                      gap,
-                    ),
-                  })}
+                    scrollSnapAlign: "start",
+                  }}
                 >
                   {item &&
                     renderItem(item, {
@@ -170,16 +162,6 @@ function buildGrid<TItem extends { id: string }>(
       return items[index];
     }),
   );
-}
-
-function pageOffset(
-  theme: Theme,
-  index: number,
-  countVar: string,
-  cellSizeVar: string,
-  gap: number,
-): string {
-  return `calc(mod(${index}, var(${countVar})) * (var(${cellSizeVar}) + ${theme.spacing(gap)}))`;
 }
 
 function visibleTracks(


### PR DESCRIPTION
Two focused simplifications to the board `Grid`.

### `style: snap the board grid per cell by proximity`
Replaces the per-page snapping (the `mod()`-based `scrollMarginInlineStart`, `scroll-snap-stop: always`, two-value `scroll-snap-align`) with **per-cell proximity snapping on both axes**: the container uses `scroll-snap-type: both proximity` and every cell aligns to `start`. The grid now scrolls freely and eases to the nearest row/column edge on whichever axis you release near, instead of forcing one screenful per swipe. The `pageOffset` helper is deleted entirely.

### `refactor: replace Grid's imperative handle with a forwarded ref`
The Grid exposed a one-method `GridHandle` (`scrollToStart`) via `useImperativeHandle` solely so the board viewer could reset scroll on a home-tap-while-home. The `ref` now forwards straight to the scroll container and the caller scrolls it — dropping the handle interface, the `useImperativeHandle` call, and the internal container ref (the codebase's only imperative handle).

**Behavior changes to note:** fast flings now scroll freely (no more one-page cap), and vertically-overflowing boards now ease to row boundaries.

Net: ~26 insertions / 76 deletions across `grid.tsx`, `board-viewer.tsx`, and `grid.test.tsx`. Scroll-snap tests rewritten; all 328 board tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
