### PR TITLE
style: outline the enable-suggestions chip

### DIFF
--- a/src/features/board/suggestions/suggestion-status.tsx
+++ b/src/features/board/suggestions/suggestion-status.tsx
@@ -30,6 +30,7 @@ function statusMessage(status: SuggestionStatusView, onEnable: () => void) {
           icon={<AutoAwesomeIcon />}
           label={m.suggestionsEnable()}
           color="primary"
+          variant="outlined"
           onClick={onEnable}
         />
       );


### PR DESCRIPTION
Give the "Enable suggestions" chip an outlined variant so it reads as an actionable affordance rather than a filled status chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)