### PR TITLE
style: refine play button and pictogram spacing

### DIFF
--- a/src/features/board/message/play-button.tsx
+++ b/src/features/board/message/play-button.tsx
@@ -29,7 +29,9 @@ export function PlayButton({
         width: 72,
         height: 72,
         flexShrink: 0,
-        m: 2,
+        my: 2,
+        marginInlineStart: 0,
+        marginInlineEnd: 2,
         alignSelf: "center",
       }}
     >

--- a/src/features/board/pictogram/pictogram.tsx
+++ b/src/features/board/pictogram/pictogram.tsx
@@ -14,13 +14,14 @@ export function Pictogram({ src, label }: PictogramProps) {
         flexDirection: "column",
         textAlign: "center",
         justifyContent: "center",
+        gap: 1,
         overflow: "hidden",
       }}
     >
       {src && (
         <Box
           sx={{
-            height: "58px",
+            height: "50px",
             aspectRatio: "1 / 1",
             flexGrow: 1,
             position: "relative",


### PR DESCRIPTION
Two small board layout tweaks.

- **Play button** ([play-button.tsx](src/features/board/message/play-button.tsx)): drop the inline-start margin (`m: 2` → `my: 2` + `marginInlineStart: 0` + `marginInlineEnd: 2`) so it sits flush to the start edge. RTL-aware via logical properties.
- **Pictogram** ([pictogram.tsx](src/features/board/pictogram/pictogram.tsx)): add a `gap` between image and label and shrink the image (`58px` → `50px`) to give the label more room.

Lint clean; pictogram + play-button + message-bar tests pass (16/16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)