### PR TITLE
feat: make tone selector a keyboard-navigable radio group

### DIFF
--- a/src/features/board/suggestions/suggestion-bar.test.tsx
+++ b/src/features/board/suggestions/suggestion-bar.test.tsx
@@ -52,7 +52,7 @@ describe("SuggestionBar", () => {
     );
 
     await expect
-      .element(screen.getByRole("button", { name: "direct tone" }))
+      .element(screen.getByRole("radio", { name: "direct tone" }))
       .toBeVisible();
   });
 
@@ -64,7 +64,7 @@ describe("SuggestionBar", () => {
     );
 
     await expect
-      .element(screen.getByRole("button", { name: "direct tone" }))
+      .element(screen.getByRole("radio", { name: "direct tone" }))
       .not.toBeInTheDocument();
   });
 
@@ -75,7 +75,7 @@ describe("SuggestionBar", () => {
     });
     const screen = await render(<SuggestionBar {...props} />);
 
-    const professional = screen.getByRole("button", {
+    const professional = screen.getByRole("radio", {
       name: "professional tone",
     });
     await expect.element(professional).toBeVisible();

--- a/src/features/board/suggestions/tone-selector.test.tsx
+++ b/src/features/board/suggestions/tone-selector.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, test, vi } from "vitest";
+import { userEvent } from "vitest/browser";
 import { render } from "vitest-browser-react";
 import { ToneSelector } from "./tone-selector";
 
@@ -7,14 +8,14 @@ describe("ToneSelector", () => {
     ["as-is", "direct tone"],
     ["more-formal", "professional tone"],
     ["more-casual", "friendly tone"],
-  ] as const)("highlights %s as the %s button", async (tone, label) => {
+  ] as const)("checks %s as the %s radio", async (tone, label) => {
     const screen = await render(
       <ToneSelector tone={tone} onChange={vi.fn()} />,
     );
 
     await expect
-      .element(screen.getByRole("button", { name: label }))
-      .toHaveAttribute("aria-pressed", "true");
+      .element(screen.getByRole("radio", { name: label }))
+      .toBeChecked();
   });
 
   test("calls onChange with new tone when selection changes", async () => {
@@ -24,13 +25,23 @@ describe("ToneSelector", () => {
       <ToneSelector tone="as-is" onChange={onChange} />,
     );
 
-    const professionalButton = screen.getByRole("button", {
-      name: "professional tone",
-    });
-    await professionalButton.click();
+    await screen.getByRole("radio", { name: "professional tone" }).click();
 
     expect(onChange).toHaveBeenCalledWith("more-formal");
     expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test("moves selection with arrow keys", async () => {
+    const onChange = vi.fn();
+
+    const screen = await render(
+      <ToneSelector tone="as-is" onChange={onChange} />,
+    );
+
+    screen.getByRole("radio", { name: "direct tone" }).element().focus();
+    await userEvent.keyboard("{ArrowRight}");
+
+    expect(onChange).toHaveBeenCalledWith("more-formal");
   });
 
   test("does not call onChange when clicking already selected tone", async () => {
@@ -40,19 +51,18 @@ describe("ToneSelector", () => {
       <ToneSelector tone="as-is" onChange={onChange} />,
     );
 
-    const directButton = screen.getByRole("button", { name: "direct tone" });
-    await directButton.click();
+    await screen.getByRole("radio", { name: "direct tone" }).click();
 
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  test("disables the buttons when disabled", async () => {
+  test("disables the radios when disabled", async () => {
     const screen = await render(
       <ToneSelector tone="as-is" disabled onChange={vi.fn()} />,
     );
 
     await expect
-      .element(screen.getByRole("button", { name: "professional tone" }))
+      .element(screen.getByRole("radio", { name: "professional tone" }))
       .toBeDisabled();
   });
 });

--- a/src/features/board/suggestions/tone-selector.tsx
+++ b/src/features/board/suggestions/tone-selector.tsx
@@ -1,8 +1,8 @@
 import BusinessCenterOutlinedIcon from "@mui/icons-material/BusinessCenterOutlined";
 import SentimentSatisfiedAltIcon from "@mui/icons-material/SentimentSatisfiedAlt";
 import ShortTextOutlinedIcon from "@mui/icons-material/ShortTextOutlined";
-import ToggleButton from "@mui/material/ToggleButton";
-import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import Radio from "@mui/material/Radio";
+import RadioGroup from "@mui/material/RadioGroup";
 import Tooltip from "@mui/material/Tooltip";
 import { m } from "@paraglide/messages.js";
 
@@ -12,60 +12,76 @@ export interface ToneSelectorProps {
   onChange: (tone: RewriterTone) => void;
 }
 
-const TONE_VALUES = {
-  direct: "as-is",
-  professional: "more-formal",
-  friendly: "more-casual",
-} as const satisfies Record<string, RewriterTone>;
+const TONES = [
+  { value: "as-is", label: m.toneDirect, Icon: ShortTextOutlinedIcon },
+  {
+    value: "more-formal",
+    label: m.toneProfessional,
+    Icon: BusinessCenterOutlinedIcon,
+  },
+  {
+    value: "more-casual",
+    label: m.toneFriendly,
+    Icon: SentimentSatisfiedAltIcon,
+  },
+] as const satisfies readonly {
+  value: RewriterTone;
+  label: () => string;
+  Icon: typeof ShortTextOutlinedIcon;
+}[];
 
 export function ToneSelector({
   tone,
   disabled = false,
   onChange,
 }: ToneSelectorProps) {
-  const handleChange = (
-    _event: React.MouseEvent<HTMLElement>,
-    nextTone: RewriterTone | null,
-  ) => {
-    if (!nextTone) {
-      return;
-    }
-
-    onChange(nextTone);
-  };
-
   return (
-    <ToggleButtonGroup
+    <RadioGroup
       aria-label={m.toneSelection()}
+      row
       value={tone}
-      onChange={handleChange}
-      exclusive
-      disabled={disabled}
-      size="medium"
+      onChange={(_event, value) => onChange(value as RewriterTone)}
+      sx={(theme) => ({
+        display: "inline-flex",
+        border: `1px solid ${theme.alpha((theme.vars ?? theme).palette.text.primary, 0.23)}`,
+        borderRadius: 7,
+        overflow: "hidden",
+      })}
     >
-      <Tooltip title={m.toneDirect()}>
-        <ToggleButton aria-label={m.toneDirect()} value={TONE_VALUES.direct}>
-          <ShortTextOutlinedIcon fontSize="medium" />
-        </ToggleButton>
-      </Tooltip>
-
-      <Tooltip title={m.toneProfessional()}>
-        <ToggleButton
-          aria-label={m.toneProfessional()}
-          value={TONE_VALUES.professional}
-        >
-          <BusinessCenterOutlinedIcon fontSize="medium" />
-        </ToggleButton>
-      </Tooltip>
-
-      <Tooltip title={m.toneFriendly()}>
-        <ToggleButton
-          aria-label={m.toneFriendly()}
-          value={TONE_VALUES.friendly}
-        >
-          <SentimentSatisfiedAltIcon fontSize="medium" />
-        </ToggleButton>
-      </Tooltip>
-    </ToggleButtonGroup>
+      {TONES.map(({ value, label, Icon }) => (
+        <Tooltip key={value} title={label()}>
+          <Radio
+            slotProps={{ input: { "aria-label": label() } }}
+            value={value}
+            disabled={disabled}
+            disableRipple
+            icon={<Icon fontSize="medium" />}
+            checkedIcon={<Icon fontSize="medium" />}
+            sx={(theme) => ({
+              padding: 1.5,
+              color: "action.active",
+              "&:hover": {
+                backgroundColor: "action.hover",
+                "@media (hover: none)": { backgroundColor: "transparent" },
+              },
+              "&.Mui-checked": {
+                color: "text.primary",
+                backgroundColor: "action.selected",
+                "&:hover": {
+                  backgroundColor: theme.alpha(
+                    (theme.vars ?? theme).palette.text.primary,
+                    `${(theme.vars ?? theme).palette.action.selectedOpacity} + ${(theme.vars ?? theme).palette.action.hoverOpacity}`,
+                  ),
+                  "@media (hover: none)": {
+                    backgroundColor: "action.selected",
+                  },
+                },
+              },
+              "&.Mui-disabled": { color: "action.disabled" },
+            })}
+          />
+        </Tooltip>
+      ))}
+    </RadioGroup>
   );
 }

--- a/src/features/board/suggestions/use-suggestions.ts
+++ b/src/features/board/suggestions/use-suggestions.ts
@@ -24,6 +24,7 @@ import {
 import { toPhrases } from "./to-phrases";
 
 const SHARED_CONTEXT_DEBOUNCE_MS = 400;
+const TONE_DEBOUNCE_MS = 400;
 
 export interface UseSuggestionsReturn {
   isSupported: boolean;
@@ -47,12 +48,13 @@ export function useSuggestions(text: string): UseSuggestionsReturn {
   );
 
   const [tone, setTone] = useState<RewriterTone>("as-is");
+  const debouncedTone = useDebouncedValue(tone, TONE_DEBOUNCE_MS);
   const { language } = useLanguage();
 
   const proofreader = useProofreader(proofreaderLanguageOptions(language));
 
   const rewriter = useRewriter({
-    tone,
+    tone: debouncedTone,
     sharedContext: debouncedSharedContext,
     length: "shorter",
     format: "plain-text",
@@ -72,7 +74,7 @@ export function useSuggestions(text: string): UseSuggestionsReturn {
 
   const rewritten = useLatestAsync({
     enabled: hasText && rewriter.status === "ready",
-    deps: [text, tone, debouncedSharedContext, language],
+    deps: [text, debouncedTone, debouncedSharedContext, language],
     fetch: (signal) => rewriter.rewrite(text, { signal }),
   });
 


### PR DESCRIPTION
## What

Replaces the tone selector's `ToggleButtonGroup` with a `RadioGroup`, so the three tones become a **single tab stop with native arrow-key selection** (roving tabindex): Tab in → arrows change → Tab out. That's the honest semantics for an exclusive, always-one-selected control, and the keyboard navigation is the browser's, not hand-rolled.

## Changes

- **A11y / keyboard nav** — `RadioGroup`/`Radio` with `role=radiogroup`/`radio`. Focus and selection move together, so the selected tone is always the visible indicator.
- **Debounce (400ms)** — tone changes are debounced in `useSuggestions` (mirroring the existing `debouncedSharedContext`), so arrow-scrubbing through tones doesn't recreate the rewriter session or refire rewrites. The radio selection stays immediate; only the rewrite work waits for the settle.
- **Styling** — the radios mirror MUI `ToggleButton`'s standard-color states (hover, selected, selected+hover blend, `@media (hover: none)` touch resets), 48px touch targets, and a visible outlined-control border (`text.primary @ 23%`, vars-aware for dark mode).
- **Tests** — updated to radio semantics (`getByRole("radio")`, `toBeChecked`) and added a real-browser arrow-key navigation test.

## Verification

- `npx tsc -b` clean
- `npm run lint` clean
- Full suite: **451 tests pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)