### PR TITLE
fix: keep tone selector from shrinking in the suggestion bar

### DIFF
--- a/src/features/board/suggestions/tone-selector.tsx
+++ b/src/features/board/suggestions/tone-selector.tsx
@@ -43,6 +43,7 @@ export function ToneSelector({
       onChange={(_event, value) => onChange(value as RewriterTone)}
       sx={(theme) => ({
         display: "inline-flex",
+        flexShrink: 0,
         border: `1px solid ${theme.alpha((theme.vars ?? theme).palette.text.primary, 0.23)}`,
         borderRadius: 7,
         overflow: "hidden",


### PR DESCRIPTION
## Bug

The suggestion bar is a flex row. When phrases overflow, the tone selector's `RadioGroup` could be compressed below its intrinsic size, distorting the icons/segments.

## Fix

Pin it with `flexShrink: 0` — the same guard the play button already uses — so it always renders at its natural size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)