### PR TITLE
Fix speak actions reading a stale message snapshot

### DIFF
--- a/src/features/board/activation/button-activation.test.ts
+++ b/src/features/board/activation/button-activation.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import type { UseMessagePlaybackReturn } from "../message/playback/use-message-playback";
 import type { MessagePart, UseMessageReturn } from "../message/use-message";
 import type { UseBoardNavigationReturn } from "../navigation/use-board-navigation";
-import type { BoardAction, BoardButton } from "../types";
+import type { BoardButton } from "../types";
 import { createButtonActivation } from "./button-activation";
 
 function createMessageStub(parts: MessagePart[] = []): UseMessageReturn {
@@ -15,6 +15,7 @@ function createMessageStub(parts: MessagePart[] = []): UseMessageReturn {
     appendText: vi.fn(),
     setFromText: vi.fn(),
     removeLastPart: vi.fn(),
+    setParts: vi.fn(),
     clear: vi.fn(),
   };
 }
@@ -64,7 +65,7 @@ describe("createButtonActivation", () => {
     audio = stubAudio();
   });
 
-  test("navigates to the linked board and skips message and audio when loadBoard.id is set", async () => {
+  test("navigates to the linked board and skips message and audio when loadBoard.id is set", () => {
     const { activation, message, playback, navigation } = setup();
 
     const button: BoardButton = {
@@ -73,133 +74,181 @@ describe("createButtonActivation", () => {
       loadBoard: { id: "child-board" },
     };
 
-    await activation.activateButton(button);
+    activation.activateButton(button);
 
     expect(navigation.goToBoard).toHaveBeenCalledWith("child-board");
-    expect(message.addPart).not.toHaveBeenCalled();
+    expect(message.setParts).not.toHaveBeenCalled();
     expect(playback.play).not.toHaveBeenCalled();
     expect(speech.speak).not.toHaveBeenCalled();
     expect(audio.play).not.toHaveBeenCalled();
   });
 
-  test("runs each action in order for an actions array", async () => {
-    const callOrder: string[] = [];
-    const message = createMessageStub();
-    message.addSpace = vi.fn(() => {
-      callOrder.push("addSpace");
-    });
-    message.clear = vi.fn(() => {
-      callOrder.push("clear");
-    });
-    const playback = createPlaybackStub();
-    playback.play = vi.fn(() => {
-      callOrder.push("play");
-
-      return Promise.resolve();
-    });
-
-    const { activation } = setup({ message, playback });
-
-    await activation.activateButton({
-      id: "btn",
-      actions: [{ kind: "space" }, { kind: "speak" }, { kind: "clear" }],
-    });
-
-    expect(callOrder).toEqual(["addSpace", "play", "clear"]);
-  });
-
-  test.each([
-    ["space", "addSpace"],
-    ["backspace", "removeLastPart"],
-    ["clear", "clear"],
-  ] as const)("maps %s to message.%s", async (kind, methodName) => {
-    const { activation, message } = setup();
-
-    await activation.activateButton({ id: "btn", actions: [{ kind }] });
-
-    expect(message[methodName]).toHaveBeenCalledTimes(1);
-  });
-
-  test("maps speak to playback.play", async () => {
-    const { activation, playback } = setup();
-
-    await activation.activateButton({
-      id: "btn",
-      actions: [{ kind: "speak" }],
-    });
-
-    expect(playback.play).toHaveBeenCalledTimes(1);
-  });
-
-  test("maps home to navigation.goHome", async () => {
+  test("maps home to navigation.goHome", () => {
     const { activation, navigation } = setup();
 
-    await activation.activateButton({
-      id: "btn",
-      actions: [{ kind: "home" }],
-    });
+    activation.activateButton({ id: "btn", actions: [{ kind: "home" }] });
 
     expect(navigation.goHome).toHaveBeenCalledTimes(1);
   });
 
-  test("delegates a spell action's text to the message's appendText", async () => {
-    const { activation, message } = setup();
+  test("spell appends the text via setParts", () => {
+    const message = createMessageStub([]);
+    const { activation } = setup({ message });
 
-    await activation.activateButton({
+    activation.activateButton({
       id: "btn",
       actions: [{ kind: "spell", text: "t" }],
     });
 
-    expect(message.appendText).toHaveBeenCalledWith("t");
+    expect(message.setParts).toHaveBeenCalledTimes(1);
+    const [committed] = vi.mocked(message.setParts).mock.calls[0];
+    expect(committed).toHaveLength(1);
+    expect(committed[0].label).toBe("t");
+    expect(committed[0].id).toBeTruthy();
   });
 
-  test("treats a loadBoard without an id as not navigable and speaks instead", async () => {
+  test("space appends an empty-label part via setParts", () => {
+    const message = createMessageStub([]);
+    const { activation } = setup({ message });
+
+    activation.activateButton({ id: "btn", actions: [{ kind: "space" }] });
+
+    expect(message.setParts).toHaveBeenCalledTimes(1);
+    const [committed] = vi.mocked(message.setParts).mock.calls[0];
+    expect(committed).toHaveLength(1);
+    expect(committed[0].label).toBe("");
+    expect(committed[0].id).toBeTruthy();
+  });
+
+  test("backspace removes the last part via setParts", () => {
+    const message = createMessageStub([
+      { id: "1", label: "hello" },
+      { id: "2", label: "world" },
+    ]);
+    const { activation } = setup({ message });
+
+    activation.activateButton({ id: "btn", actions: [{ kind: "backspace" }] });
+
+    expect(message.setParts).toHaveBeenCalledWith([
+      { id: "1", label: "hello" },
+    ]);
+  });
+
+  test("clear empties the message via setParts", () => {
+    const message = createMessageStub([{ id: "1", label: "hello" }]);
+    const { activation } = setup({ message });
+
+    activation.activateButton({ id: "btn", actions: [{ kind: "clear" }] });
+
+    expect(message.setParts).toHaveBeenCalledWith([]);
+  });
+
+  test("spelling then speaking speaks a message that includes the spelled letter", () => {
+    const message = createMessageStub([]);
+    const playback = createPlaybackStub();
+    const { activation } = setup({ message, playback });
+
+    activation.activateButton({
+      id: "btn",
+      actions: [{ kind: "spell", text: "s" }, { kind: "speak" }],
+    });
+
+    expect(playback.play).toHaveBeenCalledTimes(1);
+    const [spokenParts] = vi.mocked(playback.play).mock.calls[0];
+    expect(spokenParts).toHaveLength(1);
+    expect(spokenParts[0].label).toBe("s");
+    expect(spokenParts[0].id).toBeTruthy();
+  });
+
+  test("speaking then clearing speaks the pre-clear message and commits an empty message", () => {
+    const initialParts: MessagePart[] = [{ id: "1", label: "hi" }];
+    const message = createMessageStub(initialParts);
+    const playback = createPlaybackStub();
+    const { activation } = setup({ message, playback });
+
+    activation.activateButton({
+      id: "btn",
+      actions: [{ kind: "speak" }, { kind: "clear" }],
+    });
+
+    expect(playback.play).toHaveBeenCalledWith(initialParts);
+    expect(message.setParts).toHaveBeenCalledWith([]);
+  });
+
+  test("a mutation-only sequence commits parts once and never plays", () => {
+    const message = createMessageStub([]);
+    const playback = createPlaybackStub();
+    const { activation } = setup({ message, playback });
+
+    activation.activateButton({ id: "btn", actions: [{ kind: "space" }] });
+
+    expect(message.setParts).toHaveBeenCalledTimes(1);
+    expect(playback.play).not.toHaveBeenCalled();
+  });
+
+  test("a speak-only sequence plays without committing any parts", () => {
+    const initialParts: MessagePart[] = [{ id: "1", label: "hi" }];
+    const message = createMessageStub(initialParts);
+    const playback = createPlaybackStub();
+    const { activation } = setup({ message, playback });
+
+    activation.activateButton({ id: "btn", actions: [{ kind: "speak" }] });
+
+    expect(playback.play).toHaveBeenCalledWith(initialParts);
+    expect(message.setParts).not.toHaveBeenCalled();
+  });
+
+  test("treats a loadBoard without an id as not navigable and speaks instead", () => {
     const { activation, message, navigation } = setup();
 
-    await activation.activateButton({
+    activation.activateButton({
       id: "btn",
       label: "hi",
       loadBoard: { name: "Other" },
     });
 
     expect(navigation.goToBoard).not.toHaveBeenCalled();
-    expect(message.addPart).toHaveBeenCalledTimes(1);
+    expect(message.setParts).toHaveBeenCalledTimes(1);
   });
 
-  test("treats an empty actions array as no actions and speaks instead", async () => {
+  test("treats an empty actions array as no actions and speaks instead", () => {
     const { activation, message } = setup();
 
-    await activation.activateButton({
+    activation.activateButton({
       id: "btn",
       label: "hi",
-      actions: [] as BoardAction[],
+      actions: [],
     });
 
-    expect(message.addPart).toHaveBeenCalledTimes(1);
+    expect(message.setParts).toHaveBeenCalledTimes(1);
   });
 
-  test("adds the button as a message part when there are no actions and no loadBoard", async () => {
-    const { activation, message } = setup();
+  test("adds the button as a message part when there are no actions and no loadBoard", () => {
+    const message = createMessageStub([]);
+    const { activation } = setup({ message });
 
-    await activation.activateButton({
+    activation.activateButton({
       id: "btn",
       label: "hi",
       vocalization: "hello",
       imageSrc: "img.png",
     });
 
-    expect(message.addPart).toHaveBeenCalledWith({
+    expect(message.setParts).toHaveBeenCalledTimes(1);
+    const [committed] = vi.mocked(message.setParts).mock.calls[0];
+    expect(committed).toHaveLength(1);
+    expect(committed[0]).toMatchObject({
       label: "hi",
       vocalization: "hello",
       imageSrc: "img.png",
-      soundSrc: undefined,
     });
+    expect(committed[0].id).toBeTruthy();
   });
 
-  test("plays the button's soundSrc rather than speaking when both are present", async () => {
+  test("plays the button's soundSrc rather than speaking when both are present", () => {
     const { activation } = setup();
 
-    await activation.activateButton({
+    activation.activateButton({
       id: "btn",
       label: "bell",
       soundSrc: "bell.mp3",
@@ -209,10 +258,10 @@ describe("createButtonActivation", () => {
     expect(speech.speak).not.toHaveBeenCalled();
   });
 
-  test("speaks the lowercased vocalization when no soundSrc", async () => {
+  test("speaks the lowercased vocalization when no soundSrc", () => {
     const { activation } = setup();
 
-    await activation.activateButton({
+    activation.activateButton({
       id: "btn",
       label: "I",
       vocalization: "Hello",
@@ -222,21 +271,21 @@ describe("createButtonActivation", () => {
     expect(speech.speak.mock.calls[0][0].text).toBe("hello");
   });
 
-  test("falls back to the lowercased label when vocalization is absent", async () => {
+  test("falls back to the lowercased label when vocalization is absent", () => {
     const { activation } = setup();
 
-    await activation.activateButton({ id: "btn", label: "Goodbye" });
+    activation.activateButton({ id: "btn", label: "Goodbye" });
 
     expect(speech.speak).toHaveBeenCalledTimes(1);
     expect(speech.speak.mock.calls[0][0].text).toBe("goodbye");
   });
 
-  test("stays silent when the button has neither sound nor any speakable text", async () => {
+  test("stays silent when the button has neither sound nor any speakable text", () => {
     const { activation, message } = setup();
 
-    await activation.activateButton({ id: "btn" });
+    activation.activateButton({ id: "btn" });
 
-    expect(message.addPart).toHaveBeenCalledTimes(1);
+    expect(message.setParts).toHaveBeenCalledTimes(1);
     expect(speech.speak).not.toHaveBeenCalled();
     expect(audio.play).not.toHaveBeenCalled();
   });

--- a/src/features/board/activation/button-activation.test.ts
+++ b/src/features/board/activation/button-activation.test.ts
@@ -10,9 +10,6 @@ function createMessageStub(parts: MessagePart[] = []): UseMessageReturn {
   return {
     parts,
     text: parts.map((p) => p.label ?? "").join(" "),
-    addPart: vi.fn(),
-    addSpace: vi.fn(),
-    appendText: vi.fn(),
     setFromText: vi.fn(),
     removeLastPart: vi.fn(),
     setParts: vi.fn(),
@@ -158,12 +155,20 @@ describe("createButtonActivation", () => {
     expect(spokenParts).toHaveLength(1);
     expect(spokenParts[0].label).toBe("s");
     expect(spokenParts[0].id).toBeTruthy();
+    expect(message.setParts).toHaveBeenCalledWith(spokenParts);
   });
 
-  test("speaking then clearing speaks the pre-clear message and commits an empty message", () => {
+  test("speaking then clearing keeps the message until playback ends, then commits the clear", async () => {
     const initialParts: MessagePart[] = [{ id: "1", label: "hi" }];
     const message = createMessageStub(initialParts);
     const playback = createPlaybackStub();
+    let resolvePlay: (() => void) | undefined;
+    playback.play = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvePlay = resolve;
+        }),
+    );
     const { activation } = setup({ message, playback });
 
     activation.activateButton({
@@ -172,21 +177,35 @@ describe("createButtonActivation", () => {
     });
 
     expect(playback.play).toHaveBeenCalledWith(initialParts);
-    expect(message.setParts).toHaveBeenCalledWith([]);
+    expect(message.setParts).not.toHaveBeenCalled();
+
+    resolvePlay?.();
+    await vi.waitFor(() => {
+      expect(message.setParts).toHaveBeenCalledWith([]);
+    });
   });
 
-  test("a mutation-only sequence commits parts once and never plays", () => {
+  test("a mutation-only sequence folds every mutation into one commit and never plays", () => {
     const message = createMessageStub([]);
     const playback = createPlaybackStub();
     const { activation } = setup({ message, playback });
 
-    activation.activateButton({ id: "btn", actions: [{ kind: "space" }] });
+    activation.activateButton({
+      id: "btn",
+      actions: [
+        { kind: "spell", text: "h" },
+        { kind: "spell", text: "i" },
+        { kind: "space" },
+      ],
+    });
 
     expect(message.setParts).toHaveBeenCalledTimes(1);
+    const [committed] = vi.mocked(message.setParts).mock.calls[0];
+    expect(committed.map((part) => part.label)).toEqual(["hi", ""]);
     expect(playback.play).not.toHaveBeenCalled();
   });
 
-  test("a speak-only sequence plays without committing any parts", () => {
+  test("a speak-only sequence plays without committing any parts", async () => {
     const initialParts: MessagePart[] = [{ id: "1", label: "hi" }];
     const message = createMessageStub(initialParts);
     const playback = createPlaybackStub();
@@ -195,6 +214,9 @@ describe("createButtonActivation", () => {
     activation.activateButton({ id: "btn", actions: [{ kind: "speak" }] });
 
     expect(playback.play).toHaveBeenCalledWith(initialParts);
+
+    await Promise.resolve();
+
     expect(message.setParts).not.toHaveBeenCalled();
   });
 

--- a/src/features/board/activation/button-activation.ts
+++ b/src/features/board/activation/button-activation.ts
@@ -1,23 +1,26 @@
 import { playAudio } from "@shared/audio/play-audio";
 import { speak } from "@shared/speech/speech-store";
 import { assertNever } from "@shared/utils/assert-never";
+import {
+  addPartToParts,
+  addSpaceToParts,
+  appendTextToParts,
+  removeLastPartFromParts,
+} from "../message/message-transforms";
 import type { UseMessagePlaybackReturn } from "../message/playback/use-message-playback";
-import type { UseMessageReturn } from "../message/use-message";
+import type { MessagePart, UseMessageReturn } from "../message/use-message";
 import type { UseBoardNavigationReturn } from "../navigation/use-board-navigation";
-import type { BoardAction, BoardButton } from "../types";
+import type { BoardButton } from "../types";
 import { resolveButtonIntent } from "./button-intent-resolver";
 
 export interface ButtonActivationOptions {
-  message: Pick<
-    UseMessageReturn,
-    "addPart" | "appendText" | "addSpace" | "removeLastPart" | "clear"
-  >;
+  message: Pick<UseMessageReturn, "parts" | "setParts">;
   playback: Pick<UseMessagePlaybackReturn, "play">;
   navigation: Pick<UseBoardNavigationReturn, "goToBoard" | "goHome">;
 }
 
 export interface ButtonActivation {
-  activateButton: (button: BoardButton) => Promise<void>;
+  activateButton: (button: BoardButton) => void;
 }
 
 export function createButtonActivation({
@@ -25,8 +28,11 @@ export function createButtonActivation({
   playback,
   navigation,
 }: ButtonActivationOptions): ButtonActivation {
-  async function activateButton(button: BoardButton) {
+  function activateButton(button: BoardButton) {
     const intents = resolveButtonIntent(button);
+
+    let parts = message.parts;
+    let partsToSpeak: MessagePart[] | null = null;
 
     for (const intent of intents) {
       switch (intent.kind) {
@@ -34,7 +40,7 @@ export function createButtonActivation({
           navigation.goToBoard(intent.targetBoardId);
           break;
         case "compose":
-          message.addPart(intent.content);
+          parts = addPartToParts(parts, intent.content);
           break;
         case "playAudio":
           void playAudio(intent.src);
@@ -43,32 +49,41 @@ export function createButtonActivation({
           void speak(intent.text);
           break;
         case "runAction":
-          await runAction(intent.action);
+          switch (intent.action.kind) {
+            case "spell":
+              parts = appendTextToParts(parts, intent.action.text);
+              break;
+            case "space":
+              parts = addSpaceToParts(parts);
+              break;
+            case "backspace":
+              parts = removeLastPartFromParts(parts);
+              break;
+            case "clear":
+              parts = [];
+              break;
+            case "home":
+              navigation.goHome();
+              break;
+            case "speak":
+              partsToSpeak = parts;
+              break;
+
+            default:
+              assertNever(intent.action);
+          }
           break;
 
         default:
           assertNever(intent);
       }
     }
-  }
 
-  async function runAction(action: BoardAction) {
-    switch (action.kind) {
-      case "spell":
-        return message.appendText(action.text);
-      case "space":
-        return message.addSpace();
-      case "backspace":
-        return message.removeLastPart();
-      case "clear":
-        return message.clear();
-      case "home":
-        return navigation.goHome();
-      case "speak":
-        return playback.play();
-
-      default:
-        assertNever(action);
+    if (parts !== message.parts) {
+      message.setParts(parts);
+    }
+    if (partsToSpeak) {
+      void playback.play(partsToSpeak);
     }
   }
 

--- a/src/features/board/activation/button-activation.ts
+++ b/src/features/board/activation/button-activation.ts
@@ -79,11 +79,20 @@ export function createButtonActivation({
       }
     }
 
-    if (parts !== message.parts) {
-      message.setParts(parts);
-    }
     if (partsToSpeak) {
-      void playback.play(partsToSpeak);
+      if (partsToSpeak !== message.parts) {
+        message.setParts(partsToSpeak);
+      }
+      // Post-speak mutations (":speak" then ":clear") commit after the
+      // utterance, so the spoken message stays visible while it plays.
+      const partsAfterSpeak = parts;
+      void playback.play(partsToSpeak).then(() => {
+        if (partsAfterSpeak !== partsToSpeak) {
+          message.setParts(partsAfterSpeak);
+        }
+      });
+    } else if (parts !== message.parts) {
+      message.setParts(parts);
     }
   }
 

--- a/src/features/board/board-viewer.test.tsx
+++ b/src/features/board/board-viewer.test.tsx
@@ -9,6 +9,14 @@ import type { OBFBoard } from "@shayc/open-board-format";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { renderBoardViewer, TWO_TILE_BOARD } from "./test-utils";
 
+const SPELL_THEN_SPEAK_BOARD: OBFBoard = {
+  format: "open-board-0.1",
+  id: "spell-then-speak-board",
+  locale: "en",
+  buttons: [{ id: "btn-1", label: "S", actions: ["+s", ":speak"] }],
+  grid: { rows: 1, columns: 1, order: [["btn-1"]] },
+};
+
 const PICTOGRAM_BOARD: OBFBoard = {
   format: "open-board-0.1",
   id: "pictogram-board",
@@ -45,6 +53,17 @@ describe("BoardViewer", () => {
     await vi.waitFor(() => {
       expect(speech.speak.mock.calls).toHaveLength(1);
       expect(speech.speak.mock.calls[0][0].text).toBe("hello world");
+    });
+  });
+
+  test("a button that spells then speaks in one tap speaks the spelled letter", async () => {
+    const screen = await renderBoardViewer(SPELL_THEN_SPEAK_BOARD);
+
+    await screen.getByRole("button", { name: "S", exact: true }).click();
+
+    await vi.waitFor(() => {
+      expect(speech.speak.mock.calls).toHaveLength(1);
+      expect(speech.speak.mock.calls[0][0].text).toBe("s");
     });
   });
 

--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -40,7 +40,7 @@ export function BoardViewer({ board }: BoardViewerProps) {
   const { direction } = useLanguage();
   const { highlightActivePart } = usePlaybackConfig();
   const message = useMessage();
-  const playback = useMessagePlayback(message.parts);
+  const playback = useMessagePlayback();
   const suggestions = useSuggestions(message.text);
   const navigation = useBoardNavigation();
 
@@ -70,7 +70,7 @@ export function BoardViewer({ board }: BoardViewerProps) {
       backgroundColor={button.backgroundColor}
       borderColor={button.borderColor}
       variant={getNavigationTargetId(button) ? "folder" : undefined}
-      onClick={() => void activateButton(button)}
+      onClick={() => activateButton(button)}
       {...props}
     />
   );
@@ -83,7 +83,7 @@ export function BoardViewer({ board }: BoardViewerProps) {
         isPlaying={playback.isPlaying}
         onBackspacePress={message.removeLastPart}
         onBackspaceLongPress={message.clear}
-        onPlayClick={() => void playback.play()}
+        onPlayClick={() => void playback.play(message.parts)}
         onStopClick={playback.stop}
       />
 

--- a/src/features/board/grid/grid.test.tsx
+++ b/src/features/board/grid/grid.test.tsx
@@ -847,7 +847,10 @@ describe("Grid", () => {
   });
 
   describe("responsive column sizing", () => {
-    const PAD = 24;
+    // This suite's test viewport is narrower than the theme's "sm" breakpoint,
+    // so the grid's --pad is theme.spacing(2) here, not the theme.spacing(3)
+    // default used above that breakpoint.
+    const PAD = 16;
     const GAP = 8;
     const MIN_CELL = 96;
 
@@ -934,7 +937,8 @@ describe("Grid", () => {
   });
 
   describe("responsive row sizing", () => {
-    const PAD = 24;
+    // Same narrower-than-"sm" test viewport as the column-sizing suite above.
+    const PAD = 16;
     const GAP = 8;
     const MIN_CELL = 96;
 

--- a/src/features/board/keyboard/use-board-keyboard.ts
+++ b/src/features/board/keyboard/use-board-keyboard.ts
@@ -6,7 +6,7 @@ import type { UseMessageReturn } from "../message/use-message";
 import { resolveBoardKey } from "./board-key-resolver";
 
 export interface UseBoardKeyboardOptions {
-  message: Pick<UseMessageReturn, "removeLastPart" | "clear">;
+  message: Pick<UseMessageReturn, "parts" | "removeLastPart" | "clear">;
   playback: Pick<UseMessagePlaybackReturn, "play" | "stop" | "isPlaying">;
 }
 
@@ -40,7 +40,7 @@ export function useBoardKeyboard({
           message.clear();
           break;
         case "play":
-          void playback.play();
+          void playback.play(message.parts);
           break;
         case "stop":
           playback.stop();

--- a/src/features/board/message/message-transforms.test.ts
+++ b/src/features/board/message/message-transforms.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "vitest";
+import {
+  addPartToParts,
+  addSpaceToParts,
+  appendTextToParts,
+  removeLastPartFromParts,
+} from "./message-transforms";
+import type { MessagePart } from "./use-message";
+
+describe("addPartToParts", () => {
+  test("appends a new part with a minted id", () => {
+    const parts = addPartToParts([], { label: "hi" });
+
+    expect(parts).toHaveLength(1);
+    expect(parts[0].label).toBe("hi");
+    expect(parts[0].id).toBeTruthy();
+  });
+
+  test("mints a distinct id for each part even with identical content", () => {
+    const first = addPartToParts([], { label: "cat" });
+    const second = addPartToParts(first, { label: "cat" });
+
+    expect(second[0].id).not.toBe(second[1].id);
+  });
+
+  test("leaves the input array untouched", () => {
+    const original: MessagePart[] = [{ id: "1", label: "hi" }];
+
+    const result = addPartToParts(original, { label: "there" });
+
+    expect(original).toHaveLength(1);
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe("addSpaceToParts", () => {
+  test("appends an empty-label part", () => {
+    const parts = addSpaceToParts([{ id: "1", label: "hi" }]);
+
+    expect(parts).toHaveLength(2);
+    expect(parts[1].label).toBe("");
+  });
+});
+
+describe("appendTextToParts", () => {
+  test("appends text as a new part when the message is empty", () => {
+    const parts = appendTextToParts([], "h");
+
+    expect(parts).toHaveLength(1);
+    expect(parts[0].label).toBe("h");
+    expect(parts[0].id).toBeTruthy();
+  });
+
+  test("appends text to the last part without mangling its id or other content", () => {
+    const original: MessagePart[] = [
+      { id: "1", label: "ca", imageSrc: "img.png" },
+    ];
+
+    const parts = appendTextToParts(original, "t");
+
+    expect(parts).toHaveLength(1);
+    expect(parts[0].id).toBe("1");
+    expect(parts[0].label).toBe("cat");
+    expect(parts[0].imageSrc).toBe("img.png");
+  });
+
+  test("accumulates rapid appends into a single part", () => {
+    const afterFirst = appendTextToParts([{ id: "1", label: "" }], "h");
+    const afterSecond = appendTextToParts(afterFirst, "i");
+
+    expect(afterSecond).toHaveLength(1);
+    expect(afterSecond[0].id).toBe("1");
+    expect(afterSecond[0].label).toBe("hi");
+  });
+
+  test("leaves the input array untouched", () => {
+    const original: MessagePart[] = [{ id: "1", label: "ca" }];
+
+    appendTextToParts(original, "t");
+
+    expect(original[0].label).toBe("ca");
+  });
+});
+
+describe("removeLastPartFromParts", () => {
+  test("removes the last part", () => {
+    const parts = removeLastPartFromParts([
+      { id: "1", label: "hello" },
+      { id: "2", label: "world" },
+    ]);
+
+    expect(parts).toEqual([{ id: "1", label: "hello" }]);
+  });
+
+  test("returns an empty array when there is only one part", () => {
+    expect(removeLastPartFromParts([{ id: "1", label: "hi" }])).toEqual([]);
+  });
+
+  test("returns an empty array when already empty", () => {
+    expect(removeLastPartFromParts([])).toEqual([]);
+  });
+});

--- a/src/features/board/message/message-transforms.ts
+++ b/src/features/board/message/message-transforms.ts
@@ -1,7 +1,7 @@
 import { randomId } from "@shared/utils/random-id";
 import type { MessagePart, MessagePartContent } from "./use-message";
 
-function createPart(content: MessagePartContent): MessagePart {
+export function createPart(content: MessagePartContent): MessagePart {
   return { ...content, id: randomId() };
 }
 

--- a/src/features/board/message/message-transforms.ts
+++ b/src/features/board/message/message-transforms.ts
@@ -1,0 +1,36 @@
+import { randomId } from "@shared/utils/random-id";
+import type { MessagePart, MessagePartContent } from "./use-message";
+
+function createPart(content: MessagePartContent): MessagePart {
+  return { ...content, id: randomId() };
+}
+
+export function addPartToParts(
+  parts: MessagePart[],
+  content: MessagePartContent,
+): MessagePart[] {
+  return [...parts, createPart(content)];
+}
+
+export function addSpaceToParts(parts: MessagePart[]): MessagePart[] {
+  return addPartToParts(parts, { label: "" });
+}
+
+export function appendTextToParts(
+  parts: MessagePart[],
+  text: string,
+): MessagePart[] {
+  const lastPart = parts.at(-1);
+  if (!lastPart) {
+    return [createPart({ label: text })];
+  }
+
+  return parts.with(-1, {
+    ...lastPart,
+    label: `${lastPart.label ?? ""}${text}`,
+  });
+}
+
+export function removeLastPartFromParts(parts: MessagePart[]): MessagePart[] {
+  return parts.slice(0, -1);
+}

--- a/src/features/board/message/playback/use-message-playback.test.ts
+++ b/src/features/board/message/playback/use-message-playback.test.ts
@@ -19,9 +19,9 @@ describe("useMessagePlayback", () => {
       { id: "2", label: "want" },
     ];
 
-    const { result } = await renderHook(() => useMessagePlayback(parts));
+    const { result } = await renderHook(() => useMessagePlayback());
 
-    await result.current.play();
+    await result.current.play(parts);
 
     expect(speech.speak).toHaveBeenCalledTimes(1);
     expect(speech.speak.mock.calls[0][0].text).toBe("i want");
@@ -32,9 +32,9 @@ describe("useMessagePlayback", () => {
       { id: "1", label: "bell", soundSrc: "bell.mp3" },
     ];
 
-    const { result } = await renderHook(() => useMessagePlayback(parts));
+    const { result } = await renderHook(() => useMessagePlayback());
 
-    await result.current.play();
+    await result.current.play(parts);
 
     expect(audio.play).toHaveBeenCalledTimes(1);
     expect(speech.speak).not.toHaveBeenCalled();
@@ -64,9 +64,9 @@ describe("useMessagePlayback", () => {
       return Promise.resolve();
     });
 
-    const { result } = await renderHook(() => useMessagePlayback(parts));
+    const { result } = await renderHook(() => useMessagePlayback());
 
-    await result.current.play();
+    await result.current.play(parts);
 
     expect(callOrder).toEqual(["speak:before", "play:ding.mp3", "speak:after"]);
   });
@@ -74,9 +74,9 @@ describe("useMessagePlayback", () => {
   test("drops parts with no audible content", async () => {
     const parts: MessagePart[] = [{ id: "1" }];
 
-    const { result } = await renderHook(() => useMessagePlayback(parts));
+    const { result } = await renderHook(() => useMessagePlayback());
 
-    await result.current.play();
+    await result.current.play(parts);
 
     expect(speech.speak).not.toHaveBeenCalled();
     expect(audio.play).not.toHaveBeenCalled();
@@ -92,11 +92,9 @@ describe("useMessagePlayback", () => {
 
     const parts: MessagePart[] = [{ id: "1", label: "hi" }];
 
-    const { result, rerender } = await renderHook(() =>
-      useMessagePlayback(parts),
-    );
+    const { result, rerender } = await renderHook(() => useMessagePlayback());
 
-    const playPromise = result.current.play();
+    const playPromise = result.current.play(parts);
     await rerender();
     expect(result.current.isPlaying).toBe(true);
 
@@ -116,11 +114,9 @@ describe("useMessagePlayback", () => {
 
     const parts: MessagePart[] = [{ id: "1", label: "hi" }];
 
-    const { result, rerender } = await renderHook(() =>
-      useMessagePlayback(parts),
-    );
+    const { result, rerender } = await renderHook(() => useMessagePlayback());
 
-    const playPromise = result.current.play();
+    const playPromise = result.current.play(parts);
     await rerender();
 
     result.current.stop();
@@ -144,20 +140,16 @@ describe("useMessagePlayback", () => {
 
     const parts: MessagePart[] = [{ id: "1", label: "hi" }];
 
-    const { result, rerender } = await renderHook(() =>
-      useMessagePlayback(parts),
-    );
+    const { result, rerender } = await renderHook(() => useMessagePlayback());
 
-    await expect(result.current.play()).resolves.toBeUndefined();
+    await expect(result.current.play(parts)).resolves.toBeUndefined();
     await rerender();
 
     expect(result.current.isPlaying).toBe(false);
   });
 
   test("has no active part before playback starts", async () => {
-    const parts: MessagePart[] = [{ id: "1", label: "hi" }];
-
-    const { result } = await renderHook(() => useMessagePlayback(parts));
+    const { result } = await renderHook(() => useMessagePlayback());
 
     expect(result.current.activePartId).toBeNull();
   });
@@ -180,11 +172,9 @@ describe("useMessagePlayback", () => {
       { id: "2", label: "want" },
     ];
 
-    const { result, rerender } = await renderHook(() =>
-      useMessagePlayback(parts),
-    );
+    const { result, rerender } = await renderHook(() => useMessagePlayback());
 
-    const playPromise = result.current.play();
+    const playPromise = result.current.play(parts);
     await rerender();
 
     fireBoundary?.(2); // "want" begins at offset 2 in "i want"
@@ -208,11 +198,9 @@ describe("useMessagePlayback", () => {
 
     const parts: MessagePart[] = [{ id: "1", label: "hi" }];
 
-    const { result, rerender } = await renderHook(() =>
-      useMessagePlayback(parts),
-    );
+    const { result, rerender } = await renderHook(() => useMessagePlayback());
 
-    const playPromise = result.current.play();
+    const playPromise = result.current.play(parts);
     await rerender();
     expect(result.current.activePartId).toBe("1");
 
@@ -238,11 +226,9 @@ describe("useMessagePlayback", () => {
       { id: "3", label: "after" },
     ];
 
-    const { result, rerender } = await renderHook(() =>
-      useMessagePlayback(parts),
-    );
+    const { result, rerender } = await renderHook(() => useMessagePlayback());
 
-    const playPromise = result.current.play();
+    const playPromise = result.current.play(parts);
     await rerender();
 
     result.current.stop();
@@ -273,11 +259,9 @@ describe("useMessagePlayback", () => {
       { id: "2", label: "want" },
     ];
 
-    const { result, rerender } = await renderHook(() =>
-      useMessagePlayback(parts),
-    );
+    const { result, rerender } = await renderHook(() => useMessagePlayback());
 
-    const playPromise = result.current.play();
+    const playPromise = result.current.play(parts);
     await rerender();
 
     result.current.stop();
@@ -287,5 +271,31 @@ describe("useMessagePlayback", () => {
 
     resolveSpeak?.();
     await playPromise;
+  });
+
+  test("a second play() call aborts the first and speaks only its own parts", async () => {
+    let resolveFirstSpeak: (() => void) | undefined;
+    speech.speak.mockImplementationOnce((utterance) => {
+      resolveFirstSpeak = () => {
+        utterance.onend?.({ utterance } as unknown as SpeechSynthesisEvent);
+      };
+    });
+    speech.speak.mockImplementationOnce((utterance) => {
+      queueMicrotask(() => {
+        utterance.onend?.({ utterance } as unknown as SpeechSynthesisEvent);
+      });
+    });
+
+    const { result } = await renderHook(() => useMessagePlayback());
+
+    const firstPlay = result.current.play([{ id: "1", label: "first" }]);
+    const secondPlay = result.current.play([{ id: "2", label: "second" }]);
+
+    resolveFirstSpeak?.();
+    await firstPlay;
+    await secondPlay;
+
+    expect(speech.speak).toHaveBeenCalledTimes(2);
+    expect(speech.speak.mock.calls[1][0].text).toBe("second");
   });
 });

--- a/src/features/board/message/playback/use-message-playback.ts
+++ b/src/features/board/message/playback/use-message-playback.ts
@@ -8,18 +8,16 @@ import { planPlayback } from "./plan-playback";
 export interface UseMessagePlaybackReturn {
   isPlaying: boolean;
   activePartId: string | null;
-  play: () => Promise<void>;
+  play: (parts: MessagePart[]) => Promise<void>;
   stop: () => void;
 }
 
-export function useMessagePlayback(
-  parts: MessagePart[],
-): UseMessagePlaybackReturn {
+export function useMessagePlayback(): UseMessagePlaybackReturn {
   const [isPlaying, setIsPlaying] = useState(false);
   const [activePartId, setActivePartId] = useState<string | null>(null);
   const playbackRef = useRef<AbortController | null>(null);
 
-  async function play() {
+  async function play(parts: MessagePart[]) {
     playbackRef.current?.abort();
     const controller = new AbortController();
     playbackRef.current = controller;

--- a/src/features/board/message/use-message.test.ts
+++ b/src/features/board/message/use-message.test.ts
@@ -142,4 +142,16 @@ describe("useMessage", () => {
 
     expect(result.current.parts).toHaveLength(0);
   });
+
+  test("setParts replaces the parts wholesale", async () => {
+    const { result, rerender } = await renderHook(() => useMessage());
+
+    result.current.addPart({ label: "existing" });
+    await rerender();
+
+    result.current.setParts([{ id: "1", label: "replaced" }]);
+    await rerender();
+
+    expect(result.current.parts).toEqual([{ id: "1", label: "replaced" }]);
+  });
 });

--- a/src/features/board/message/use-message.test.ts
+++ b/src/features/board/message/use-message.test.ts
@@ -6,11 +6,7 @@ describe("useMessage", () => {
   test("builds text from multiple parts joined by spaces", async () => {
     const { result, rerender } = await renderHook(() => useMessage());
 
-    result.current.addPart({ label: "I" });
-    await rerender();
-    result.current.addPart({ label: "want" });
-    await rerender();
-    result.current.addPart({ label: "water" });
+    result.current.setFromText("I want water");
     await rerender();
 
     expect(result.current.parts).toHaveLength(3);
@@ -20,9 +16,7 @@ describe("useMessage", () => {
   test("mints a distinct id for each part even with identical content", async () => {
     const { result, rerender } = await renderHook(() => useMessage());
 
-    result.current.addPart({ label: "cat" });
-    await rerender();
-    result.current.addPart({ label: "cat" });
+    result.current.setFromText("cat cat");
     await rerender();
 
     const [first, second] = result.current.parts;
@@ -31,57 +25,10 @@ describe("useMessage", () => {
     expect(first.id).not.toBe(second.id);
   });
 
-  test("appends text to the last part without mangling its id", async () => {
-    const { result, rerender } = await renderHook(() => useMessage());
-
-    result.current.addPart({ label: "ca", imageSrc: "img.png" });
-    await rerender();
-
-    const partId = result.current.parts[0].id;
-
-    result.current.appendText("t");
-    await rerender();
-
-    expect(result.current.parts).toHaveLength(1);
-    expect(result.current.parts[0].id).toBe(partId);
-    expect(result.current.parts[0].label).toBe("cat");
-    expect(result.current.parts[0].imageSrc).toBe("img.png");
-  });
-
-  test("appends text as a new part when the message is empty", async () => {
-    const { result, rerender } = await renderHook(() => useMessage());
-
-    result.current.appendText("h");
-    await rerender();
-
-    expect(result.current.parts).toHaveLength(1);
-    expect(result.current.parts[0].label).toBe("h");
-    expect(result.current.parts[0].id).toBeTruthy();
-  });
-
-  test("accumulates rapid appends into a single part", async () => {
-    const { result, rerender } = await renderHook(() => useMessage());
-
-    result.current.addPart({ label: "" });
-    await rerender();
-
-    const partId = result.current.parts[0].id;
-
-    result.current.appendText("h");
-    result.current.appendText("i");
-    await rerender();
-
-    expect(result.current.parts).toHaveLength(1);
-    expect(result.current.parts[0].id).toBe(partId);
-    expect(result.current.parts[0].label).toBe("hi");
-  });
-
   test("removes the last-added part", async () => {
     const { result, rerender } = await renderHook(() => useMessage());
 
-    result.current.addPart({ label: "hello" });
-    await rerender();
-    result.current.addPart({ label: "world" });
+    result.current.setFromText("hello world");
     await rerender();
 
     result.current.removeLastPart();
@@ -134,7 +81,7 @@ describe("useMessage", () => {
   test("clears all existing parts when called with an empty string", async () => {
     const { result, rerender } = await renderHook(() => useMessage());
 
-    result.current.addPart({ label: "existing" });
+    result.current.setFromText("existing");
     await rerender();
 
     result.current.setFromText("");
@@ -146,7 +93,7 @@ describe("useMessage", () => {
   test("setParts replaces the parts wholesale", async () => {
     const { result, rerender } = await renderHook(() => useMessage());
 
-    result.current.addPart({ label: "existing" });
+    result.current.setFromText("existing");
     await rerender();
 
     result.current.setParts([{ id: "1", label: "replaced" }]);

--- a/src/features/board/message/use-message.ts
+++ b/src/features/board/message/use-message.ts
@@ -1,11 +1,6 @@
 import { useState } from "react";
 import type { BoardButton } from "../types";
-import {
-  addPartToParts,
-  addSpaceToParts,
-  appendTextToParts,
-  removeLastPartFromParts,
-} from "./message-transforms";
+import { createPart, removeLastPartFromParts } from "./message-transforms";
 
 export type MessagePartContent = Pick<
   BoardButton,
@@ -19,9 +14,6 @@ export type MessagePart = { id: string } & MessagePartContent;
 export interface UseMessageReturn {
   parts: MessagePart[];
   text: string;
-  addPart: (content: MessagePartContent) => void;
-  addSpace: () => void;
-  appendText: (text: string) => void;
   setFromText: (input: string) => void;
   removeLastPart: () => void;
   setParts: (parts: MessagePart[]) => void;
@@ -32,28 +24,13 @@ export function useMessage(): UseMessageReturn {
   const [parts, setParts] = useState<MessagePart[]>([]);
   const text = parts.map((part) => part.label).join(" ");
 
-  function addPart(content: MessagePartContent) {
-    setParts((prev) => addPartToParts(prev, content));
-  }
-
-  function addSpace() {
-    setParts((prev) => addSpaceToParts(prev));
-  }
-
-  function appendText(text: string) {
-    setParts((prev) => appendTextToParts(prev, text));
-  }
-
   function setFromText(input: string) {
     setParts(
       input
         .trim()
         .split(/\s+/)
         .filter(Boolean)
-        .reduce<MessagePart[]>(
-          (prev, word) => addPartToParts(prev, { label: word }),
-          [],
-        ),
+        .map((word) => createPart({ label: word })),
     );
   }
 
@@ -68,9 +45,6 @@ export function useMessage(): UseMessageReturn {
   return {
     parts,
     text,
-    addPart,
-    addSpace,
-    appendText,
     setFromText,
     removeLastPart,
     setParts,

--- a/src/features/board/message/use-message.ts
+++ b/src/features/board/message/use-message.ts
@@ -1,6 +1,11 @@
-import { randomId } from "@shared/utils/random-id";
 import { useState } from "react";
 import type { BoardButton } from "../types";
+import {
+  addPartToParts,
+  addSpaceToParts,
+  appendTextToParts,
+  removeLastPartFromParts,
+} from "./message-transforms";
 
 export type MessagePartContent = Pick<
   BoardButton,
@@ -19,11 +24,8 @@ export interface UseMessageReturn {
   appendText: (text: string) => void;
   setFromText: (input: string) => void;
   removeLastPart: () => void;
+  setParts: (parts: MessagePart[]) => void;
   clear: () => void;
-}
-
-function createPart(content: MessagePartContent): MessagePart {
-  return { ...content, id: randomId() };
 }
 
 export function useMessage(): UseMessageReturn {
@@ -31,25 +33,15 @@ export function useMessage(): UseMessageReturn {
   const text = parts.map((part) => part.label).join(" ");
 
   function addPart(content: MessagePartContent) {
-    setParts((prev) => [...prev, createPart(content)]);
+    setParts((prev) => addPartToParts(prev, content));
   }
 
   function addSpace() {
-    addPart({ label: "" });
+    setParts((prev) => addSpaceToParts(prev));
   }
 
   function appendText(text: string) {
-    setParts((prev) => {
-      const lastPart = prev.at(-1);
-      if (!lastPart) {
-        return [createPart({ label: text })];
-      }
-
-      return prev.with(-1, {
-        ...lastPart,
-        label: `${lastPart.label ?? ""}${text}`,
-      });
-    });
+    setParts((prev) => appendTextToParts(prev, text));
   }
 
   function setFromText(input: string) {
@@ -58,12 +50,15 @@ export function useMessage(): UseMessageReturn {
         .trim()
         .split(/\s+/)
         .filter(Boolean)
-        .map((word) => createPart({ label: word })),
+        .reduce<MessagePart[]>(
+          (prev, word) => addPartToParts(prev, { label: word }),
+          [],
+        ),
     );
   }
 
   function removeLastPart() {
-    setParts((prev) => prev.slice(0, -1));
+    setParts((prev) => removeLastPartFromParts(prev));
   }
 
   function clear() {
@@ -78,6 +73,7 @@ export function useMessage(): UseMessageReturn {
     appendText,
     setFromText,
     removeLastPart,
+    setParts,
     clear,
   };
 }


### PR DESCRIPTION
## Summary
- Activation now folds a button's action sequence over an explicit `parts` value instead of `play()` closing over render-time `message.parts` — a button whose actions spell a letter then speak it (`["+s", ":speak"]`) previously spoke the message from *before* the letter was added. Compose intents fold into the same sequence, so a button can't mix message-mutating and text-composing behavior through two different commit paths.
- Fixes 6 pre-existing failures in `grid.test.tsx`'s responsive sizing suites: the test viewport (414×896) sits below the theme's `sm` breakpoint, where the grid's own CSS (from #648) already drops `--pad` from 24px to 16px — the test's `PAD` constant was never updated to match, so every assertion was off by exactly 8px.

## Test plan
- [x] `npm run -s lint` on all touched files
- [x] Targeted suite: `message-transforms`, `use-message`, `use-message-playback`, `button-activation`, `board-viewer`, `use-board-keyboard`
- [x] Full suite: 467/467 passing
- [x] `npm run build` (includes `tsc -b`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)