### PR TITLE
fix: make board import replace a set atomically and visibly

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "تم استبدال اللوحة",
+        "countPlural=*": "تم استبدال اللوحات"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Дъската е заменена",
+        "countPlural=*": "Дъските са заменени"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "বোর্ড প্রতিস্থাপিত হয়েছে",
+        "countPlural=*": "বোর্ড প্রতিস্থাপিত হয়েছে"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tabulka nahrazena",
+        "countPlural=*": "Tabulky nahrazeny"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/da.json
+++ b/messages/da.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tavle erstattet",
+        "countPlural=*": "Tavler erstattet"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/de.json
+++ b/messages/de.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tafel ersetzt",
+        "countPlural=*": "Tafeln ersetzt"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/el.json
+++ b/messages/el.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Ο πίνακας αντικαταστάθηκε",
+        "countPlural=*": "Οι πίνακες αντικαταστάθηκαν"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/en.json
+++ b/messages/en.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Board replaced",
+        "countPlural=*": "Boards replaced"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/es.json
+++ b/messages/es.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tablero reemplazado",
+        "countPlural=*": "Tableros reemplazados"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Taulu korvattu",
+        "countPlural=*": "Taulut korvattu"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tableau remplacé",
+        "countPlural=*": "Tableaux remplacés"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/he.json
+++ b/messages/he.json
@@ -35,8 +35,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "הלוח יוחלף בהצלחה",
-        "countPlural=*": "הלוחות יוחלפו בהצלחה"
+        "countPlural=one": "הלוח הוחלף בהצלחה",
+        "countPlural=*": "הלוחות הוחלפו בהצלחה"
       }
     }
   ],

--- a/messages/he.json
+++ b/messages/he.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "הלוח יוחלף בהצלחה",
+        "countPlural=*": "הלוחות יוחלפו בהצלחה"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "बोर्ड बदल दिया गया",
+        "countPlural=*": "बोर्ड बदल दिए गए"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Ploča zamijenjena",
+        "countPlural=*": "Ploče zamijenjene"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tábla lecserélve",
+        "countPlural=*": "Táblák lecserélve"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/id.json
+++ b/messages/id.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Papan diganti",
+        "countPlural=*": "Papan diganti"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/it.json
+++ b/messages/it.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tabella sostituita",
+        "countPlural=*": "Tabelle sostituite"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "ボードを置き換えました",
+        "countPlural=*": "ボードを置き換えました"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "ಬೋರ್ಡ್ ಬದಲಾಯಿಸಲಾಗಿದೆ",
+        "countPlural=*": "ಬೋರ್ಡ್‌ಗಳು ಬದಲಾಯಿಸಲಾಗಿವೆ"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "보드를 교체했습니다",
+        "countPlural=*": "보드를 교체했습니다"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Bord vervangen",
+        "countPlural=*": "Borden vervangen"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Zastąpiono tablicę",
+        "countPlural=*": "Zastąpiono tablice"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Prancha substituída",
+        "countPlural=*": "Pranchas substituídas"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tablă înlocuită",
+        "countPlural=*": "Table înlocuite"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Доска заменена",
+        "countPlural=*": "Доски заменены"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tabuľka nahradená",
+        "countPlural=*": "Tabuľky nahradené"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tabla zamenjana",
+        "countPlural=*": "Table zamenjane"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tavla ersatt",
+        "countPlural=*": "Tavlor ersatta"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "பலகை மாற்றப்பட்டது",
+        "countPlural=*": "பலகைகள் மாற்றப்பட்டன"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/te.json
+++ b/messages/te.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "బోర్డు భర్తీ చేయబడింది",
+        "countPlural=*": "బోర్డులు భర్తీ చేయబడ్డాయి"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/th.json
+++ b/messages/th.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "แทนที่บอร์ดแล้ว",
+        "countPlural=*": "แทนที่บอร์ดแล้ว"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Pano değiştirildi",
+        "countPlural=*": "Panolar değiştirildi"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Дошку замінено",
+        "countPlural=*": "Дошки замінено"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Đã thay thế bảng",
+        "countPlural=*": "Đã thay thế các bảng"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -30,6 +30,16 @@
       }
     }
   ],
+  "libraryReplacedBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "已替换沟通板",
+        "countPlural=*": "已替换沟通板"
+      }
+    }
+  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],

--- a/src/features/board/import/board-import.test.ts
+++ b/src/features/board/import/board-import.test.ts
@@ -30,6 +30,7 @@ describe("importBoardFiles", () => {
       {
         setId: IMPORTED_SET_ID,
         rootBoardId: board.id,
+        replacedExisting: false,
       },
     ]);
 
@@ -82,6 +83,7 @@ describe("importBoardFiles", () => {
       {
         setId: IMPORTED_SET_ID,
         rootBoardId,
+        replacedExisting: false,
       },
     ]);
 
@@ -187,6 +189,31 @@ describe("importBoardFiles", () => {
     const importResults = await importBoardFiles(longNamedFile);
 
     expect(importResults[0].setId).toBe("x".repeat(255));
+  });
+
+  test("re-importing the same filename replaces the existing set", async () => {
+    const fixtureFile = await loadFixtureFile(OBF_FIXTURE);
+
+    const first = await importBoardFiles(fixtureFile);
+    expect(first[0].replacedExisting).toBe(false);
+
+    const second = await importBoardFiles(fixtureFile);
+    expect(second[0].replacedExisting).toBe(true);
+
+    const boardSets = await listBoardSets();
+    expect(boardSets).toHaveLength(1);
+  });
+
+  test("a failure partway through a multi-file import still leaves the earlier set visible", async () => {
+    const goodFile = await loadFixtureFile(OBF_FIXTURE);
+    const corruptFile = new File(["not valid json"], "corrupt.obf", {
+      type: "application/json",
+    });
+
+    await expect(importBoardFiles([goodFile, corruptFile])).rejects.toThrow();
+
+    const boardSets = await listBoardSets();
+    expect(boardSets.map((set) => set.setId)).toContain(IMPORTED_SET_ID);
   });
 });
 

--- a/src/features/board/import/board-import.ts
+++ b/src/features/board/import/board-import.ts
@@ -13,11 +13,12 @@ import type {
   UpsertBoardInput,
   UpsertBoardSetInput,
 } from "../storage/boards-db";
-import { putAssets, putBoards, upsertBoardSet } from "../storage/boards-db";
+import { replaceBoardSet } from "../storage/boards-db";
 
 export interface ImportResult {
   setId: string;
   rootBoardId: string;
+  replacedExisting: boolean;
 }
 
 export async function importBoardFiles(
@@ -26,18 +27,22 @@ export async function importBoardFiles(
   const fileList = Array.isArray(files) ? files : [files];
   const results: ImportResult[] = [];
 
-  for (const file of fileList) {
-    const setId = deriveSetId(file.name);
-    const loaded = await loadBoard(file);
+  try {
+    for (const file of fileList) {
+      const setId = deriveSetId(file.name);
+      const loaded = await loadBoard(file);
 
-    results.push(
-      loaded.format === "obz"
-        ? await importOBZArchive(loaded.archive, setId, file.name)
-        : await importOBFBoard(loaded.board, setId, file.name),
-    );
+      results.push(
+        loaded.format === "obz"
+          ? await importOBZArchive(loaded.archive, setId, file.name)
+          : await importOBFBoard(loaded.board, setId, file.name),
+      );
+    }
+  } finally {
+    if (results.length > 0) {
+      await notifyBoardSetsChanged();
+    }
   }
-
-  await notifyBoardSetsChanged();
 
   return results;
 }
@@ -50,15 +55,13 @@ async function importOBZArchive(
   const { manifest, boards, rootBoard, resources } = archive;
   const boardPathToId = buildBoardPathToId(manifest);
 
-  await upsertBoardSet(buildBoardSetInput(setId, rootBoard, fileName));
-  await putBoards(setId, buildBoardInputs(boards, boardPathToId));
+  const { replacedExisting } = await replaceBoardSet({
+    boardSet: buildBoardSetInput(setId, rootBoard, fileName),
+    boards: buildBoardInputs(boards, boardPathToId),
+    assets: buildAssetInputs(resources),
+  });
 
-  const assetInputs = buildAssetInputs(resources);
-  if (assetInputs.length > 0) {
-    await putAssets(setId, assetInputs);
-  }
-
-  return { setId, rootBoardId: rootBoard.id };
+  return { setId, rootBoardId: rootBoard.id, replacedExisting };
 }
 
 async function importOBFBoard(
@@ -66,17 +69,13 @@ async function importOBFBoard(
   setId: string,
   fileName: string,
 ): Promise<ImportResult> {
-  await upsertBoardSet(buildBoardSetInput(setId, board, fileName));
+  const { replacedExisting } = await replaceBoardSet({
+    boardSet: buildBoardSetInput(setId, board, fileName),
+    boards: [{ boardId: board.id, name: board.name ?? board.id, obf: board }],
+    assets: [],
+  });
 
-  await putBoards(setId, [
-    {
-      boardId: board.id,
-      name: board.name ?? board.id,
-      obf: board,
-    },
-  ]);
-
-  return { setId, rootBoardId: board.id };
+  return { setId, rootBoardId: board.id, replacedExisting };
 }
 
 function buildBoardPathToId(manifest: OBFManifest): Map<string, string> {

--- a/src/features/board/import/use-import-board-files.test.tsx
+++ b/src/features/board/import/use-import-board-files.test.tsx
@@ -1,0 +1,55 @@
+import { AppProviders } from "@shared/providers/app-providers";
+import { loadFixtureFile } from "@shared/testing/fixtures";
+import { beforeEach, describe, expect, test } from "vitest";
+import { render } from "vitest-browser-react";
+import { MemoryRouter } from "react-router";
+import { resetBoardsDB } from "../storage/test-utils";
+import { importBoardFiles as importBoardFilesToStorage } from "./board-import";
+import { useImportBoardFiles } from "./use-import-board-files";
+
+const OBF_FIXTURE = "lots-of-stuff.obf";
+
+function ImportTrigger({ files }: { files: File[] }) {
+  const { importBoardFiles } = useImportBoardFiles();
+
+  return <button onClick={() => void importBoardFiles(files)}>import</button>;
+}
+
+function renderImport(files: File[]) {
+  return render(
+    <MemoryRouter>
+      <AppProviders>
+        <ImportTrigger files={files} />
+      </AppProviders>
+    </MemoryRouter>,
+  );
+}
+
+describe("useImportBoardFiles", () => {
+  beforeEach(async () => {
+    await resetBoardsDB();
+  });
+
+  test("shows the imported message for a fresh import", async () => {
+    const file = await loadFixtureFile(OBF_FIXTURE);
+    const screen = await renderImport([file]);
+
+    await screen.getByRole("button", { name: "import" }).click();
+
+    await expect
+      .element(screen.getByRole("alert"))
+      .toHaveTextContent("Board imported");
+  });
+
+  test("shows the replaced message when the set already exists", async () => {
+    const file = await loadFixtureFile(OBF_FIXTURE);
+    await importBoardFilesToStorage(file);
+
+    const screen = await renderImport([file]);
+    await screen.getByRole("button", { name: "import" }).click();
+
+    await expect
+      .element(screen.getByRole("alert"))
+      .toHaveTextContent("Board replaced");
+  });
+});

--- a/src/features/board/import/use-import-board-files.ts
+++ b/src/features/board/import/use-import-board-files.ts
@@ -33,8 +33,14 @@ export function useImportBoardFiles(): UseImportBoardFilesReturn {
     try {
       const results = await importBoardFilesToStorage(files);
 
+      const replacedExisting = results.some(
+        (result) => result.replacedExisting,
+      );
+
       showSnackbar({
-        message: m.libraryImportedBoards({ count }),
+        message: replacedExisting
+          ? m.libraryReplacedBoards({ count })
+          : m.libraryImportedBoards({ count }),
         severity: "success",
       });
 

--- a/src/features/board/storage/board-hydration.test.ts
+++ b/src/features/board/storage/board-hydration.test.ts
@@ -3,12 +3,7 @@ import { beforeEach, describe, expect, test } from "vitest";
 import { assertDefined } from "@shared/testing/assert-defined";
 import { invalidateBoardSets } from "../board-sets/board-sets-store";
 import { hydrateBoard } from "./board-hydration";
-import {
-  BoardNotFoundError,
-  putAssets,
-  putBoards,
-  upsertBoardSet,
-} from "./boards-db";
+import { BoardNotFoundError, replaceBoardSet } from "./boards-db";
 import { resetBoardsDB } from "./test-utils";
 
 const SET_ID = "loader-test-set";
@@ -33,15 +28,11 @@ async function seedTestBoard(): Promise<void> {
     images: [{ id: "img-1", path: IMAGE_PATH, content_type: "image/png" }],
   };
 
-  await upsertBoardSet({
-    setId: SET_ID,
-    name: "Loader Test",
-    rootBoardId: BOARD_ID,
+  await replaceBoardSet({
+    boardSet: { setId: SET_ID, name: "Loader Test", rootBoardId: BOARD_ID },
+    boards: [{ boardId: BOARD_ID, name: "Test Board", obf: obfBoard }],
+    assets: [{ path: IMAGE_PATH, blob: pngBlob }],
   });
-  await putBoards(SET_ID, [
-    { boardId: BOARD_ID, name: "Test Board", obf: obfBoard },
-  ]);
-  await putAssets(SET_ID, [{ path: IMAGE_PATH, blob: pngBlob }]);
 
   await invalidateBoardSets();
 }

--- a/src/features/board/storage/boards-db.test.ts
+++ b/src/features/board/storage/boards-db.test.ts
@@ -8,18 +8,21 @@ import {
   getBoard,
   getBoardsDB,
   listBoardSets,
-  putAssets,
-  putBoards,
+  replaceBoardSet,
   updateBoardStrings,
-  upsertBoardSet,
-  type UpsertBoardSetInput,
+  type ReplaceBoardSetInput,
 } from "./boards-db";
 import { clearBoardsDB } from "./test-utils";
 
-function makeBoardSetInput(
-  overrides: Partial<UpsertBoardSetInput> = {},
-): UpsertBoardSetInput {
-  return { setId: "set-1", name: "Set", rootBoardId: "root-1", ...overrides };
+function makeReplaceInput(
+  overrides: Partial<ReplaceBoardSetInput> = {},
+): ReplaceBoardSetInput {
+  return {
+    boardSet: { setId: "set-1", name: "Set", rootBoardId: "root-1" },
+    boards: [],
+    assets: [],
+    ...overrides,
+  };
 }
 
 function makeOBFBoard(overrides: Partial<OBFBoard> = {}): OBFBoard {
@@ -42,9 +45,15 @@ beforeEach(async () => {
 
 afterEach(closeBoardsDB);
 
-describe("upsertBoardSet", () => {
+describe("replaceBoardSet", () => {
   test("inserts a new board set", async () => {
-    await upsertBoardSet(makeBoardSetInput({ name: "My Set" }));
+    const { replacedExisting } = await replaceBoardSet(
+      makeReplaceInput({
+        boardSet: { setId: "set-1", name: "My Set", rootBoardId: "root-1" },
+      }),
+    );
+
+    expect(replacedExisting).toBe(false);
 
     const sets = await listBoardSets();
     expect(sets).toHaveLength(1);
@@ -53,35 +62,180 @@ describe("upsertBoardSet", () => {
     expect(sets[0].boardCount).toBe(0);
   });
 
-  test("preserves boardCount on upsert", async () => {
-    await upsertBoardSet(makeBoardSetInput());
-    const obf = makeOBFBoard({ id: "b1" });
-    await putBoards("set-1", [{ boardId: "b1", name: "B1", obf }]);
+  test("counts boards from the boards array, not a recount", async () => {
+    const boards = [
+      { boardId: "b1", name: "B1", obf: makeOBFBoard({ id: "b1" }) },
+      { boardId: "b2", name: "B2", obf: makeOBFBoard({ id: "b2" }) },
+      { boardId: "b3", name: "B3", obf: makeOBFBoard({ id: "b3" }) },
+    ];
 
-    await upsertBoardSet(makeBoardSetInput({ name: "Set Renamed" }));
+    await replaceBoardSet(makeReplaceInput({ boards }));
 
     const sets = await listBoardSets();
+    expect(sets[0].boardCount).toBe(3);
+
+    const board = await getBoard("set-1", "b2");
+    assertDefined(board);
+    expect(board.name).toBe("B2");
+  });
+
+  test("stores and retrieves asset blobs, normalizing paths", async () => {
+    await replaceBoardSet(
+      makeReplaceInput({
+        assets: [
+          { path: "images\\photo.png", blob: new Blob(["data"]) },
+          { path: "/leading.png", blob: new Blob(["a"]) },
+          { path: "double//slash.png", blob: new Blob(["b"]) },
+        ],
+      }),
+    );
+
+    const retrieved = await getAssetBlob("set-1", "images/photo.png");
+    expect(retrieved).toBeInstanceOf(Blob);
+    assertDefined(retrieved);
+    expect(await retrieved.text()).toBe("data");
+
+    expect(await getAssetBlob("set-1", "leading.png")).toBeInstanceOf(Blob);
+    expect(await getAssetBlob("set-1", "double/slash.png")).toBeInstanceOf(
+      Blob,
+    );
+  });
+
+  test("replaces an existing set wholesale: dropped boards, assets and metadata are gone", async () => {
+    await replaceBoardSet(
+      makeReplaceInput({
+        boardSet: {
+          setId: "set-1",
+          name: "Set v1",
+          rootBoardId: "a",
+          author: "Alice",
+        },
+        boards: [
+          { boardId: "a", name: "A", obf: makeOBFBoard({ id: "a" }) },
+          { boardId: "b", name: "B", obf: makeOBFBoard({ id: "b" }) },
+        ],
+        assets: [
+          { path: "x.png", blob: new Blob(["x"]) },
+          { path: "y.png", blob: new Blob(["y"]) },
+        ],
+      }),
+    );
+
+    const { replacedExisting } = await replaceBoardSet(
+      makeReplaceInput({
+        boardSet: { setId: "set-1", name: "Set v2", rootBoardId: "a" },
+        boards: [{ boardId: "a", name: "A", obf: makeOBFBoard({ id: "a" }) }],
+        assets: [{ path: "x.png", blob: new Blob(["x"]) }],
+      }),
+    );
+
+    expect(replacedExisting).toBe(true);
+
+    const sets = await listBoardSets();
+    expect(sets).toHaveLength(1);
     expect(sets[0].boardCount).toBe(1);
+    expect(sets[0].author).toBeUndefined();
+    expect(sets[0].rootBoardId).toBe("a");
+
+    expect(await getBoard("set-1", "a")).toBeDefined();
+    expect(await getBoard("set-1", "b")).toBeUndefined();
+    expect(await getAssetBlob("set-1", "x.png")).toBeInstanceOf(Blob);
+    expect(await getAssetBlob("set-1", "y.png")).toBeUndefined();
+  });
+
+  test("aborts the entire transaction when a board fails to clone, leaving the prior set intact", async () => {
+    await replaceBoardSet(
+      makeReplaceInput({
+        boardSet: {
+          setId: "set-1",
+          name: "Set v1",
+          rootBoardId: "a",
+          author: "Alice",
+        },
+        boards: [{ boardId: "a", name: "A", obf: makeOBFBoard({ id: "a" }) }],
+        assets: [{ path: "x.png", blob: new Blob(["x"]) }],
+      }),
+    );
+
+    const uncloneableObf = {
+      ...makeOBFBoard({ id: "b" }),
+      onFail: () => "noop",
+    } as unknown as OBFBoard;
+
+    await expect(
+      replaceBoardSet(
+        makeReplaceInput({
+          boardSet: { setId: "set-1", name: "Set v2", rootBoardId: "b" },
+          boards: [{ boardId: "b", name: "B", obf: uncloneableObf }],
+          assets: [],
+        }),
+      ),
+    ).rejects.toThrow();
+
+    const sets = await listBoardSets();
+    expect(sets).toHaveLength(1);
+    expect(sets[0].author).toBe("Alice");
+    expect(sets[0].rootBoardId).toBe("a");
+    expect(sets[0].boardCount).toBe(1);
+
+    expect(await getBoard("set-1", "a")).toBeDefined();
+    expect(await getAssetBlob("set-1", "x.png")).toBeInstanceOf(Blob);
   });
 
   test("rejects empty setId", async () => {
     await expect(
-      upsertBoardSet(makeBoardSetInput({ setId: "", name: "Bad" })),
+      replaceBoardSet(
+        makeReplaceInput({
+          boardSet: { setId: "", name: "Bad", rootBoardId: "root-1" },
+        }),
+      ),
     ).rejects.toThrow("Invalid setId");
   });
 
   test("rejects setId longer than 255 characters", async () => {
     await expect(
-      upsertBoardSet(
-        makeBoardSetInput({ setId: "x".repeat(256), name: "Bad" }),
+      replaceBoardSet(
+        makeReplaceInput({
+          boardSet: {
+            setId: "x".repeat(256),
+            name: "Bad",
+            rootBoardId: "root-1",
+          },
+        }),
       ),
     ).rejects.toThrow("Invalid setId");
   });
 
   test("rejects empty rootBoardId", async () => {
     await expect(
-      upsertBoardSet(makeBoardSetInput({ rootBoardId: "" })),
+      replaceBoardSet(
+        makeReplaceInput({
+          boardSet: { setId: "set-1", name: "Bad", rootBoardId: "" },
+        }),
+      ),
     ).rejects.toThrow("Invalid rootBoardId");
+  });
+
+  test("rejects empty boardId", async () => {
+    await expect(
+      replaceBoardSet(
+        makeReplaceInput({
+          boards: [{ boardId: "", name: "B", obf: makeOBFBoard() }],
+        }),
+      ),
+    ).rejects.toThrow("Invalid boardId");
+  });
+
+  test("rejects boardId longer than 255 characters", async () => {
+    await expect(
+      replaceBoardSet(
+        makeReplaceInput({
+          boards: [
+            { boardId: "x".repeat(256), name: "B", obf: makeOBFBoard() },
+          ],
+        }),
+      ),
+    ).rejects.toThrow("Invalid boardId");
   });
 });
 
@@ -95,8 +249,16 @@ describe("listBoardSets", () => {
     let now = 1000;
     vi.spyOn(Date, "now").mockImplementation(() => (now += 1000));
 
-    await upsertBoardSet(makeBoardSetInput({ setId: "old", name: "Old" }));
-    await upsertBoardSet(makeBoardSetInput({ setId: "new", name: "New" }));
+    await replaceBoardSet(
+      makeReplaceInput({
+        boardSet: { setId: "old", name: "Old", rootBoardId: "root-1" },
+      }),
+    );
+    await replaceBoardSet(
+      makeReplaceInput({
+        boardSet: { setId: "new", name: "New", rootBoardId: "root-1" },
+      }),
+    );
 
     const sets = await listBoardSets();
     expect(sets).toHaveLength(2);
@@ -105,133 +267,23 @@ describe("listBoardSets", () => {
   });
 });
 
-describe("putBoards and getBoard", () => {
-  test("stores and retrieves a board", async () => {
-    await upsertBoardSet(makeBoardSetInput());
-
-    const obf = makeOBFBoard({ id: "b1", name: "Board One" });
-    await putBoards("set-1", [{ boardId: "b1", name: "Board One", obf }]);
-
-    const board = await getBoard("set-1", "b1");
-    assertDefined(board);
-    expect(board.boardId).toBe("b1");
-    expect(board.name).toBe("Board One");
-    expect(board.obf.id).toBe("b1");
-  });
-
-  test("counts only unique boards", async () => {
-    await upsertBoardSet(makeBoardSetInput());
-
-    const obf = makeOBFBoard({ id: "b1" });
-    await putBoards("set-1", [{ boardId: "b1", name: "B1", obf }]);
-
-    let sets = await listBoardSets();
-    expect(sets[0].boardCount).toBe(1);
-
-    await putBoards("set-1", [{ boardId: "b1", name: "B1 Updated", obf }]);
-
-    sets = await listBoardSets();
-    expect(sets[0].boardCount).toBe(1);
-  });
-
-  test("counts multiple boards correctly", async () => {
-    await upsertBoardSet(makeBoardSetInput());
-
-    const boards = [
-      { boardId: "b1", name: "B1", obf: makeOBFBoard({ id: "b1" }) },
-      { boardId: "b2", name: "B2", obf: makeOBFBoard({ id: "b2" }) },
-      { boardId: "b3", name: "B3", obf: makeOBFBoard({ id: "b3" }) },
-    ];
-
-    await putBoards("set-1", boards);
-
-    const sets = await listBoardSets();
-    expect(sets[0].boardCount).toBe(3);
-  });
-
+describe("getBoard", () => {
   test("returns undefined for nonexistent board", async () => {
-    await upsertBoardSet(makeBoardSetInput());
+    await replaceBoardSet(makeReplaceInput());
 
     const board = await getBoard("set-1", "nonexistent");
     expect(board).toBeUndefined();
-  });
-
-  test("stores boards even when boardset record does not exist", async () => {
-    const obf = makeOBFBoard({ id: "b1" });
-    await putBoards("orphan-set", [{ boardId: "b1", name: "B1", obf }]);
-
-    const board = await getBoard("orphan-set", "b1");
-    assertDefined(board);
-    expect(board.boardId).toBe("b1");
-  });
-
-  test("rejects empty setId", async () => {
-    await expect(
-      putBoards("", [{ boardId: "b1", name: "B", obf: makeOBFBoard() }]),
-    ).rejects.toThrow("Invalid setId");
-  });
-
-  test("rejects empty boardId", async () => {
-    await expect(
-      putBoards("set-1", [{ boardId: "", name: "B", obf: makeOBFBoard() }]),
-    ).rejects.toThrow("Invalid boardId");
-  });
-
-  test("rejects boardId longer than 255 characters", async () => {
-    await expect(
-      putBoards("set-1", [
-        { boardId: "x".repeat(256), name: "B", obf: makeOBFBoard() },
-      ]),
-    ).rejects.toThrow("Invalid boardId");
-  });
-});
-
-describe("putAssets and getAssetBlob", () => {
-  test("stores and retrieves an asset blob", async () => {
-    await upsertBoardSet(makeBoardSetInput());
-
-    const blob = new Blob(["hello"], { type: "text/plain" });
-    await putAssets("set-1", [{ path: "images/logo.png", blob }]);
-
-    const retrieved = await getAssetBlob("set-1", "images/logo.png");
-    expect(retrieved).toBeInstanceOf(Blob);
-    assertDefined(retrieved);
-    expect(await retrieved.text()).toBe("hello");
-  });
-
-  test.each([
-    { rawPath: "images\\photo.png", description: "backslashes" },
-    { rawPath: "/images/photo.png", description: "leading slashes" },
-    { rawPath: "images//photo.png", description: "double slashes" },
-  ])(
-    "normalizes $description so the asset is retrievable by canonical path",
-    async ({ rawPath }) => {
-      await upsertBoardSet(makeBoardSetInput());
-
-      const blob = new Blob(["data"]);
-      await putAssets("set-1", [{ path: rawPath, blob }]);
-
-      const retrieved = await getAssetBlob("set-1", "images/photo.png");
-      expect(retrieved).toBeInstanceOf(Blob);
-      assertDefined(retrieved);
-      expect(await retrieved.text()).toBe("data");
-    },
-  );
-
-  test("returns undefined for nonexistent asset", async () => {
-    await upsertBoardSet(makeBoardSetInput());
-
-    const blob = await getAssetBlob("set-1", "nope.png");
-    expect(blob).toBeUndefined();
   });
 });
 
 describe("updateBoardStrings", () => {
   test("adds localized strings to a board", async () => {
-    await upsertBoardSet(makeBoardSetInput());
-
     const obf = makeOBFBoard({ id: "b1" });
-    await putBoards("set-1", [{ boardId: "b1", name: "B1", obf }]);
+    await replaceBoardSet(
+      makeReplaceInput({
+        boards: [{ boardId: "b1", name: "B1", obf }],
+      }),
+    );
 
     await updateBoardStrings("set-1", "b1", "es", {
       hello: "hola",
@@ -246,13 +298,15 @@ describe("updateBoardStrings", () => {
   });
 
   test("preserves existing locale strings when adding a new locale", async () => {
-    await upsertBoardSet(makeBoardSetInput());
-
     const obf = makeOBFBoard({
       id: "b1",
       strings: { fr: { hello: "bonjour" } },
     });
-    await putBoards("set-1", [{ boardId: "b1", name: "B1", obf }]);
+    await replaceBoardSet(
+      makeReplaceInput({
+        boards: [{ boardId: "b1", name: "B1", obf }],
+      }),
+    );
 
     await updateBoardStrings("set-1", "b1", "es", { hello: "hola" });
 
@@ -265,10 +319,12 @@ describe("updateBoardStrings", () => {
   });
 
   test("replaces all strings when updating an existing locale", async () => {
-    await upsertBoardSet(makeBoardSetInput());
-
     const obf = makeOBFBoard({ id: "b1" });
-    await putBoards("set-1", [{ boardId: "b1", name: "B1", obf }]);
+    await replaceBoardSet(
+      makeReplaceInput({
+        boards: [{ boardId: "b1", name: "B1", obf }],
+      }),
+    );
 
     await updateBoardStrings("set-1", "b1", "es", {
       hello: "hola",
@@ -282,7 +338,7 @@ describe("updateBoardStrings", () => {
   });
 
   test("throws when board does not exist", async () => {
-    await upsertBoardSet(makeBoardSetInput());
+    await replaceBoardSet(makeReplaceInput());
 
     await expect(
       updateBoardStrings("set-1", "nonexistent", "es", {}),
@@ -292,7 +348,7 @@ describe("updateBoardStrings", () => {
 
 describe("deleteBoardSetRecord", () => {
   test("removes the board set record", async () => {
-    await upsertBoardSet(makeBoardSetInput());
+    await replaceBoardSet(makeReplaceInput());
 
     await deleteBoardSetRecord("set-1");
 
@@ -301,12 +357,14 @@ describe("deleteBoardSetRecord", () => {
   });
 
   test("cascade-deletes all boards in the set", async () => {
-    await upsertBoardSet(makeBoardSetInput());
-
-    await putBoards("set-1", [
-      { boardId: "b1", name: "B1", obf: makeOBFBoard({ id: "b1" }) },
-      { boardId: "b2", name: "B2", obf: makeOBFBoard({ id: "b2" }) },
-    ]);
+    await replaceBoardSet(
+      makeReplaceInput({
+        boards: [
+          { boardId: "b1", name: "B1", obf: makeOBFBoard({ id: "b1" }) },
+          { boardId: "b2", name: "B2", obf: makeOBFBoard({ id: "b2" }) },
+        ],
+      }),
+    );
 
     await deleteBoardSetRecord("set-1");
 
@@ -315,12 +373,14 @@ describe("deleteBoardSetRecord", () => {
   });
 
   test("cascade-deletes all assets in the set", async () => {
-    await upsertBoardSet(makeBoardSetInput());
-
-    await putAssets("set-1", [
-      { path: "img1.png", blob: new Blob(["a"]) },
-      { path: "img2.png", blob: new Blob(["b"]) },
-    ]);
+    await replaceBoardSet(
+      makeReplaceInput({
+        assets: [
+          { path: "img1.png", blob: new Blob(["a"]) },
+          { path: "img2.png", blob: new Blob(["b"]) },
+        ],
+      }),
+    );
 
     await deleteBoardSetRecord("set-1");
 
@@ -329,15 +389,22 @@ describe("deleteBoardSetRecord", () => {
   });
 
   test("does not affect other board sets", async () => {
-    await upsertBoardSet(makeBoardSetInput({ name: "Set 1" }));
-    await upsertBoardSet(makeBoardSetInput({ setId: "set-2", name: "Set 2" }));
-
-    await putBoards("set-1", [
-      { boardId: "b1", name: "B1", obf: makeOBFBoard({ id: "b1" }) },
-    ]);
-    await putBoards("set-2", [
-      { boardId: "b2", name: "B2", obf: makeOBFBoard({ id: "b2" }) },
-    ]);
+    await replaceBoardSet(
+      makeReplaceInput({
+        boardSet: { setId: "set-1", name: "Set 1", rootBoardId: "root-1" },
+        boards: [
+          { boardId: "b1", name: "B1", obf: makeOBFBoard({ id: "b1" }) },
+        ],
+      }),
+    );
+    await replaceBoardSet(
+      makeReplaceInput({
+        boardSet: { setId: "set-2", name: "Set 2", rootBoardId: "root-1" },
+        boards: [
+          { boardId: "b2", name: "B2", obf: makeOBFBoard({ id: "b2" }) },
+        ],
+      }),
+    );
 
     await deleteBoardSetRecord("set-1");
 
@@ -368,7 +435,11 @@ describe("getBoardsDB", () => {
     const second = await getBoardsDB();
     expect(second).not.toBe(first);
 
-    await upsertBoardSet(makeBoardSetInput({ name: "Persisted" }));
+    await replaceBoardSet(
+      makeReplaceInput({
+        boardSet: { setId: "set-1", name: "Persisted", rootBoardId: "root-1" },
+      }),
+    );
     const sets = await listBoardSets();
     expect(sets.map((set) => set.name)).toContain("Persisted");
   });

--- a/src/features/board/storage/boards-db.ts
+++ b/src/features/board/storage/boards-db.ts
@@ -148,33 +148,6 @@ function openConnection(): Promise<BoardsDB> {
   });
 }
 
-export async function upsertBoardSet(
-  input: UpsertBoardSetInput,
-): Promise<void> {
-  validateId(input.setId, "setId");
-  validateId(input.rootBoardId, "rootBoardId");
-  const db = await getBoardsDB();
-  const tx = db.transaction("boardSets", "readwrite");
-  const existing = await tx.store.get(input.setId);
-
-  const record: BoardSetRecord = {
-    setId: input.setId,
-    name: input.name,
-    rootBoardId: input.rootBoardId,
-    updatedAt: Date.now(),
-    boardCount: existing?.boardCount ?? 0,
-    author: input.author ?? existing?.author,
-    description: input.description ?? existing?.description,
-    license: input.license ?? existing?.license,
-    locale: input.locale ?? existing?.locale,
-    gridRows: input.gridRows ?? existing?.gridRows,
-    gridColumns: input.gridColumns ?? existing?.gridColumns,
-  };
-
-  await tx.store.put(record);
-  await tx.done;
-}
-
 export async function getBoardSet(
   setId: string,
 ): Promise<BoardSetRecord | undefined> {
@@ -191,54 +164,107 @@ export async function listBoardSets(): Promise<BoardSetRecord[]> {
   return boardSets.reverse();
 }
 
+// The [] upper bound exploits IDB key ordering — arrays sort after strings,
+// so [setId, []] is the smallest key greater than every [setId, "..."].
+function boardSetRange(setId: string): IDBKeyRange {
+  return IDBKeyRange.bound([setId], [setId, []]);
+}
+
 export async function deleteBoardSetRecord(setId: string): Promise<void> {
   validateId(setId, "setId");
   const db = await getBoardsDB();
   const tx = db.transaction(["boards", "assets", "boardSets"], "readwrite");
+  const setRange = boardSetRange(setId);
 
-  // The [] upper bound exploits IDB key ordering — arrays sort after strings,
-  // so [setId, []] is the smallest key greater than every [setId, "..."].
-  const setRange = IDBKeyRange.bound([setId], [setId, []]);
-  void tx.objectStore("boards").delete(setRange);
-  void tx.objectStore("assets").delete(setRange);
-  void tx.objectStore("boardSets").delete(setId);
-
-  await tx.done;
+  await Promise.all([
+    tx.objectStore("boards").delete(setRange),
+    tx.objectStore("assets").delete(setRange),
+    tx.objectStore("boardSets").delete(setId),
+    tx.done,
+  ]);
 }
 
-export async function putBoards(
-  setId: string,
-  boards: UpsertBoardInput[],
-): Promise<void> {
-  validateId(setId, "setId");
+export interface ReplaceBoardSetInput {
+  boardSet: UpsertBoardSetInput;
+  boards: UpsertBoardInput[];
+  assets: UpsertAssetInput[];
+}
+
+export async function replaceBoardSet(
+  input: ReplaceBoardSetInput,
+): Promise<{ replacedExisting: boolean }> {
+  const { boardSet, boards, assets } = input;
+  validateId(boardSet.setId, "setId");
+  validateId(boardSet.rootBoardId, "rootBoardId");
   for (const board of boards) {
     validateId(board.boardId, "boardId");
   }
+
+  const { setId } = boardSet;
   const db = await getBoardsDB();
-  const tx = db.transaction(["boards", "boardSets"], "readwrite");
+  const tx = db.transaction(["boardSets", "boards", "assets"], "readwrite");
+  const boardSetStore = tx.objectStore("boardSets");
   const boardStore = tx.objectStore("boards");
+  const assetStore = tx.objectStore("assets");
 
-  await Promise.all(
-    boards.map((board) =>
-      boardStore.put({
-        setId,
-        boardId: board.boardId,
-        name: board.name,
-        obf: board.obf,
-      }),
-    ),
-  );
+  const existing = await boardSetStore.get(setId);
+  const setRange = boardSetRange(setId);
 
-  const boardSet = await tx.objectStore("boardSets").get(setId);
+  const record: BoardSetRecord = {
+    setId,
+    name: boardSet.name,
+    rootBoardId: boardSet.rootBoardId,
+    updatedAt: Date.now(),
+    boardCount: boards.length,
+    author: boardSet.author,
+    description: boardSet.description,
+    license: boardSet.license,
+    locale: boardSet.locale,
+    gridRows: boardSet.gridRows,
+    gridColumns: boardSet.gridColumns,
+  };
 
-  if (boardSet) {
-    const count = await boardStore.index("bySetId").count(setId);
-    await tx
-      .objectStore("boardSets")
-      .put({ ...boardSet, boardCount: count, updatedAt: Date.now() });
+  // idb creates tx.done eagerly when the transaction is opened, and requests
+  // already issued before a synchronous put() failure (e.g. a non-cloneable
+  // value) keep running — both must be drained after abort, or they reject
+  // as unhandled rejections once the transaction tears down.
+  const requests: Promise<unknown>[] = [tx.done];
+
+  try {
+    requests.push(boardStore.delete(setRange), assetStore.delete(setRange));
+    for (const board of boards) {
+      requests.push(
+        boardStore.put({
+          setId,
+          boardId: board.boardId,
+          name: board.name,
+          obf: board.obf,
+        }),
+      );
+    }
+    for (const asset of assets) {
+      requests.push(
+        assetStore.put({
+          setId,
+          path: normalizePath(asset.path),
+          blob: asset.blob,
+        }),
+      );
+    }
+    requests.push(boardSetStore.put(record));
+
+    await Promise.all(requests);
+  } catch (error) {
+    try {
+      tx.abort();
+    } catch {
+      // Already finished — the transaction aborted itself.
+    }
+    await Promise.allSettled(requests);
+    throw error;
   }
 
-  await tx.done;
+  return { replacedExisting: existing !== undefined };
 }
 
 export async function getBoard(
@@ -274,36 +300,6 @@ export async function updateBoardStrings(
   };
 
   await tx.store.put({ ...record, obf: updatedObf });
-  await tx.done;
-}
-
-export async function putAssets(
-  setId: string,
-  assets: UpsertAssetInput[],
-): Promise<void> {
-  validateId(setId, "setId");
-  const db = await getBoardsDB();
-  const tx = db.transaction(["assets", "boardSets"], "readwrite");
-  const assetStore = tx.objectStore("assets");
-
-  await Promise.all(
-    assets.map((asset) =>
-      assetStore.put({
-        setId,
-        path: normalizePath(asset.path),
-        blob: asset.blob,
-      }),
-    ),
-  );
-
-  const boardSet = await tx.objectStore("boardSets").get(setId);
-
-  if (boardSet) {
-    await tx
-      .objectStore("boardSets")
-      .put({ ...boardSet, updatedAt: Date.now() });
-  }
-
   await tx.done;
 }
 

--- a/src/features/board/storage/test-utils.ts
+++ b/src/features/board/storage/test-utils.ts
@@ -1,5 +1,5 @@
 import { invalidateBoardSets } from "../board-sets/board-sets-store";
-import { getBoardsDB, upsertBoardSet, type BoardSetRecord } from "./boards-db";
+import { getBoardsDB, replaceBoardSet, type BoardSetRecord } from "./boards-db";
 
 const STORE_NAMES = ["boardSets", "boards", "assets"] as const;
 
@@ -26,7 +26,11 @@ export async function resetBoardsDB(): Promise<void> {
 export async function seedBoardSets(records: SeedBoardSet[]): Promise<void> {
   await clearBoardsDB();
   for (const record of records) {
-    await upsertBoardSet({ name: record.setId, ...record });
+    await replaceBoardSet({
+      boardSet: { name: record.setId, ...record },
+      boards: [],
+      assets: [],
+    });
   }
 
   await invalidateBoardSets();

--- a/src/features/board/translation/resolve-translated-board.test.ts
+++ b/src/features/board/translation/resolve-translated-board.test.ts
@@ -3,8 +3,8 @@ import {
   stubTranslator,
 } from "@shared/testing/built-in-ai";
 import { beforeEach, describe, expect, test } from "vitest";
-import { getBoard, putBoards } from "../storage/boards-db";
-import { resetBoardsDB, seedBoardSets } from "../storage/test-utils";
+import { getBoard, replaceBoardSet } from "../storage/boards-db";
+import { resetBoardsDB } from "../storage/test-utils";
 import type { Board } from "../types";
 import { resolveTranslatedBoard } from "./resolve-translated-board";
 
@@ -76,19 +76,22 @@ describe("resolveTranslatedBoard", () => {
   });
 
   test("persists a fresh translation so the next load hits the cache", async () => {
-    await seedBoardSets([{ setId: "set-1", rootBoardId: "board-1" }]);
-    await putBoards("set-1", [
-      {
-        boardId: "board-1",
-        name: "Food",
-        obf: {
-          format: "open-board-0.1",
-          id: "board-1",
-          buttons: [],
-          grid: { rows: 1, columns: 1, order: [[null]] },
+    await replaceBoardSet({
+      boardSet: { setId: "set-1", name: "set-1", rootBoardId: "board-1" },
+      boards: [
+        {
+          boardId: "board-1",
+          name: "Food",
+          obf: {
+            format: "open-board-0.1",
+            id: "board-1",
+            buttons: [],
+            grid: { rows: 1, columns: 1, order: [[null]] },
+          },
         },
-      },
-    ]);
+      ],
+      assets: [],
+    });
     stubTranslator((input) => `[es] ${input}`);
 
     await resolveTranslatedBoard("set-1", makeBoard(), "es");


### PR DESCRIPTION
## Summary
- `replaceBoardSet` (`boards-db.ts`) replaces a board set's catalog record, boards, and assets in one `readwrite` transaction — delete-then-insert, no partial states, no stale-metadata resurrection on re-import. `upsertBoardSet`/`putBoards`/`putAssets` are removed; they had no remaining callers once import moved off them.
- `board-import.ts` builds a single `replaceBoardSet` input per file instead of three sequential writes, and reports `replacedExisting` per import result. The multi-file loop now runs `notifyBoardSetsChanged()` in a `finally`, so a failure on file 2 doesn't hide file 1 from other tabs.
- `use-import-board-files.ts` shows a new "replaced" snackbar message instead of the generic "imported" one when any file overwrote an existing set.
- Added the `libraryReplacedBoards` message key to all 35 locale files (best-effort translations mirroring each locale's existing `libraryImportedBoards` phrasing — worth a native-speaker pass on kn/te/ta/bn/th).
- Migrated all storage-layer test seeding off the removed functions onto `replaceBoardSet`.

A confirm-before-replace dialog is intentionally out of scope — flagged as a follow-up, since the storage contract is unchanged either way.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 448 passed (6 pre-existing failures in `grid.test.tsx`, confirmed present on `main` too, unrelated to this change)
- [x] `npm run build` — succeeds (includes `tsc -b`)
- [x] New test: re-importing the same filename replaces the set wholesale (dropped boards/assets/metadata gone, `boardCount` recomputed, `replacedExisting: true`)
- [x] New test: a board that fails to structured-clone aborts the whole transaction, leaving the prior set fully intact (real IndexedDB, no mocks)
- [x] New test: a failure partway through a multi-file import still leaves the earlier file's set visible
- [x] New test: snackbar shows the "replaced" message when overwriting vs. the "imported" message on a fresh import