### PR TITLE
fix: restore static <title> as fallback for routes without PageTitle

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
 
+    <title>AAC Board AI</title>
     <meta
       name="description"
       content="AAC Board AI helps people who can't speak communicate naturally with Built-in AI — proofreading, rephrasing, and translating safely on their device."


### PR DESCRIPTION
## Summary
- Restores `<title>AAC Board AI</title>` in index.html, which was dropped in #459 in favor of the dynamic `PageTitle` component.
- `PageTitle` (React 19 title hoisting) is only rendered on `board-page.tsx`, so every other route was left with no document title at all.
- This adds back a static fallback; `PageTitle` still overrides it where used.

## Test plan
- [x] Verified `<title>` renders in the built HTML head
- [x] Confirmed `PageTitle` on the board page still overrides via React 19 title hoisting