### PR TITLE
chore: bump vite to 8.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "prettier": "3.9.4",
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.62.1",
-        "vite": "^8.1.2",
+        "vite": "^8.1.3",
         "vite-plugin-pwa": "^1.3.0",
         "vitest": "^4.1.9",
         "vitest-browser-react": "^2.2.0"
@@ -9290,9 +9290,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.2.tgz",
-      "integrity": "sha512-6YYPbRXTxx6bRXmOn7XdnQAy5DQNHhDgtjhDHI13oe4pY93kkcdGJWxpGwOm++/Wh0QpQhDrpIoVMrmrsI5AGQ==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "prettier": "3.9.4",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.62.1",
-    "vite": "^8.1.2",
+    "vite": "^8.1.3",
     "vite-plugin-pwa": "^1.3.0",
     "vitest": "^4.1.9",
     "vitest-browser-react": "^2.2.0"


### PR DESCRIPTION
## Summary
- Bump vite from 8.1.2 to 8.1.3 (patch release)

## Test plan
- [x] package-lock.json regenerated via lockfile update

🤖 Generated with [Claude Code](https://claude.com/claude-code)