### PR TITLE
fix(suggestions): show indeterminate download state instead of frozen 0%

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "جارٍ التنزيل…",
   "suggestionsEnable": "تفعيل الاقتراحات",
   "suggestionsDownloading": "جارٍ تنزيل نموذج الذكاء الاصطناعي… {progress}%",
+  "suggestionsDownloadingIndeterminate": "جارٍ تنزيل نموذج الذكاء الاصطناعي…",
   "suggestionsUnavailable": "الاقتراحات غير متاحة",
   "aiFeatureProofreading": "تدقيق لغوي",
   "aiFeatureRewriting": "إعادة صياغة",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "Изтегляне…",
   "suggestionsEnable": "Включване на предложенията",
   "suggestionsDownloading": "Изтегляне на модела на ИИ… {progress}%",
+  "suggestionsDownloadingIndeterminate": "Изтегляне на модела на ИИ…",
   "suggestionsUnavailable": "Предложенията не са налични",
   "aiFeatureProofreading": "Коректура",
   "aiFeatureRewriting": "Преписване",

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "ডাউনলোড হচ্ছে…",
   "suggestionsEnable": "পরামর্শ চালু করুন",
   "suggestionsDownloading": "AI মডেল ডাউনলোড হচ্ছে… {progress}%",
+  "suggestionsDownloadingIndeterminate": "AI মডেল ডাউনলোড হচ্ছে…",
   "suggestionsUnavailable": "পরামর্শ উপলব্ধ নয়",
   "aiFeatureProofreading": "প্রুফরিডিং",
   "aiFeatureRewriting": "পুনর্লিখন",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "Stahování…",
   "suggestionsEnable": "Zapnout návrhy",
   "suggestionsDownloading": "Stahování modelu AI… {progress} %",
+  "suggestionsDownloadingIndeterminate": "Stahování modelu AI…",
   "suggestionsUnavailable": "Návrhy nejsou k dispozici",
   "aiFeatureProofreading": "Korektura",
   "aiFeatureRewriting": "Přepis",

--- a/messages/da.json
+++ b/messages/da.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "Downloader…",
   "suggestionsEnable": "Slå forslag til",
   "suggestionsDownloading": "Downloader AI-model… {progress}%",
+  "suggestionsDownloadingIndeterminate": "Downloader AI-model…",
   "suggestionsUnavailable": "Forslag er ikke tilgængelige",
   "aiFeatureProofreading": "Korrekturlæsning",
   "aiFeatureRewriting": "Omskrivning",

--- a/messages/de.json
+++ b/messages/de.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "Wird heruntergeladen…",
   "suggestionsEnable": "Vorschläge aktivieren",
   "suggestionsDownloading": "KI-Modell wird heruntergeladen… {progress}%",
+  "suggestionsDownloadingIndeterminate": "KI-Modell wird heruntergeladen…",
   "suggestionsUnavailable": "Vorschläge nicht verfügbar",
   "aiFeatureProofreading": "Korrektur",
   "aiFeatureRewriting": "Umformulierung",

--- a/messages/el.json
+++ b/messages/el.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "Λήψη…",
   "suggestionsEnable": "Ενεργοποίηση προτάσεων",
   "suggestionsDownloading": "Λήψη μοντέλου AI… {progress}%",
+  "suggestionsDownloadingIndeterminate": "Λήψη μοντέλου AI…",
   "suggestionsUnavailable": "Οι προτάσεις δεν είναι διαθέσιμες",
   "aiFeatureProofreading": "Διόρθωση",
   "aiFeatureRewriting": "Αναδιατύπωση",

--- a/messages/en.json
+++ b/messages/en.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "Downloading...",
   "suggestionsEnable": "Enable suggestions",
   "suggestionsDownloading": "Downloading AI model... {progress}%",
+  "suggestionsDownloadingIndeterminate": "Downloading AI model...",
   "suggestionsUnavailable": "Suggestions unavailable",
   "aiFeatureProofreading": "Proofreading",
   "aiFeatureRewriting": "Rewriting",

--- a/messages/es.json
+++ b/messages/es.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "Descargando…",
   "suggestionsEnable": "Activar sugerencias",
   "suggestionsDownloading": "Descargando modelo de IA… {progress}%",
+  "suggestionsDownloadingIndeterminate": "Descargando modelo de IA…",
   "suggestionsUnavailable": "Sugerencias no disponibles",
   "aiFeatureProofreading": "Corrección",
   "aiFeatureRewriting": "Reescritura",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "Ladataan…",
   "suggestionsEnable": "Ota ehdotukset käyttöön",
   "suggestionsDownloading": "Ladataan tekoälymallia… {progress} %",
+  "suggestionsDownloadingIndeterminate": "Ladataan tekoälymallia…",
   "suggestionsUnavailable": "Ehdotukset eivät ole saatavilla",
   "aiFeatureProofreading": "Oikoluku",
   "aiFeatureRewriting": "Uudelleenkirjoitus",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "Téléchargement…",
   "suggestionsEnable": "Activer les suggestions",
   "suggestionsDownloading": "Téléchargement du modèle d'IA… {progress} %",
+  "suggestionsDownloadingIndeterminate": "Téléchargement du modèle d'IA…",
   "suggestionsUnavailable": "Suggestions indisponibles",
   "aiFeatureProofreading": "Correction",
   "aiFeatureRewriting": "Réécriture",

--- a/messages/he.json
+++ b/messages/he.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "הורדה…",
   "suggestionsEnable": "הפעלת הצעות",
   "suggestionsDownloading": "הורדת מודל ה-AI… {progress}%",
+  "suggestionsDownloadingIndeterminate": "הורדת מודל ה-AI…",
   "suggestionsUnavailable": "ההצעות אינן זמינות",
   "aiFeatureProofreading": "הגהה",
   "aiFeatureRewriting": "שכתוב",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "डाउनलोड हो रहा है…",
   "suggestionsEnable": "सुझाव चालू करें",
   "suggestionsDownloading": "AI मॉडल डाउनलोड हो रहा है… {progress}%",
+  "suggestionsDownloadingIndeterminate": "AI मॉडल डाउनलोड हो रहा है…",
   "suggestionsUnavailable": "सुझाव उपलब्ध नहीं हैं",
   "aiFeatureProofreading": "प्रूफ़रीडिंग",
   "aiFeatureRewriting": "पुनर्लेखन",

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "Preuzimanje…",
   "suggestionsEnable": "Uključi prijedloge",
   "suggestionsDownloading": "Preuzimanje AI modela… {progress} %",
+  "suggestionsDownloadingIndeterminate": "Preuzimanje AI modela…",
   "suggestionsUnavailable": "Prijedlozi nisu dostupni",
   "aiFeatureProofreading": "Lektura",
   "aiFeatureRewriting": "Preoblikovanje",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "Letöltés…",
   "suggestionsEnable": "Javaslatok bekapcsolása",
   "suggestionsDownloading": "MI-modell letöltése… {progress}%",
+  "suggestionsDownloadingIndeterminate": "MI-modell letöltése…",
   "suggestionsUnavailable": "A javaslatok nem érhetők el",
   "aiFeatureProofreading": "Korrektúra",
   "aiFeatureRewriting": "Átfogalmazás",

--- a/messages/id.json
+++ b/messages/id.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "Mengunduh…",
   "suggestionsEnable": "Aktifkan saran",
   "suggestionsDownloading": "Mengunduh model AI… {progress}%",
+  "suggestionsDownloadingIndeterminate": "Mengunduh model AI…",
   "suggestionsUnavailable": "Saran tidak tersedia",
   "aiFeatureProofreading": "Koreksi",
   "aiFeatureRewriting": "Penulisan ulang",

--- a/messages/it.json
+++ b/messages/it.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "Download…",
   "suggestionsEnable": "Attiva i suggerimenti",
   "suggestionsDownloading": "Download del modello IA… {progress}%",
+  "suggestionsDownloadingIndeterminate": "Download del modello IA…",
   "suggestionsUnavailable": "Suggerimenti non disponibili",
   "aiFeatureProofreading": "Correzione",
   "aiFeatureRewriting": "Riscrittura",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "ダウンロード中…",
   "suggestionsEnable": "提案を有効にする",
   "suggestionsDownloading": "AI モデルをダウンロード中… {progress}%",
+  "suggestionsDownloadingIndeterminate": "AI モデルをダウンロード中…",
   "suggestionsUnavailable": "提案は利用できません",
   "aiFeatureProofreading": "校正",
   "aiFeatureRewriting": "リライト",

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "ಡೌನ್‌ಲೋಡ್ ಆಗುತ್ತಿದೆ…",
   "suggestionsEnable": "ಸಲಹೆಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ",
   "suggestionsDownloading": "AI ಮಾದರಿ ಡೌನ್‌ಲೋಡ್ ಆಗುತ್ತಿದೆ… {progress}%",
+  "suggestionsDownloadingIndeterminate": "AI ಮಾದರಿ ಡೌನ್‌ಲೋಡ್ ಆಗುತ್ತಿದೆ…",
   "suggestionsUnavailable": "ಸಲಹೆಗಳು ಲಭ್ಯವಿಲ್ಲ",
   "aiFeatureProofreading": "ಪ್ರೂಫ್‌ರೀಡಿಂಗ್",
   "aiFeatureRewriting": "ಮರುಬರವಣಿಗೆ",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "다운로드 중…",
   "suggestionsEnable": "제안 켜기",
   "suggestionsDownloading": "AI 모델 다운로드 중… {progress}%",
+  "suggestionsDownloadingIndeterminate": "AI 모델 다운로드 중…",
   "suggestionsUnavailable": "제안을 사용할 수 없음",
   "aiFeatureProofreading": "교정",
   "aiFeatureRewriting": "다시 쓰기",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "Downloaden…",
   "suggestionsEnable": "Suggesties inschakelen",
   "suggestionsDownloading": "AI-model downloaden… {progress}%",
+  "suggestionsDownloadingIndeterminate": "AI-model downloaden…",
   "suggestionsUnavailable": "Suggesties niet beschikbaar",
   "aiFeatureProofreading": "Correctie",
   "aiFeatureRewriting": "Herschrijven",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "Pobieranie…",
   "suggestionsEnable": "Włącz sugestie",
   "suggestionsDownloading": "Pobieranie modelu AI… {progress}%",
+  "suggestionsDownloadingIndeterminate": "Pobieranie modelu AI…",
   "suggestionsUnavailable": "Sugestie są niedostępne",
   "aiFeatureProofreading": "Korekta",
   "aiFeatureRewriting": "Przeredagowanie",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "Baixando…",
   "suggestionsEnable": "Ativar sugestões",
   "suggestionsDownloading": "Baixando modelo de IA… {progress}%",
+  "suggestionsDownloadingIndeterminate": "Baixando modelo de IA…",
   "suggestionsUnavailable": "Sugestões indisponíveis",
   "aiFeatureProofreading": "Revisão",
   "aiFeatureRewriting": "Reescrita",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "Se descarcă…",
   "suggestionsEnable": "Activează sugestiile",
   "suggestionsDownloading": "Se descarcă modelul AI… {progress}%",
+  "suggestionsDownloadingIndeterminate": "Se descarcă modelul AI…",
   "suggestionsUnavailable": "Sugestiile nu sunt disponibile",
   "aiFeatureProofreading": "Corectură",
   "aiFeatureRewriting": "Rescriere",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "Загрузка…",
   "suggestionsEnable": "Включить предложения",
   "suggestionsDownloading": "Загрузка модели ИИ… {progress}%",
+  "suggestionsDownloadingIndeterminate": "Загрузка модели ИИ…",
   "suggestionsUnavailable": "Предложения недоступны",
   "aiFeatureProofreading": "Корректура",
   "aiFeatureRewriting": "Перефразирование",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "Sťahovanie…",
   "suggestionsEnable": "Zapnúť návrhy",
   "suggestionsDownloading": "Sťahovanie modelu AI… {progress} %",
+  "suggestionsDownloadingIndeterminate": "Sťahovanie modelu AI…",
   "suggestionsUnavailable": "Návrhy nie sú k dispozícii",
   "aiFeatureProofreading": "Korektúra",
   "aiFeatureRewriting": "Prepis",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "Prenašanje…",
   "suggestionsEnable": "Vklopi predloge",
   "suggestionsDownloading": "Prenašanje modela UI… {progress} %",
+  "suggestionsDownloadingIndeterminate": "Prenašanje modela UI…",
   "suggestionsUnavailable": "Predlogi niso na voljo",
   "aiFeatureProofreading": "Lektoriranje",
   "aiFeatureRewriting": "Preoblikovanje",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "Laddar ner…",
   "suggestionsEnable": "Aktivera förslag",
   "suggestionsDownloading": "Laddar ner AI-modell… {progress}%",
+  "suggestionsDownloadingIndeterminate": "Laddar ner AI-modell…",
   "suggestionsUnavailable": "Förslag är inte tillgängliga",
   "aiFeatureProofreading": "Korrekturläsning",
   "aiFeatureRewriting": "Omskrivning",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "பதிவிறக்கப்படுகிறது…",
   "suggestionsEnable": "பரிந்துரைகளை இயக்கு",
   "suggestionsDownloading": "AI மாடல் பதிவிறக்கப்படுகிறது… {progress}%",
+  "suggestionsDownloadingIndeterminate": "AI மாடல் பதிவிறக்கப்படுகிறது…",
   "suggestionsUnavailable": "பரிந்துரைகள் கிடைக்கவில்லை",
   "aiFeatureProofreading": "மெய்ப்புத் திருத்தம்",
   "aiFeatureRewriting": "மறுஎழுத்து",

--- a/messages/te.json
+++ b/messages/te.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "డౌన్‌లోడ్ అవుతోంది…",
   "suggestionsEnable": "సూచనలను ప్రారంభించండి",
   "suggestionsDownloading": "AI మోడల్ డౌన్‌లోడ్ అవుతోంది… {progress}%",
+  "suggestionsDownloadingIndeterminate": "AI మోడల్ డౌన్‌లోడ్ అవుతోంది…",
   "suggestionsUnavailable": "సూచనలు అందుబాటులో లేవు",
   "aiFeatureProofreading": "ప్రూఫ్‌రీడింగ్",
   "aiFeatureRewriting": "తిరిగి రాయడం",

--- a/messages/th.json
+++ b/messages/th.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "กำลังดาวน์โหลด…",
   "suggestionsEnable": "เปิดใช้คำแนะนำ",
   "suggestionsDownloading": "กำลังดาวน์โหลดโมเดล AI… {progress}%",
+  "suggestionsDownloadingIndeterminate": "กำลังดาวน์โหลดโมเดล AI…",
   "suggestionsUnavailable": "คำแนะนำไม่พร้อมใช้งาน",
   "aiFeatureProofreading": "การตรวจทาน",
   "aiFeatureRewriting": "การเขียนใหม่",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "İndiriliyor…",
   "suggestionsEnable": "Önerileri aç",
   "suggestionsDownloading": "Yapay zeka modeli indiriliyor… %{progress}",
+  "suggestionsDownloadingIndeterminate": "Yapay zeka modeli indiriliyor…",
   "suggestionsUnavailable": "Öneriler kullanılamıyor",
   "aiFeatureProofreading": "Düzeltme",
   "aiFeatureRewriting": "Yeniden yazma",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "Завантаження…",
   "suggestionsEnable": "Увімкнути пропозиції",
   "suggestionsDownloading": "Завантаження моделі ШІ… {progress}%",
+  "suggestionsDownloadingIndeterminate": "Завантаження моделі ШІ…",
   "suggestionsUnavailable": "Пропозиції недоступні",
   "aiFeatureProofreading": "Коректура",
   "aiFeatureRewriting": "Переписування",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "Đang tải xuống…",
   "suggestionsEnable": "Bật gợi ý",
   "suggestionsDownloading": "Đang tải mô hình AI xuống… {progress}%",
+  "suggestionsDownloadingIndeterminate": "Đang tải mô hình AI xuống…",
   "suggestionsUnavailable": "Gợi ý không khả dụng",
   "aiFeatureProofreading": "Hiệu đính",
   "aiFeatureRewriting": "Viết lại",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -93,6 +93,7 @@
   "aiStatusDownloading": "正在下载…",
   "suggestionsEnable": "启用建议",
   "suggestionsDownloading": "正在下载 AI 模型… {progress}%",
+  "suggestionsDownloadingIndeterminate": "正在下载 AI 模型…",
   "suggestionsUnavailable": "建议不可用",
   "aiFeatureProofreading": "校对",
   "aiFeatureRewriting": "改写",

--- a/src/features/board/suggestions/derive-suggestion-status.test.ts
+++ b/src/features/board/suggestions/derive-suggestion-status.test.ts
@@ -55,8 +55,18 @@ describe("deriveSuggestionStatus", () => {
 
     expect(deriveSuggestionStatus(input)).toEqual({
       kind: "downloading",
-      progress: 0.43,
+      percent: 43,
     });
+  });
+
+  test("treats a download without measurable progress as indeterminate", () => {
+    expect(deriveSuggestionStatus(makeInput({ downloadProgress: 0 }))).toEqual({
+      kind: "downloading",
+      percent: null,
+    });
+    expect(
+      deriveSuggestionStatus(makeInput({ downloadProgress: 0.004 })),
+    ).toEqual({ kind: "downloading", percent: null });
   });
 
   test("shows pending while any request is in flight, even with phrases showing", () => {

--- a/src/features/board/suggestions/derive-suggestion-status.ts
+++ b/src/features/board/suggestions/derive-suggestion-status.ts
@@ -2,7 +2,7 @@ import type { Status } from "@shayc/react-built-in-ai";
 
 export type SuggestionStatusView =
   | { kind: "needs-activation" }
-  | { kind: "downloading"; progress: number }
+  | { kind: "downloading"; percent: number | null }
   | { kind: "pending" }
   | { kind: "unavailable" }
   | null;
@@ -37,7 +37,8 @@ export function deriveSuggestionStatus({
   }
 
   if (downloadProgress !== null) {
-    return { kind: "downloading", progress: downloadProgress };
+    const percent = Math.round(downloadProgress * 100);
+    return { kind: "downloading", percent: percent === 0 ? null : percent };
   }
 
   if (isPending) {

--- a/src/features/board/suggestions/suggestion-bar.test.tsx
+++ b/src/features/board/suggestions/suggestion-bar.test.tsx
@@ -94,12 +94,24 @@ describe("SuggestionBar", () => {
   test("shows download progress while the model downloads", async () => {
     const screen = await render(
       <SuggestionBar
-        {...makeProps({ status: { kind: "downloading", progress: 0.43 } })}
+        {...makeProps({ status: { kind: "downloading", percent: 43 } })}
       />,
     );
 
     await expect
       .element(screen.getByText("Downloading AI model... 43%"))
+      .toBeVisible();
+  });
+
+  test("shows a percentless download message while progress is unknown", async () => {
+    const screen = await render(
+      <SuggestionBar
+        {...makeProps({ status: { kind: "downloading", percent: null } })}
+      />,
+    );
+
+    await expect
+      .element(screen.getByText("Downloading AI model...", { exact: true }))
       .toBeVisible();
   });
 

--- a/src/features/board/suggestions/suggestion-status.tsx
+++ b/src/features/board/suggestions/suggestion-status.tsx
@@ -37,9 +37,9 @@ function statusMessage(status: SuggestionStatusView, onEnable: () => void) {
     case "downloading":
       return (
         <Typography variant="body2" sx={{ color: "text.secondary" }}>
-          {m.suggestionsDownloading({
-            progress: Math.round(status.progress * 100),
-          })}
+          {status.percent === null
+            ? m.suggestionsDownloadingIndeterminate()
+            : m.suggestionsDownloading({ progress: status.percent })}
         </Typography>
       );
     case "unavailable":


### PR DESCRIPTION
## Summary
- On some Chrome builds, `create()` calls that join an in-flight built-in AI model download receive no `downloadprogress` events until a single `loaded=1` fires at completion — the suggestion bar's percentage was frozen at 0% for the whole download.
- `deriveSuggestionStatus` now rounds progress once and reports `percent: null` when the rounded value is 0, so a genuinely-unknown download reads as "Downloading AI model..." instead of a misleading "0%".
- Added the `suggestionsDownloadingIndeterminate` message key to all 34 locale files, derived from each locale's existing `suggestionsDownloading` string with the progress token stripped.

## Test plan
- [x] `npm run lint` on touched files
- [x] `npx tsc --noEmit`
- [x] `npx vitest run` on `derive-suggestion-status.test.ts` and `suggestion-bar.test.tsx` (20/20 passing, including new 0%/near-0% indeterminate cases)
- [ ] Manual check in a real browser once a build reproduces the silent-progress case again

🤖 Generated with [Claude Code](https://claude.com/claude-code)