### PR TITLE
chore: bump react-built-in-ai to 0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@mui/material": "^9.1.2",
         "@mui/stylis-plugin-rtl": "^9.1.1",
         "@shayc/open-board-format": "^1.0.2",
-        "@shayc/react-built-in-ai": "^0.9.0",
+        "@shayc/react-built-in-ai": "^0.10.0",
         "idb": "^8.0.3",
         "mrmime": "^2.0.1",
         "react": "^19.2.7",
@@ -3471,9 +3471,9 @@
       }
     },
     "node_modules/@shayc/react-built-in-ai": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@shayc/react-built-in-ai/-/react-built-in-ai-0.9.0.tgz",
-      "integrity": "sha512-wHUce0bLxUP+jbwI+5TRhDAq8OPBQezqW//aAMm+0SkqzFMgA1Mdqu3PqfCVKQwtAvoBF9BQn1Cg2XEBhAT0uw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@shayc/react-built-in-ai/-/react-built-in-ai-0.10.0.tgz",
+      "integrity": "sha512-VqzkJFBTfcmHwNkVnioZbVLwb8viEsdrxbMHT7SmCtEnLyGOCTH4TJHQmi0aT4BPKf5M8IFaGzMNU6LvPDKA2g==",
       "license": "MIT",
       "dependencies": {
         "@types/dom-chromium-ai": "^0.0.17"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@mui/material": "^9.1.2",
     "@mui/stylis-plugin-rtl": "^9.1.1",
     "@shayc/open-board-format": "^1.0.2",
-    "@shayc/react-built-in-ai": "^0.9.0",
+    "@shayc/react-built-in-ai": "^0.10.0",
     "idb": "^8.0.3",
     "mrmime": "^2.0.1",
     "react": "^19.2.7",


### PR DESCRIPTION
## Summary
- Bumps `@shayc/react-built-in-ai` from `^0.9.0` to `^0.10.0`
- 0.10.0 fixes passively-observing hooks getting stuck on `"downloadable"` when a download is already in flight elsewhere — they now correctly report `"downloading"` and join it
- `progress` now starts at `null` (not a fabricated `0`) until the browser reports a real fraction; app code already treats `null`/`0` progress the same way, so no adaptation needed

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (463 tests)