### PR TITLE
chore: clarify naming in message/import/snackbar internals

### DIFF
--- a/src/features/board/activation/button-activation.ts
+++ b/src/features/board/activation/button-activation.ts
@@ -2,10 +2,10 @@ import { playAudio } from "@shared/audio/play-audio";
 import { speak } from "@shared/speech/speak";
 import { assertNever } from "@shared/utils/assert-never";
 import {
-  addPartToParts,
-  addSpaceToParts,
+  appendPart,
+  appendSpace,
   appendTextToLastPart,
-  removeLastPartFromParts,
+  dropLastPart,
 } from "../message/message-transforms";
 import type { UseMessagePlaybackReturn } from "../message/playback/use-message-playback";
 import type { MessagePart, UseMessageReturn } from "../message/use-message";
@@ -40,7 +40,7 @@ export function createButtonActivation({
           navigation.goToBoard(intent.targetBoardId);
           break;
         case "compose":
-          parts = addPartToParts(parts, intent.content);
+          parts = appendPart(parts, intent.content);
           break;
         case "playAudio":
           void playAudio(intent.src);
@@ -54,10 +54,10 @@ export function createButtonActivation({
               parts = appendTextToLastPart(parts, intent.action.text);
               break;
             case "space":
-              parts = addSpaceToParts(parts);
+              parts = appendSpace(parts);
               break;
             case "backspace":
-              parts = removeLastPartFromParts(parts);
+              parts = dropLastPart(parts);
               break;
             case "clear":
               parts = [];

--- a/src/features/board/board-sets/board-sets-store.ts
+++ b/src/features/board/board-sets/board-sets-store.ts
@@ -13,7 +13,7 @@ export interface BoardSetsSnapshot {
 
 const boardSetsSyncChannel = new BroadcastChannel("board-sets-sync");
 boardSetsSyncChannel.addEventListener("message", () => {
-  void invalidateBoardSets();
+  void refreshBoardSets();
 });
 
 const store = createExternalStore<BoardSetsSnapshot>({
@@ -50,13 +50,13 @@ function ensureLoaded(): Promise<void> {
   return pendingLoad ?? Promise.resolve();
 }
 
-export async function invalidateBoardSets(): Promise<void> {
+export async function refreshBoardSets(): Promise<void> {
   pendingLoad = loadBoardSets();
   await pendingLoad;
 }
 
 export async function notifyBoardSetsChanged(): Promise<void> {
-  await invalidateBoardSets();
+  await refreshBoardSets();
   boardSetsSyncChannel.postMessage("invalidate");
 }
 

--- a/src/features/board/import/board-import.test.ts
+++ b/src/features/board/import/board-import.test.ts
@@ -9,13 +9,13 @@ import {
   listBoardSets,
 } from "../storage/boards-db";
 import { resetBoardsDB } from "../storage/test-utils";
-import { persistBoardFiles, resolveLoadBoardPaths } from "./board-import";
+import { importBoardSets, resolveLoadBoardPaths } from "./board-import";
 
 const OBZ_FIXTURE = "lots-of-stuff.obz";
 const OBF_FIXTURE = "lots-of-stuff.obf";
 const IMPORTED_SET_ID = "lots-of-stuff";
 
-describe("persistBoardFiles", () => {
+describe("importBoardSets", () => {
   beforeEach(async () => {
     await resetBoardsDB();
   });
@@ -24,7 +24,7 @@ describe("persistBoardFiles", () => {
     const fixtureFile = await loadFixtureFile(OBF_FIXTURE);
     const board = await loadOBF(fixtureFile);
 
-    const importResults = await persistBoardFiles(fixtureFile);
+    const importResults = await importBoardSets(fixtureFile);
 
     expect(importResults).toEqual([
       {
@@ -77,7 +77,7 @@ describe("persistBoardFiles", () => {
     assertDefined(sampleAssetEntry);
     const [sampleAssetPath, sampleAssetBytes] = sampleAssetEntry;
 
-    const importResults = await persistBoardFiles(fixtureFile);
+    const importResults = await importBoardSets(fixtureFile);
 
     expect(importResults).toEqual([
       {
@@ -156,7 +156,7 @@ describe("persistBoardFiles", () => {
       type: "application/zip",
     });
 
-    const importResults = await persistBoardFiles(zipNamedFile);
+    const importResults = await importBoardSets(zipNamedFile);
 
     expect(importResults).toHaveLength(1);
     expect(importResults[0].setId).toBe(IMPORTED_SET_ID);
@@ -175,7 +175,7 @@ describe("persistBoardFiles", () => {
       type: "application/octet-stream",
     });
 
-    const importResults = await persistBoardFiles(extensionOnlyFile);
+    const importResults = await importBoardSets(extensionOnlyFile);
 
     expect(importResults[0].setId).toBe("imported-board");
   });
@@ -186,7 +186,7 @@ describe("persistBoardFiles", () => {
       type: "application/octet-stream",
     });
 
-    const importResults = await persistBoardFiles(longNamedFile);
+    const importResults = await importBoardSets(longNamedFile);
 
     expect(importResults[0].setId).toBe("x".repeat(255));
   });
@@ -194,10 +194,10 @@ describe("persistBoardFiles", () => {
   test("re-importing the same filename replaces the existing set", async () => {
     const fixtureFile = await loadFixtureFile(OBF_FIXTURE);
 
-    const first = await persistBoardFiles(fixtureFile);
+    const first = await importBoardSets(fixtureFile);
     expect(first[0].replacedExisting).toBe(false);
 
-    const second = await persistBoardFiles(fixtureFile);
+    const second = await importBoardSets(fixtureFile);
     expect(second[0].replacedExisting).toBe(true);
 
     const boardSets = await listBoardSets();
@@ -210,7 +210,7 @@ describe("persistBoardFiles", () => {
       type: "application/json",
     });
 
-    await expect(persistBoardFiles([goodFile, corruptFile])).rejects.toThrow();
+    await expect(importBoardSets([goodFile, corruptFile])).rejects.toThrow();
 
     const boardSets = await listBoardSets();
     expect(boardSets.map((set) => set.setId)).toContain(IMPORTED_SET_ID);

--- a/src/features/board/import/board-import.ts
+++ b/src/features/board/import/board-import.ts
@@ -21,7 +21,7 @@ export interface ImportResult {
   replacedExisting: boolean;
 }
 
-export async function persistBoardFiles(
+export async function importBoardSets(
   files: File | File[],
 ): Promise<ImportResult[]> {
   const fileList = Array.isArray(files) ? files : [files];
@@ -153,8 +153,8 @@ function buildBoardSetInput(
   };
 }
 
-function deriveSetId(filename: string): string {
-  const stem = filename.replace(/\.(obz|obf|zip|json)$/i, "").toLowerCase();
+function deriveSetId(fileName: string): string {
+  const stem = fileName.replace(/\.(obz|obf|zip|json)$/i, "").toLowerCase();
 
   return stem.slice(0, 255) || "imported-board";
 }

--- a/src/features/board/import/import-from-url.ts
+++ b/src/features/board/import/import-from-url.ts
@@ -1,4 +1,4 @@
-import { persistBoardFiles, type ImportResult } from "./board-import";
+import { importBoardSets, type ImportResult } from "./board-import";
 
 export async function importBoardFromUrl(url: string): Promise<ImportResult> {
   const response = await fetch(url);
@@ -15,7 +15,7 @@ export async function importBoardFromUrl(url: string): Promise<ImportResult> {
     type: blob.type || "application/octet-stream",
   });
 
-  const [result] = await persistBoardFiles(file);
+  const [result] = await importBoardSets(file);
 
   return result;
 }

--- a/src/features/board/import/use-import-board-files.test.tsx
+++ b/src/features/board/import/use-import-board-files.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, test } from "vitest";
 import { render } from "vitest-browser-react";
 import { MemoryRouter } from "react-router";
 import { resetBoardsDB } from "../storage/test-utils";
-import { persistBoardFiles } from "./board-import";
+import { importBoardSets } from "./board-import";
 import { useImportBoardFiles } from "./use-import-board-files";
 
 const OBF_FIXTURE = "lots-of-stuff.obf";
@@ -43,7 +43,7 @@ describe("useImportBoardFiles", () => {
 
   test("shows the replaced message when the set already exists", async () => {
     const file = await loadFixtureFile(OBF_FIXTURE);
-    await persistBoardFiles(file);
+    await importBoardSets(file);
 
     const screen = await renderImport([file]);
     await screen.getByRole("button", { name: "import" }).click();

--- a/src/features/board/import/use-import-board-files.ts
+++ b/src/features/board/import/use-import-board-files.ts
@@ -4,7 +4,7 @@ import { openFiles } from "@shared/utils/file-picker";
 import { useNavigate } from "react-router";
 import { boardSetPath } from "../navigation/board-paths";
 import { BOARD_FILE_ACCEPT } from "./board-file-types";
-import { persistBoardFiles, type ImportResult } from "./board-import";
+import { importBoardSets, type ImportResult } from "./board-import";
 
 export interface UseImportBoardFilesReturn {
   pickAndImportBoardFiles: () => Promise<void>;
@@ -28,7 +28,7 @@ export function useImportBoardFiles(): UseImportBoardFilesReturn {
     });
 
     try {
-      const results = await persistBoardFiles(files);
+      const results = await importBoardSets(files);
 
       const replacedExisting = results.some(
         (result) => result.replacedExisting,

--- a/src/features/board/message/message-transforms.test.ts
+++ b/src/features/board/message/message-transforms.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, test } from "vitest";
 import {
-  addPartToParts,
-  addSpaceToParts,
+  appendPart,
+  appendSpace,
   appendTextToLastPart,
-  removeLastPartFromParts,
+  dropLastPart,
 } from "./message-transforms";
 import type { MessagePart } from "./use-message";
 
-describe("addPartToParts", () => {
+describe("appendPart", () => {
   test("appends a new part with a minted id", () => {
-    const parts = addPartToParts([], { label: "hi" });
+    const parts = appendPart([], { label: "hi" });
 
     expect(parts).toHaveLength(1);
     expect(parts[0].label).toBe("hi");
@@ -17,8 +17,8 @@ describe("addPartToParts", () => {
   });
 
   test("mints a distinct id for each part even with identical content", () => {
-    const first = addPartToParts([], { label: "cat" });
-    const second = addPartToParts(first, { label: "cat" });
+    const first = appendPart([], { label: "cat" });
+    const second = appendPart(first, { label: "cat" });
 
     expect(second[0].id).not.toBe(second[1].id);
   });
@@ -26,16 +26,16 @@ describe("addPartToParts", () => {
   test("leaves the input array untouched", () => {
     const original: MessagePart[] = [{ id: "1", label: "hi" }];
 
-    const result = addPartToParts(original, { label: "there" });
+    const result = appendPart(original, { label: "there" });
 
     expect(original).toHaveLength(1);
     expect(result).toHaveLength(2);
   });
 });
 
-describe("addSpaceToParts", () => {
+describe("appendSpace", () => {
   test("appends an empty-label part", () => {
-    const parts = addSpaceToParts([{ id: "1", label: "hi" }]);
+    const parts = appendSpace([{ id: "1", label: "hi" }]);
 
     expect(parts).toHaveLength(2);
     expect(parts[1].label).toBe("");
@@ -82,9 +82,9 @@ describe("appendTextToLastPart", () => {
   });
 });
 
-describe("removeLastPartFromParts", () => {
+describe("dropLastPart", () => {
   test("removes the last part", () => {
-    const parts = removeLastPartFromParts([
+    const parts = dropLastPart([
       { id: "1", label: "hello" },
       { id: "2", label: "world" },
     ]);
@@ -93,10 +93,10 @@ describe("removeLastPartFromParts", () => {
   });
 
   test("returns an empty array when there is only one part", () => {
-    expect(removeLastPartFromParts([{ id: "1", label: "hi" }])).toEqual([]);
+    expect(dropLastPart([{ id: "1", label: "hi" }])).toEqual([]);
   });
 
   test("returns an empty array when already empty", () => {
-    expect(removeLastPartFromParts([])).toEqual([]);
+    expect(dropLastPart([])).toEqual([]);
   });
 });

--- a/src/features/board/message/message-transforms.ts
+++ b/src/features/board/message/message-transforms.ts
@@ -5,15 +5,15 @@ export function createPart(content: MessagePartContent): MessagePart {
   return { ...content, id: randomId() };
 }
 
-export function addPartToParts(
+export function appendPart(
   parts: MessagePart[],
   content: MessagePartContent,
 ): MessagePart[] {
   return [...parts, createPart(content)];
 }
 
-export function addSpaceToParts(parts: MessagePart[]): MessagePart[] {
-  return addPartToParts(parts, { label: "" });
+export function appendSpace(parts: MessagePart[]): MessagePart[] {
+  return appendPart(parts, { label: "" });
 }
 
 export function appendTextToLastPart(
@@ -31,6 +31,6 @@ export function appendTextToLastPart(
   });
 }
 
-export function removeLastPartFromParts(parts: MessagePart[]): MessagePart[] {
+export function dropLastPart(parts: MessagePart[]): MessagePart[] {
   return parts.slice(0, -1);
 }

--- a/src/features/board/message/play-button.tsx
+++ b/src/features/board/message/play-button.tsx
@@ -17,13 +17,13 @@ export function PlayButton({
   onPlayClick,
   onStopClick,
 }: PlayButtonProps) {
-  const playButtonLabel = isPlaying ? m.messageStop() : m.messagePlay();
+  const label = isPlaying ? m.messageStop() : m.messagePlay();
 
   return (
     <Fab
       color={isPlaying ? "default" : "primary"}
       disabled={disabled}
-      aria-label={playButtonLabel}
+      aria-label={label}
       onClick={isPlaying ? onStopClick : onPlayClick}
       sx={{
         width: 72,

--- a/src/features/board/message/use-message.ts
+++ b/src/features/board/message/use-message.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { BoardButton } from "../types";
-import { createPart, removeLastPartFromParts } from "./message-transforms";
+import { createPart, dropLastPart } from "./message-transforms";
 
 export type MessagePartContent = Pick<
   BoardButton,
@@ -35,7 +35,7 @@ export function useMessage(): UseMessageReturn {
   }
 
   function removeLastPart() {
-    setParts((prev) => removeLastPartFromParts(prev));
+    setParts((prev) => dropLastPart(prev));
   }
 
   function clear() {

--- a/src/features/board/storage/board-hydration.test.ts
+++ b/src/features/board/storage/board-hydration.test.ts
@@ -1,7 +1,7 @@
 import type { OBFBoard } from "@shayc/open-board-format";
 import { beforeEach, describe, expect, test } from "vitest";
 import { assertDefined } from "@shared/testing/assert-defined";
-import { invalidateBoardSets } from "../board-sets/board-sets-store";
+import { refreshBoardSets } from "../board-sets/board-sets-store";
 import { hydrateBoard } from "./board-hydration";
 import { BoardNotFoundError, replaceBoardSet } from "./boards-db";
 import { resetBoardsDB } from "./test-utils";
@@ -34,7 +34,7 @@ async function seedTestBoard(): Promise<void> {
     assets: [{ path: IMAGE_PATH, blob: pngBlob }],
   });
 
-  await invalidateBoardSets();
+  await refreshBoardSets();
 }
 
 async function expectThrown(promise: Promise<unknown>): Promise<unknown> {
@@ -65,7 +65,7 @@ function isObjectUrlAlive(url: string): Promise<boolean> {
 describe("hydrateBoard", () => {
   beforeEach(async () => {
     await resetBoardsDB();
-    await invalidateBoardSets();
+    await refreshBoardSets();
   });
 
   test("returns a hydrated board on the happy path", async () => {

--- a/src/features/board/storage/test-utils.ts
+++ b/src/features/board/storage/test-utils.ts
@@ -1,4 +1,4 @@
-import { invalidateBoardSets } from "../board-sets/board-sets-store";
+import { refreshBoardSets } from "../board-sets/board-sets-store";
 import { getBoardsDB, replaceBoardSet, type BoardSetRecord } from "./boards-db";
 
 const STORE_NAMES = ["boardSets", "boards", "assets"] as const;
@@ -20,7 +20,7 @@ export async function clearBoardsDB(): Promise<void> {
 
 export async function resetBoardsDB(): Promise<void> {
   await clearBoardsDB();
-  await invalidateBoardSets();
+  await refreshBoardSets();
 }
 
 export async function seedBoardSets(records: SeedBoardSet[]): Promise<void> {
@@ -33,5 +33,5 @@ export async function seedBoardSets(records: SeedBoardSet[]): Promise<void> {
     });
   }
 
-  await invalidateBoardSets();
+  await refreshBoardSets();
 }

--- a/src/shared/snackbar/snackbar-provider.tsx
+++ b/src/shared/snackbar/snackbar-provider.tsx
@@ -11,18 +11,18 @@ import {
 
 const DEFAULT_SNACKBAR_SEVERITY: SnackbarSeverity = "info";
 
-interface SnackbarMessage extends SnackbarOptions {
+interface QueuedSnackbar extends SnackbarOptions {
   key: number;
 }
 
 interface SnackbarState {
-  queue: SnackbarMessage[];
-  current: SnackbarMessage | undefined;
+  queue: QueuedSnackbar[];
+  current: QueuedSnackbar | undefined;
   open: boolean;
 }
 
 type SnackbarAction =
-  | { type: "show"; message: SnackbarMessage }
+  | { type: "show"; snackbar: QueuedSnackbar }
   | { type: "close" }
   | { type: "exited" };
 
@@ -45,11 +45,11 @@ export function SnackbarProvider({ children }: SnackbarProviderProps) {
     const snackbarOptions: SnackbarOptions =
       typeof options === "string" ? { message: options } : options;
 
-    const message: SnackbarMessage = {
+    const snackbar: QueuedSnackbar = {
       ...snackbarOptions,
       key: nextKeyRef.current++,
     };
-    dispatch({ type: "show", message });
+    dispatch({ type: "show", snackbar });
   };
 
   const handleClose = (
@@ -108,12 +108,12 @@ function snackbarReducer(
       if (state.current) {
         return {
           ...state,
-          queue: [...state.queue, action.message],
+          queue: [...state.queue, action.snackbar],
           open: false,
         };
       }
 
-      return { ...state, current: action.message, open: true };
+      return { ...state, current: action.snackbar, open: true };
     }
 
     case "close":


### PR DESCRIPTION
## Summary
- Renames identifiers to better match their behavior: `persistBoardFiles`→`importBoardSets`, `invalidateBoardSets`→`refreshBoardSets`, `addPartToParts`/`addSpaceToParts`/`removeLastPartFromParts`→`appendPart`/`appendSpace`/`dropLastPart`, `SnackbarMessage`→`QueuedSnackbar`
- No behavior changes — pure rename pass

## Test plan
- [x] `npm run lint` on changed files — clean
- [x] `tsc --noEmit` — clean
- [x] `npm run test` — 463 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)