### PR TITLE
feat(library): use sidebar icon for drawer close button

### DIFF
--- a/src/app/layouts/app-header.tsx
+++ b/src/app/layouts/app-header.tsx
@@ -12,6 +12,7 @@ import Toolbar from "@mui/material/Toolbar";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
+import { flipForLtr } from "@shared/theme/rtl";
 import { useMatch } from "react-router";
 import { usePageTitle } from "./page-title-store";
 
@@ -41,7 +42,7 @@ export function AppHeader({
               color="inherit"
               onClick={onLibraryClick}
             >
-              <ViewSidebarOutlinedIcon />
+              <ViewSidebarOutlinedIcon sx={flipForLtr} />
             </IconButton>
           </Tooltip>
         )}

--- a/src/app/library/library-drawer.tsx
+++ b/src/app/library/library-drawer.tsx
@@ -1,7 +1,7 @@
 import { DRAWER_BASE_WIDTH } from "@app/layouts/drawer-width";
 import { BoardSetLibrary, boardSetPath } from "@features/board";
-import CloseIcon from "@mui/icons-material/Close";
 import GitHubIcon from "@mui/icons-material/GitHub";
+import ViewSidebarOutlinedIcon from "@mui/icons-material/ViewSidebarOutlined";
 import Box from "@mui/material/Box";
 import Drawer from "@mui/material/Drawer";
 import IconButton from "@mui/material/IconButton";
@@ -11,6 +11,7 @@ import Typography from "@mui/material/Typography";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { m } from "@paraglide/messages.js";
 import { ExternalLink } from "@shared/components/external-link";
+import { flipForLtr } from "@shared/theme/rtl";
 import { useMatches, useNavigate } from "react-router";
 
 export const LIBRARY_DRAWER_WIDTH = `calc(${DRAWER_BASE_WIDTH} + env(safe-area-inset-left))`;
@@ -71,7 +72,7 @@ export function LibraryDrawer({
             color="inherit"
             onClick={onClose}
           >
-            <CloseIcon />
+            <ViewSidebarOutlinedIcon sx={flipForLtr} />
           </IconButton>
         </Tooltip>
       </Toolbar>

--- a/src/shared/theme/rtl.ts
+++ b/src/shared/theme/rtl.ts
@@ -10,3 +10,14 @@ import type { Theme } from "@mui/material/styles";
  */
 export const flipForRtl = (theme: Theme) =>
   theme.direction === "rtl" ? { transform: "scaleX(-1)" } : {};
+
+/**
+ * sx helper that mirrors an element on the X axis when the theme direction is
+ * LTR. Intended for icons that are inherently asymmetric but happen to read
+ * correctly unflipped in RTL (e.g. a sidebar icon depicting a left-hand rail).
+ *
+ * Usage:
+ *   <ViewSidebarOutlinedIcon sx={flipForLtr} />
+ */
+export const flipForLtr = (theme: Theme) =>
+  theme.direction === "ltr" ? { transform: "scaleX(-1)" } : {};


### PR DESCRIPTION
## Summary
- Swap the library drawer's close X for the same `ViewSidebarOutlinedIcon` used to open it, so open/close use one consistent icon.
- Add a `flipForLtr` sx helper (mirror image of the existing `flipForRtl`) since this icon needs mirroring in LTR but reads correctly unflipped in RTL.

## Test plan
- [x] `npm run lint` passes on changed files
- [ ] Manually verify in browser: open/close library drawer in both an LTR and RTL locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)