### PR TITLE
fix(board): move backspace button before suggestion bar

### DIFF
--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -79,6 +79,11 @@ export function BoardViewer({ board }: BoardViewerProps) {
         spacing={2}
         sx={{ justifyContent: "flex-end", px: { xs: 2, sm: 3 } }}
       >
+        <BackspaceButton
+          onPress={message.removeLastPart}
+          onLongPress={message.clear}
+        />
+
         {suggestions.isSupported && (
           <SuggestionBar
             status={suggestions.status}
@@ -87,11 +92,6 @@ export function BoardViewer({ board }: BoardViewerProps) {
             onPhraseClick={message.setFromText}
           />
         )}
-
-        <BackspaceButton
-          onPress={message.removeLastPart}
-          onLongPress={message.clear}
-        />
       </Stack>
 
       <Box sx={{ flex: 1, minHeight: 0 }}>


### PR DESCRIPTION
## Summary
- Reorders the message toolbar so the backspace button appears before the suggestion bar

## Test plan
- [ ] Verify toolbar layout in the browser