### PR TITLE
style(board): restyle backspace as contained button after suggestions

### DIFF
--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -79,11 +79,6 @@ export function BoardViewer({ board }: BoardViewerProps) {
         spacing={2}
         sx={{ justifyContent: "flex-end", px: { xs: 2, sm: 3 } }}
       >
-        <BackspaceButton
-          onPress={message.removeLastPart}
-          onLongPress={message.clear}
-        />
-
         {suggestions.isSupported && (
           <SuggestionBar
             status={suggestions.status}
@@ -92,6 +87,11 @@ export function BoardViewer({ board }: BoardViewerProps) {
             onPhraseClick={message.setFromText}
           />
         )}
+
+        <BackspaceButton
+          onPress={message.removeLastPart}
+          onLongPress={message.clear}
+        />
       </Stack>
 
       <Box sx={{ flex: 1, minHeight: 0 }}>

--- a/src/features/board/message/backspace-button.tsx
+++ b/src/features/board/message/backspace-button.tsx
@@ -1,5 +1,5 @@
 import BackspaceOutlinedIcon from "@mui/icons-material/BackspaceOutlined";
-import IconButton from "@mui/material/IconButton";
+import Button from "@mui/material/Button";
 import { m } from "@paraglide/messages.js";
 import { flipForRtl } from "@shared/theme/rtl";
 import { mergeProps, useLongPress, usePress } from "react-aria";
@@ -26,13 +26,16 @@ export function BackspaceButton({
   });
 
   return (
-    <IconButton
+    <Button
       {...mergeProps(pressProps, longPressProps)}
       aria-label={m.messageBackspace()}
       size="large"
+      color="inherit"
       disabled={disabled}
+      variant="contained"
+      sx={{ width: 96, borderRadius: 4 }}
     >
       <BackspaceOutlinedIcon sx={flipForRtl} />
-    </IconButton>
+    </Button>
   );
 }


### PR DESCRIPTION
## Summary
- Swap the icon-only backspace button for a full-size contained `Button`
- Move the backspace button back after the suggestion bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)