### PR TITLE
style(board): widen backspace button to 104px

### DIFF
--- a/src/features/board/message/backspace-button.tsx
+++ b/src/features/board/message/backspace-button.tsx
@@ -33,7 +33,7 @@ export function BackspaceButton({
       color="inherit"
       disabled={disabled}
       variant="contained"
-      sx={{ width: 96, borderRadius: 4 }}
+      sx={{ width: 104, borderRadius: 4 }}
     >
       <BackspaceOutlinedIcon sx={flipForRtl} />
     </Button>


### PR DESCRIPTION
## Summary
- Bump the backspace button's fixed width from 96px to 104px

## Test plan
- [x] Lint/format pass via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)