### PR TITLE
feat(board): Pictogram label required + labelPlacement

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "جارٍ التحميل...",
   "close": "إغلاق",
-  "boardLoading": "جارٍ تحميل اللوحة...",
   "boardGridLabel": "لوحة تواصل",
   "board": "لوحة",
   "libraryLoading": "جارٍ تحميل اللوحات...",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Зареждане...",
   "close": "Затваряне",
-  "boardLoading": "Зареждане на дъската...",
   "boardGridLabel": "Комуникационна дъска",
   "board": "Дъска",
   "libraryLoading": "Зареждане на дъските...",

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "লোড হচ্ছে…",
   "close": "বন্ধ করুন",
-  "boardLoading": "বোর্ড লোড হচ্ছে…",
   "boardGridLabel": "যোগাযোগ বোর্ড",
   "board": "বোর্ড",
   "libraryLoading": "বোর্ড লোড হচ্ছে…",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Načítání...",
   "close": "Zavřít",
-  "boardLoading": "Načítání tabulky...",
   "boardGridLabel": "Komunikační tabulka",
   "board": "Tabulka",
   "libraryLoading": "Načítání tabulek...",

--- a/messages/da.json
+++ b/messages/da.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Indlæser...",
   "close": "Luk",
-  "boardLoading": "Indlæser tavle...",
   "boardGridLabel": "Kommunikationstavle",
   "board": "Tavle",
   "libraryLoading": "Indlæser tavler...",

--- a/messages/de.json
+++ b/messages/de.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Wird geladen...",
   "close": "Schließen",
-  "boardLoading": "Tafel wird geladen...",
   "boardGridLabel": "Kommunikationstafel",
   "board": "Tafel",
   "libraryLoading": "Tafeln werden geladen...",

--- a/messages/el.json
+++ b/messages/el.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Φόρτωση...",
   "close": "Κλείσιμο",
-  "boardLoading": "Φόρτωση πίνακα...",
   "boardGridLabel": "Πίνακας επικοινωνίας",
   "board": "Πίνακας",
   "libraryLoading": "Φόρτωση πινάκων...",

--- a/messages/en.json
+++ b/messages/en.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Loading...",
   "close": "Close",
-  "boardLoading": "Loading board...",
   "boardGridLabel": "Communication board",
   "board": "Board",
   "libraryLoading": "Loading boards...",

--- a/messages/es.json
+++ b/messages/es.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Cargando...",
   "close": "Cerrar",
-  "boardLoading": "Cargando tablero...",
   "boardGridLabel": "Tablero de comunicación",
   "board": "Tablero",
   "libraryLoading": "Cargando tableros...",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Ladataan...",
   "close": "Sulje",
-  "boardLoading": "Ladataan taulua...",
   "boardGridLabel": "Kommunikointitaulu",
   "board": "Taulu",
   "libraryLoading": "Ladataan tauluja...",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Chargement...",
   "close": "Fermer",
-  "boardLoading": "Chargement du tableau...",
   "boardGridLabel": "Tableau de communication",
   "board": "Tableau",
   "libraryLoading": "Chargement des tableaux...",

--- a/messages/he.json
+++ b/messages/he.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "טעינה...",
   "close": "סגירה",
-  "boardLoading": "טעינת לוח...",
   "boardGridLabel": "לוח תקשורת",
   "board": "לוח",
   "libraryLoading": "טעינת לוחות...",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "लोड हो रहा है…",
   "close": "बंद करें",
-  "boardLoading": "बोर्ड लोड हो रहा है…",
   "boardGridLabel": "संचार बोर्ड",
   "board": "बोर्ड",
   "libraryLoading": "बोर्ड लोड हो रहे हैं…",

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Učitavanje...",
   "close": "Zatvori",
-  "boardLoading": "Učitavanje ploče...",
   "boardGridLabel": "Komunikacijska ploča",
   "board": "Ploča",
   "libraryLoading": "Učitavanje ploča...",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Betöltés...",
   "close": "Bezárás",
-  "boardLoading": "Tábla betöltése...",
   "boardGridLabel": "Kommunikációs tábla",
   "board": "Tábla",
   "libraryLoading": "Táblák betöltése...",

--- a/messages/id.json
+++ b/messages/id.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Memuat...",
   "close": "Tutup",
-  "boardLoading": "Memuat papan...",
   "boardGridLabel": "Papan komunikasi",
   "board": "Papan",
   "libraryLoading": "Memuat papan...",

--- a/messages/it.json
+++ b/messages/it.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Caricamento...",
   "close": "Chiudi",
-  "boardLoading": "Caricamento tabella...",
   "boardGridLabel": "Tabella di comunicazione",
   "board": "Tabella",
   "libraryLoading": "Caricamento tabelle...",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "読み込んでいます…",
   "close": "閉じる",
-  "boardLoading": "ボードを読み込んでいます…",
   "boardGridLabel": "コミュニケーションボード",
   "board": "ボード",
   "libraryLoading": "ボードを読み込んでいます…",

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "ಲೋಡ್ ಆಗುತ್ತಿದೆ…",
   "close": "ಮುಚ್ಚಿ",
-  "boardLoading": "ಬೋರ್ಡ್ ಲೋಡ್ ಆಗುತ್ತಿದೆ…",
   "boardGridLabel": "ಸಂವಹನ ಬೋರ್ಡ್",
   "board": "ಬೋರ್ಡ್",
   "libraryLoading": "ಬೋರ್ಡ್‌ಗಳು ಲೋಡ್ ಆಗುತ್ತಿವೆ…",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "불러오는 중…",
   "close": "닫기",
-  "boardLoading": "보드를 불러오는 중…",
   "boardGridLabel": "의사소통 보드",
   "board": "보드",
   "libraryLoading": "보드를 불러오는 중…",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Laden...",
   "close": "Sluiten",
-  "boardLoading": "Bord laden...",
   "boardGridLabel": "Communicatiebord",
   "board": "Bord",
   "libraryLoading": "Borden laden...",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Ładowanie...",
   "close": "Zamknij",
-  "boardLoading": "Ładowanie tablicy...",
   "boardGridLabel": "Tablica komunikacyjna",
   "board": "Tablica",
   "libraryLoading": "Ładowanie tablic...",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Carregando...",
   "close": "Fechar",
-  "boardLoading": "Carregando prancha...",
   "boardGridLabel": "Prancha de comunicação",
   "board": "Prancha",
   "libraryLoading": "Carregando pranchas...",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Se încarcă...",
   "close": "Închide",
-  "boardLoading": "Se încarcă tabla...",
   "boardGridLabel": "Tablă de comunicare",
   "board": "Tablă",
   "libraryLoading": "Se încarcă tablele...",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Загрузка...",
   "close": "Закрыть",
-  "boardLoading": "Загрузка доски...",
   "boardGridLabel": "Коммуникационная доска",
   "board": "Доска",
   "libraryLoading": "Загрузка досок...",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Načítava sa...",
   "close": "Zavrieť",
-  "boardLoading": "Načítava sa tabuľka...",
   "boardGridLabel": "Komunikačná tabuľka",
   "board": "Tabuľka",
   "libraryLoading": "Načítavajú sa tabuľky...",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Nalaganje...",
   "close": "Zapri",
-  "boardLoading": "Nalaganje table...",
   "boardGridLabel": "Komunikacijska tabla",
   "board": "Tabla",
   "libraryLoading": "Nalaganje tabel...",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Laddar...",
   "close": "Stäng",
-  "boardLoading": "Laddar tavla...",
   "boardGridLabel": "Kommunikationstavla",
   "board": "Tavla",
   "libraryLoading": "Laddar tavlor...",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "ஏற்றப்படுகிறது…",
   "close": "மூடு",
-  "boardLoading": "பலகை ஏற்றப்படுகிறது…",
   "boardGridLabel": "தொடர்பு பலகை",
   "board": "பலகை",
   "libraryLoading": "பலகைகள் ஏற்றப்படுகின்றன…",

--- a/messages/te.json
+++ b/messages/te.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "లోడ్ అవుతోంది…",
   "close": "మూసివేయి",
-  "boardLoading": "బోర్డు లోడ్ అవుతోంది…",
   "boardGridLabel": "సంభాషణ బోర్డు",
   "board": "బోర్డు",
   "libraryLoading": "బోర్డులు లోడ్ అవుతున్నాయి…",

--- a/messages/th.json
+++ b/messages/th.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "กำลังโหลด...",
   "close": "ปิด",
-  "boardLoading": "กำลังโหลดบอร์ด...",
   "boardGridLabel": "บอร์ดสื่อสาร",
   "board": "บอร์ด",
   "libraryLoading": "กำลังโหลดบอร์ด...",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Yükleniyor...",
   "close": "Kapat",
-  "boardLoading": "Pano yükleniyor...",
   "boardGridLabel": "İletişim panosu",
   "board": "Pano",
   "libraryLoading": "Panolar yükleniyor...",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Завантаження...",
   "close": "Закрити",
-  "boardLoading": "Завантаження дошки...",
   "boardGridLabel": "Комунікаційна дошка",
   "board": "Дошка",
   "libraryLoading": "Завантаження дошок...",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "Đang tải...",
   "close": "Đóng",
-  "boardLoading": "Đang tải bảng...",
   "boardGridLabel": "Bảng giao tiếp",
   "board": "Bảng",
   "libraryLoading": "Đang tải các bảng...",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -2,7 +2,6 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "loading": "正在加载……",
   "close": "关闭",
-  "boardLoading": "正在加载沟通板……",
   "boardGridLabel": "沟通板",
   "board": "沟通板",
   "libraryLoading": "正在加载沟通板……",

--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -54,7 +54,7 @@ export function BoardViewer({ board }: BoardViewerProps) {
   const renderTile = (button: BoardButton, props: GridItemProps) => (
     <Tile
       key={button.id}
-      label={button.label}
+      label={button.label ?? ""}
       imageSrc={button.imageSrc}
       backgroundColor={button.backgroundColor}
       borderColor={button.borderColor}

--- a/src/features/board/message/message-bar.tsx
+++ b/src/features/board/message/message-bar.tsx
@@ -86,7 +86,7 @@ export function MessageBar({
                     : "none",
                 })}
               >
-                <Pictogram label={part.label} src={part.imageSrc} />
+                <Pictogram label={part.label ?? ""} src={part.imageSrc} />
               </Stack>
             );
           })}

--- a/src/features/board/pictogram/pictogram.test.tsx
+++ b/src/features/board/pictogram/pictogram.test.tsx
@@ -35,4 +35,33 @@ describe("Pictogram", () => {
     await expect.element(screen.getByText("Action")).toBeVisible();
     expect(screen.container.querySelector("img")).not.toBeNull();
   });
+
+  test("places the label above the image when labelPlacement is top", async () => {
+    const screen = await render(
+      <Pictogram src={TEST_IMAGE_SRC} label="Action" labelPlacement="top" />,
+    );
+
+    const container = screen.getByText("Action").element().parentElement;
+    if (!container) {
+      throw new Error("Pictogram container not found");
+    }
+    expect(getComputedStyle(container).flexDirection).toBe("column-reverse");
+  });
+
+  test("keeps the label accessible when labelPlacement is hidden", async () => {
+    const screen = await render(
+      <Pictogram src={TEST_IMAGE_SRC} label="Action" labelPlacement="hidden" />,
+    );
+
+    await expect.element(screen.getByText("Action")).toBeInTheDocument();
+  });
+
+  test("takes no layout space for the label when labelPlacement is hidden", async () => {
+    const screen = await render(
+      <Pictogram src={TEST_IMAGE_SRC} label="Action" labelPlacement="hidden" />,
+    );
+
+    const label = screen.getByText("Action").element();
+    expect(label.getBoundingClientRect().width).toBeLessThanOrEqual(1);
+  });
 });

--- a/src/features/board/pictogram/pictogram.test.tsx
+++ b/src/features/board/pictogram/pictogram.test.tsx
@@ -5,7 +5,7 @@ import { Pictogram } from "./pictogram";
 
 describe("Pictogram", () => {
   test("renders no content when no src or label is provided", async () => {
-    const screen = await render(<Pictogram />);
+    const screen = await render(<Pictogram label="" />);
 
     expect(screen.container.textContent).toBe("");
     expect(screen.container.querySelector("img")).toBeNull();
@@ -19,7 +19,7 @@ describe("Pictogram", () => {
   });
 
   test("renders image when src is provided", async () => {
-    const screen = await render(<Pictogram src={TEST_IMAGE_SRC} />);
+    const screen = await render(<Pictogram src={TEST_IMAGE_SRC} label="" />);
 
     const img = screen.container.querySelector("img");
     expect(img).not.toBeNull();

--- a/src/features/board/pictogram/pictogram.tsx
+++ b/src/features/board/pictogram/pictogram.tsx
@@ -3,7 +3,7 @@ import Typography from "@mui/material/Typography";
 
 export interface PictogramProps {
   src?: string;
-  label?: string;
+  label: string;
 }
 
 export function Pictogram({ src, label }: PictogramProps) {
@@ -44,16 +44,14 @@ export function Pictogram({ src, label }: PictogramProps) {
         </Box>
       )}
 
-      {label && (
-        <Typography
-          noWrap
-          component="span"
-          variant={src ? "body2" : "h5"}
-          sx={{ lineHeight: 1 }}
-        >
-          {label}
-        </Typography>
-      )}
+      <Typography
+        noWrap
+        component="span"
+        variant={src ? "body2" : "h5"}
+        sx={{ lineHeight: 1 }}
+      >
+        {label}
+      </Typography>
     </Box>
   );
 }

--- a/src/features/board/pictogram/pictogram.tsx
+++ b/src/features/board/pictogram/pictogram.tsx
@@ -1,17 +1,23 @@
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
+import visuallyHidden from "@mui/utils/visuallyHidden";
 
 export interface PictogramProps {
   src?: string;
   label: string;
+  labelPlacement?: "top" | "bottom" | "hidden";
 }
 
-export function Pictogram({ src, label }: PictogramProps) {
+export function Pictogram({
+  src,
+  label,
+  labelPlacement = "bottom",
+}: PictogramProps) {
   return (
     <Box
       sx={{
         display: "flex",
-        flexDirection: "column",
+        flexDirection: labelPlacement === "top" ? "column-reverse" : "column",
         textAlign: "center",
         justifyContent: "center",
         gap: 1,
@@ -48,7 +54,7 @@ export function Pictogram({ src, label }: PictogramProps) {
         noWrap
         component="span"
         variant={src ? "body2" : "h5"}
-        sx={{ lineHeight: 1 }}
+        sx={labelPlacement === "hidden" ? visuallyHidden : { lineHeight: 1 }}
       >
         {label}
       </Typography>

--- a/src/features/board/tile/tile.tsx
+++ b/src/features/board/tile/tile.tsx
@@ -3,7 +3,7 @@ import { alpha } from "@mui/material/styles";
 import { Pictogram } from "../pictogram/pictogram";
 
 export interface TileProps {
-  label?: string;
+  label: string;
   imageSrc?: string;
   backgroundColor?: string;
   borderColor?: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -93,6 +93,7 @@ export default defineConfig({
       "@mui/icons-material/*",
       "@mui/material/*",
       "@mui/stylis-plugin-rtl",
+      "@mui/utils/*",
       "react-dom/client",
       "react-router/dom",
       "stylis",


### PR DESCRIPTION
Two related Pictogram changes on this branch:

1. **Label required** — make `label` a required prop and drop the unused `boardLoading` key.
2. **`labelPlacement` prop** — `"top" | "bottom" | "hidden"` (default `"bottom"`):
   - `top` → label above the image (`flexDirection: column-reverse`)
   - `bottom` → current behavior
   - `hidden` → label stays in the DOM (accessible name preserved) but is pulled out of layout via `visuallyHidden`, so the image fills the space.

   Backward-compatible — existing consumers (Tile, MessageBar) inherit `"bottom"`. Wiring `hidden` up to a board setting is deferred.

Also pre-bundles `@mui/utils/*` in `optimizeDeps.include` to avoid a mid-test Vite optimizer reload.

Verified: lint clean, `tsc -b` clean, `npm test -- pictogram` (7 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)