### PR TITLE
style(board): right-align the pending dot in suggestion bar

### DIFF
--- a/src/features/board/suggestions/suggestion-bar.tsx
+++ b/src/features/board/suggestions/suggestion-bar.tsx
@@ -2,6 +2,7 @@ import Box from "@mui/material/Box";
 import Chip from "@mui/material/Chip";
 import Stack from "@mui/material/Stack";
 import type { SuggestionStatusView } from "./derive-suggestion-status";
+import { PendingDot } from "./pending-dot";
 import { SuggestionStatus } from "./suggestion-status";
 
 export interface SuggestionBarProps {
@@ -42,6 +43,10 @@ export function SuggestionBar({
           />
         ))}
       </Box>
+
+      {(status === null || status.kind === "pending") && (
+        <PendingDot show={status?.kind === "pending"} />
+      )}
     </Stack>
   );
 }

--- a/src/features/board/suggestions/suggestion-status.tsx
+++ b/src/features/board/suggestions/suggestion-status.tsx
@@ -3,7 +3,6 @@ import Chip from "@mui/material/Chip";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
 import type { SuggestionStatusView } from "./derive-suggestion-status";
-import { PendingDot } from "./pending-dot";
 
 export interface SuggestionStatusProps {
   status: SuggestionStatusView;
@@ -11,14 +10,6 @@ export interface SuggestionStatusProps {
 }
 
 export function SuggestionStatus({ status, onEnable }: SuggestionStatusProps) {
-  return (
-    statusMessage(status, onEnable) ?? (
-      <PendingDot show={status?.kind === "pending"} />
-    )
-  );
-}
-
-function statusMessage(status: SuggestionStatusView, onEnable: () => void) {
   if (status === null || status.kind === "pending") {
     return null;
   }


### PR DESCRIPTION
## Summary
- The pending dot in the suggestion status area used to reserve 8px + gap on the left even while invisible, pushing phrase chips away from the edge.
- Now the dot only mounts for the `null`/`pending` states and floats to the right end of the row (`marginInlineEnd: auto` on the phrase list), so chips stay flush left with no reserved space.
- Message states (`needs-activation`, `downloading`, `unavailable`) are unaffected — still rendered at the left, as before.

## Test plan
- [x] `npm run lint` on changed files
- [x] `suggestion-bar.test.tsx` passes (7/7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)