### PR TITLE
style(board): dedupe pending check in suggestion bar

### DIFF
--- a/src/features/board/suggestions/suggestion-bar.tsx
+++ b/src/features/board/suggestions/suggestion-bar.tsx
@@ -18,6 +18,8 @@ export function SuggestionBar({
   onEnable,
   onPhraseClick,
 }: SuggestionBarProps) {
+  const isPending = status?.kind === "pending";
+
   return (
     <Stack
       direction="row"
@@ -44,9 +46,7 @@ export function SuggestionBar({
         ))}
       </Box>
 
-      {(status === null || status.kind === "pending") && (
-        <PendingDot show={status?.kind === "pending"} />
-      )}
+      {(status === null || isPending) && <PendingDot show={isPending} />}
     </Stack>
   );
 }


### PR DESCRIPTION
## Summary
- Follow-up to #669: compute `status?.kind === "pending"` once instead of twice, so the mount-vs-show distinction for `PendingDot` is explicit in a single variable.

## Test plan
- [x] `npm run lint` on changed file
- [x] `suggestion-bar.test.tsx` passes (7/7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)