### PR TITLE
fix(app): remove redundant title fallback causing header flash

### DIFF
--- a/src/app/layouts/app-header.tsx
+++ b/src/app/layouts/app-header.tsx
@@ -1,8 +1,4 @@
-import {
-  BOARD_ROUTE_PATTERN,
-  BoardSwitcher,
-  NavButtons,
-} from "@features/board";
+import { BoardSwitcher, NavButtons } from "@features/board";
 import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
 import ViewSidebarOutlinedIcon from "@mui/icons-material/ViewSidebarOutlined";
 import AppBar from "@mui/material/AppBar";
@@ -10,10 +6,8 @@ import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import Toolbar from "@mui/material/Toolbar";
 import Tooltip from "@mui/material/Tooltip";
-import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
 import { flipForLtr } from "@shared/theme/rtl";
-import { useMatch } from "react-router";
 import { usePageTitle } from "./page-title-store";
 
 export interface AppHeaderProps {
@@ -28,7 +22,6 @@ export function AppHeader({
   onSettingsClick,
 }: AppHeaderProps) {
   const pageTitle = usePageTitle();
-  const boardMatch = useMatch(BOARD_ROUTE_PATTERN);
 
   return (
     <AppBar position="static">
@@ -50,21 +43,7 @@ export function AppHeader({
         <NavButtons />
 
         <Box sx={{ flexGrow: 1, minWidth: 0 }}>
-          {boardMatch && pageTitle ? (
-            <BoardSwitcher label={pageTitle} />
-          ) : (
-            <Typography
-              component="h1"
-              variant="h6"
-              sx={{
-                overflow: "hidden",
-                whiteSpace: "nowrap",
-                textOverflow: "ellipsis",
-              }}
-            >
-              {pageTitle}
-            </Typography>
-          )}
+          <BoardSwitcher label={pageTitle} />
         </Box>
 
         <Tooltip title={m.settingsOpen()}>


### PR DESCRIPTION
## Summary
- `AppHeader` gated its title slot on `boardMatch && pageTitle`, falling back to its own `Typography`. That fallback duplicated `BoardSwitcher`'s existing empty-state `Typography` and desynced from route changes (the title store resets/repopulates via effects), forcing `BoardSwitcher` to unmount/remount on every board navigation — visible as a flash of mismatched styling.
- `BoardSwitcher` already handles an unresolved `setId`/`boardId`/board gracefully (`useSetBoards` is null-safe for `setId: undefined`), so it can render unconditionally. Removed the outer `Typography` branch and the `boardMatch` check entirely.

## Test plan
- [x] `npm run -s lint -- src/app/layouts/app-header.tsx` passes
- [ ] Manually verify: navigating between boards in the same set shows no header flash
- [ ] Manually verify: navigating between board sets still looks reasonable (falls to BoardSwitcher's own fallback briefly)