### PR TITLE
style(app): add trailing margin to library toggle button

### DIFF
--- a/src/app/layouts/app-header.tsx
+++ b/src/app/layouts/app-header.tsx
@@ -34,6 +34,7 @@ export function AppHeader({
               edge="start"
               color="inherit"
               onClick={onLibraryClick}
+              sx={{ marginInlineEnd: 1 }}
             >
               <ViewSidebarOutlinedIcon sx={flipForLtr} />
             </IconButton>


### PR DESCRIPTION
## Summary
- Adds `marginInlineEnd: 1` to the library toggle `IconButton` in `AppHeader`.

## Test plan
- [x] `npm run -s lint -- src/app/layouts/app-header.tsx` passes