### PR TITLE
fix(board-viewer): stabilize mobile nav row height and vertical centering

### DIFF
--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -113,7 +113,9 @@ export function BoardViewer({ board }: BoardViewerProps) {
       {isSmallScreen && (
         <Box
           sx={{
+            height: 56,
             display: "flex",
+            alignItems: "center",
             justifyContent: "center",
             pb: safeAreaInset("bottom"),
           }}


### PR DESCRIPTION
## Summary
- Pin the mobile bottom nav row to a fixed height and vertically center its content, so layout doesn't shift based on what renders inside.

## Test plan
- [ ] Verify the mobile bottom nav row stays a consistent height across different board states.