### PR TITLE
style(board-switcher): restyle input as a pill and drop the visible label

### DIFF
--- a/src/features/board/navigation/board-switcher.tsx
+++ b/src/features/board/navigation/board-switcher.tsx
@@ -44,8 +44,32 @@ export function BoardSwitcher({ label }: BoardSwitcherProps) {
       isOptionEqualToValue={(option, selected) =>
         option.boardId === selected.boardId
       }
-      sx={{ width: 300, maxWidth: "100%" }}
-      renderInput={(params) => <TextField {...params} label={m.board()} />}
+      sx={(theme) => ({
+        width: 320,
+        maxWidth: "100%",
+        "& .MuiOutlinedInput-root.MuiInputBase-sizeSmall": {
+          paddingTop: 1,
+          paddingBottom: 1,
+          paddingInlineStart: "10px",
+          borderRadius: 7,
+          fontSize: theme.typography.h6.fontSize,
+        },
+      })}
+      slotProps={{
+        popupIndicator: { sx: { padding: "6px", border: "none" } },
+      }}
+      renderInput={(params) => (
+        <TextField
+          {...params}
+          slotProps={{
+            ...params.slotProps,
+            htmlInput: {
+              ...params.slotProps?.htmlInput,
+              "aria-label": m.board(),
+            },
+          }}
+        />
+      )}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Restyle the board switcher's Autocomplete input as a taller pill (padding, radius, popup-indicator size, one-step-larger font).
- Remove the floating label so the pill border has no notch, replaced with an `aria-label` for accessibility.

## Test plan
- [ ] Verify the board switcher renders as a clean pill with no visible label and no border notch.
- [ ] Verify a screen reader announces the input's accessible name.