### PR TITLE
fix(board-viewer): use minHeight for mobile nav row

### DIFF
--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -113,7 +113,7 @@ export function BoardViewer({ board }: BoardViewerProps) {
       {isSmallScreen && (
         <Box
           sx={{
-            height: 56,
+            minHeight: 56,
             display: "flex",
             alignItems: "center",
             justifyContent: "center",


### PR DESCRIPTION
## Summary
- Switch the mobile nav row's fixed `height: 56` to `minHeight: 56` so content isn't clipped when it needs more space.

## Test plan
- [ ] Verify mobile nav row still centers correctly at 56px on standard content
- [ ] Verify nav row grows without clipping when content exceeds 56px

🤖 Generated with [Claude Code](https://claude.com/claude-code)