### PR TITLE
style(board-switcher, pictogram): input padding via slot + pictogram sizing tweaks

### DIFF
--- a/src/features/board/navigation/board-switcher.tsx
+++ b/src/features/board/navigation/board-switcher.tsx
@@ -44,25 +44,22 @@ export function BoardSwitcher({ label }: BoardSwitcherProps) {
       isOptionEqualToValue={(option, selected) =>
         option.boardId === selected.boardId
       }
-      sx={(theme) => ({
-        width: 320,
-        maxWidth: "100%",
-        "& .MuiOutlinedInput-root.MuiInputBase-sizeSmall": {
-          paddingTop: 1,
-          paddingBottom: 1,
-          paddingInlineStart: "10px",
-          borderRadius: 7,
-          fontSize: theme.typography.h6.fontSize,
-        },
-      })}
+      sx={{ width: 320, maxWidth: "100%" }}
       slotProps={{
-        popupIndicator: { sx: { padding: "6px", border: "none" } },
+        popupIndicator: { sx: { border: "none" } },
       }}
       renderInput={(params) => (
         <TextField
           {...params}
           slotProps={{
             ...params.slotProps,
+            input: {
+              ...params.slotProps?.input,
+              sx: {
+                paddingTop: 1,
+                paddingBottom: 1,
+              },
+            },
             htmlInput: {
               ...params.slotProps?.htmlInput,
               "aria-label": m.board(),

--- a/src/features/board/pictogram/pictogram.tsx
+++ b/src/features/board/pictogram/pictogram.tsx
@@ -20,14 +20,14 @@ export function Pictogram({
         flexDirection: labelPlacement === "top" ? "column-reverse" : "column",
         textAlign: "center",
         justifyContent: "center",
-        gap: 1,
+        gap: 0.5,
         overflow: "hidden",
       }}
     >
       {src && (
         <Box
           sx={{
-            height: "50px",
+            height: "54px",
             aspectRatio: "1 / 1",
             flexGrow: 1,
             position: "relative",


### PR DESCRIPTION
## Summary
- Board switcher: apply input padding via the TextField input slot instead of MUI internal selectors; drop redundant popup indicator padding and font-size overrides
- Pictogram: tighten label gap and slightly increase image height for better balance at small sizes

## Test plan
- [ ] Verify board switcher input renders correctly (padding, pill shape) in browser
- [ ] Verify pictogram image/label spacing looks correct on a board