### PR TITLE
style(board-set-list): remove border from row more-options button

### DIFF
--- a/src/features/board/board-sets/board-set-list.tsx
+++ b/src/features/board/board-sets/board-set-list.tsx
@@ -111,6 +111,7 @@ export function BoardSetList({
                       aria-haspopup="menu"
                       aria-expanded={isMenuOpen ? "true" : undefined}
                       onClick={(event) => handleMenuOpen(event, boardSet)}
+                      sx={{ border: "none" }}
                     >
                       <MoreVertIcon />
                     </IconButton>


### PR DESCRIPTION
## Summary
- Drop the theme-default border from the per-row "more options" icon button in the board set list, since it read as noisy next to the row content

## Test plan
- [ ] Verify the more-options button in the board set list no longer shows a border, while other icon buttons app-wide are unaffected