### PR TITLE
fix(ui): misc drawer, board-set chip, and theme tweaks

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,7 +131,7 @@ an action:
 
 ```mermaid
 flowchart LR
-    tap["tile tap / Enter"] --> resolve["resolveButtonIntent<br/>navigate · compose · speakText · playAudio · runAction"]
+    tap["tile tap / Enter"] --> resolve["resolveButtonIntents<br/>navigate · compose · speakText · playAudio · runAction"]
     resolve --> dispatch["activateButton"]
     dispatch --> msg["append to message bar"]
     dispatch --> goto["navigate to board"]
@@ -152,7 +152,7 @@ hyperlinked, so a moved file never breaks this table.
 | `src/pages/`                                                             | Route entry components, each code-split via React Router's `lazy` route import.                                             |
 | `src/features/board/`                                                    | The entire board domain. `board-viewer.tsx` is the orchestrator.                                                            |
 | `src/features/board/grid·tile·pictogram/`                                | Render the tile grid and each pictogram.                                                                                    |
-| `src/features/board/activation/`                                         | Tap → typed intent → dispatch. Search `resolveButtonIntent`, `createButtonActivation`.                                      |
+| `src/features/board/activation/`                                         | Tap → typed intent → dispatch. Search `resolveButtonIntents`, `createButtonActivation`.                                     |
 | `src/features/board/message/`                                            | The message bar: accumulate parts, then `planPlayback` → TTS with per-part highlighting.                                    |
 | `src/features/board/navigation/`                                         | Board-to-board navigation over the router. Search `useBoardNavigation`, `boardPath`.                                        |
 | `src/features/board/keyboard/` + `grid/use-grid-keyboard.ts`             | Keyboard as a first-class input surface: grid navigation (`useGridKeyboard`) and message editing (`useBoardKeyboard`).      |
@@ -189,10 +189,11 @@ State has **five kinds**, each with one home:
    These change outside React (DB writes, the browser's `voiceschanged` event).
 4. **Persisted settings** — `createPersistedStore` (localStorage, written on every
    change): selected **language**, speech config (voice/rate/pitch/volume),
-   playback config, and AI shared context. Theme mode
-   persists separately as MUI's `mui-mode`, read pre-paint in `index.html`.
+   playback config, AI shared context, AI tone (`tone-store.ts`, key `ai-tone`), and
+   the onboarding-seen flag (`use-onboarding.ts`, key `hasSeenOnboarding`). Theme
+   mode persists separately as MUI's `mui-mode`, read pre-paint in `index.html`.
 5. **Local component state** — the in-progress message (`useMessage`), playback
-   progress, grid focus, selected tone. Never promoted to a global store.
+   progress, grid focus. Never promoted to a global store.
 
 **Cross-tab coherence** rides on `BroadcastChannel` (`board-sets-sync`) — one
 listener per tab, registered at module load and never tied to a component mount, so

--- a/src/app/library/library-drawer.tsx
+++ b/src/app/library/library-drawer.tsx
@@ -30,7 +30,7 @@ export function LibraryDrawer({
 
   const closeOnNavigate = variant === "temporary" ? onClose : undefined;
   const reducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
-  const animated = variant === "temporary" && !reducedMotion;
+  const animated = !reducedMotion;
 
   return (
     <Drawer

--- a/src/features/board/board-sets/board-set-info-dialog.tsx
+++ b/src/features/board/board-sets/board-set-info-dialog.tsx
@@ -7,7 +7,6 @@ import DialogTitle from "@mui/material/DialogTitle";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
-import { getEnglishLanguageName } from "@shared/utils/locale";
 import type { BoardSetRecord } from "../storage/boards-db";
 
 export interface BoardSetInfoDialogProps {
@@ -76,10 +75,6 @@ function buildChipLabels(boardSet: BoardSetRecord): string[] {
         columns: boardSet.gridColumns,
       }),
     );
-  }
-
-  if (boardSet.locale) {
-    labels.push(getEnglishLanguageName(boardSet.locale));
   }
 
   if (boardSet.license) {

--- a/src/shared/theme/theme-provider.tsx
+++ b/src/shared/theme/theme-provider.tsx
@@ -61,7 +61,6 @@ const themeOptions = {
             backgroundColor: SHELL_LIGHT,
             color: palette.text.primary,
             backgroundImage: "none",
-            borderBottom: `1px solid ${palette.divider}`,
             ...theme.applyStyles("dark", {
               backgroundColor: SHELL_DARK,
             }),


### PR DESCRIPTION
## Summary
- Always animate the library drawer regardless of variant
- Drop locale chip from board-set info dialog
- Remove divider border from theme app bar
- Update architecture docs for the resolveButtonIntent → resolveButtonIntents rename and new persisted store keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)