### PR TITLE
feat(speech-settings): slider value labels and settings tweaks

### DIFF
--- a/src/app/settings/language-settings.test.tsx
+++ b/src/app/settings/language-settings.test.tsx
@@ -18,14 +18,14 @@ function renderLanguageSettings() {
 }
 
 describe("LanguageSettings", () => {
-  test("disables the language select without the Translator", async () => {
+  test("hides the language select without the Translator", async () => {
     stubBuiltInAIUnsupported("Translator");
 
     const screen = await renderLanguageSettings();
 
     await expect
       .element(screen.getByRole("combobox", { name: "Language" }))
-      .toHaveAttribute("aria-disabled", "true");
+      .not.toBeInTheDocument();
   });
 
   test("enables the language select when the Translator is available, with no a11y violations", async () => {

--- a/src/app/settings/language-settings.tsx
+++ b/src/app/settings/language-settings.tsx
@@ -18,6 +18,10 @@ export function LanguageSettings() {
   const { languages, language, setLanguage } = useLanguage();
   const progress = useGlobalDownloadProgress("Translator");
 
+  if (!isSupported("Translator")) {
+    return null;
+  }
+
   return (
     <Stack spacing={2}>
       <FormControl size="small" fullWidth>
@@ -28,7 +32,6 @@ export function LanguageSettings() {
           labelId="language-select-label"
           id="language-select"
           value={language}
-          disabled={!isSupported("Translator")}
           onChange={(event) => setLanguage(event.target.value)}
         >
           {languages.map(({ code, name }) => (

--- a/src/app/settings/speech-settings.tsx
+++ b/src/app/settings/speech-settings.tsx
@@ -66,6 +66,7 @@ export function SpeechSettings() {
       min: SPEECH_RATE.min,
       max: SPEECH_RATE.max,
       onChange: setRate,
+      valueLabelFormat: (value: number) => `${value}x`,
     },
     {
       id: "pitch",
@@ -74,6 +75,7 @@ export function SpeechSettings() {
       min: SPEECH_PITCH.min,
       max: SPEECH_PITCH.max,
       onChange: setPitch,
+      valueLabelFormat: (value: number) => `${value}x`,
     },
     {
       id: "volume",
@@ -82,6 +84,7 @@ export function SpeechSettings() {
       min: SPEECH_VOLUME.min,
       max: SPEECH_VOLUME.max,
       onChange: setVolume,
+      valueLabelFormat: (value: number) => `${Math.round(value * 100)}%`,
     },
   ];
 
@@ -101,22 +104,25 @@ export function SpeechSettings() {
         </Select>
       </FormControl>
 
-      {speechControls.map(({ id, label, value, min, max, onChange }) => (
-        <Stack key={id} spacing={0.5}>
-          <Typography variant="body2" sx={{ color: "text.secondary" }}>
-            {label}
-          </Typography>
-          <Slider
-            aria-label={label}
-            valueLabelDisplay="auto"
-            value={value}
-            min={min}
-            max={max}
-            step={0.1}
-            onChange={(_event, newValue) => onChange(newValue)}
-          />
-        </Stack>
-      ))}
+      {speechControls.map(
+        ({ id, label, value, min, max, onChange, valueLabelFormat }) => (
+          <Stack key={id} spacing={0.5}>
+            <Typography variant="body2" sx={{ color: "text.secondary" }}>
+              {label}
+            </Typography>
+            <Slider
+              aria-label={label}
+              valueLabelDisplay="auto"
+              valueLabelFormat={valueLabelFormat}
+              value={value}
+              min={min}
+              max={max}
+              step={0.1}
+              onChange={(_event, newValue) => onChange(newValue)}
+            />
+          </Stack>
+        ),
+      )}
 
       <Button
         variant="contained"

--- a/src/features/board/navigation/board-switcher.test.tsx
+++ b/src/features/board/navigation/board-switcher.test.tsx
@@ -134,6 +134,20 @@ describe("BoardSwitcher", () => {
     expect(router.state.location.pathname).toBe("/sets/set-1/boards/root");
   });
 
+  test("clears the input on focus, showing the current board name as a placeholder, and restores it on blur", async () => {
+    const { screen } = await renderSwitcher("/sets/set-1/boards/root");
+
+    const combobox = screen.getByRole("combobox");
+    await expect.element(combobox).toHaveValue("Home");
+
+    await combobox.click();
+    await expect.element(combobox).toHaveValue("");
+    await expect.element(combobox).toHaveAttribute("placeholder", "Home");
+
+    await userEvent.tab();
+    await expect.element(combobox).toHaveValue("Home");
+  });
+
   test("shows the cached translated name for the active language, falling back to the raw name otherwise", async () => {
     await replaceBoardSet({
       boardSet: { setId: "set-2", name: "Set", rootBoardId: "root" },

--- a/src/features/board/navigation/board-switcher.tsx
+++ b/src/features/board/navigation/board-switcher.tsx
@@ -2,6 +2,7 @@ import Autocomplete from "@mui/material/Autocomplete";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
+import { useState } from "react";
 import { useBoardNavigation } from "./use-board-navigation";
 import { useSetBoards } from "./use-set-boards";
 
@@ -12,6 +13,7 @@ export interface BoardSwitcherProps {
 export function BoardSwitcher({ label }: BoardSwitcherProps) {
   const { setId, boardId, goToBoard } = useBoardNavigation();
   const { boards } = useSetBoards({ setId });
+  const [inputValue, setInputValue] = useState("");
 
   const selectedBoard = boards.find((board) => board.boardId === boardId);
 
@@ -34,10 +36,11 @@ export function BoardSwitcher({ label }: BoardSwitcherProps) {
     <Autocomplete
       disableClearable
       autoHighlight
-      selectOnFocus
       size="small"
       options={boards}
       value={selectedBoard}
+      inputValue={inputValue}
+      onInputChange={(_event, value) => setInputValue(value)}
       onChange={(_event, board) => goToBoard(board.boardId)}
       getOptionLabel={(board) => board.name}
       getOptionKey={(board) => board.boardId}
@@ -51,6 +54,8 @@ export function BoardSwitcher({ label }: BoardSwitcherProps) {
       renderInput={(params) => (
         <TextField
           {...params}
+          placeholder={selectedBoard.name}
+          onFocus={() => setInputValue("")}
           slotProps={{
             ...params.slotProps,
             htmlInput: {

--- a/src/features/board/navigation/board-switcher.tsx
+++ b/src/features/board/navigation/board-switcher.tsx
@@ -53,13 +53,6 @@ export function BoardSwitcher({ label }: BoardSwitcherProps) {
           {...params}
           slotProps={{
             ...params.slotProps,
-            input: {
-              ...params.slotProps?.input,
-              sx: {
-                paddingTop: 1,
-                paddingBottom: 1,
-              },
-            },
             htmlInput: {
               ...params.slotProps?.htmlInput,
               "aria-label": m.board(),


### PR DESCRIPTION
## Summary
- Format slider value labels in speech settings
- Hide language selector when Translator API unsupported
- Board switcher: clear input on focus with current board as placeholder
- Misc cleanup

## Commits
- feat(speech-settings): format slider value labels
- feat(language-settings): hide language selector when Translator unsupported
- feat(board-switcher): clear input on focus with current board as placeholder
- fix: cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)