### PR TITLE
feat(suggestions-settings): show unsupported message instead of hiding section

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "تعليمات مخصصة",
   "aiCustomInstructionsPlaceholder": "مثل: تحدث بنبرة ساخرة",
   "aiCustomInstructionsHelper": "صِغ الاقتراحات بأسلوبك الخاص.",
+  "suggestionsUnsupported": "تحتاج الاقتراحات إلى ذكاء اصطناعي مدمج، مُعد في نسخة سطح المكتب من Chrome أو Edge.",
   "suggestionsEnable": "تفعيل الاقتراحات",
   "suggestionsDownloading": "جارٍ تنزيل نموذج الذكاء الاصطناعي… {progress}%",
   "suggestionsDownloadingIndeterminate": "جارٍ تنزيل نموذج الذكاء الاصطناعي…",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Персонализирани инструкции",
   "aiCustomInstructionsPlaceholder": "напр. говори със саркастичен тон",
   "aiCustomInstructionsHelper": "Оформете предложенията с ваши думи.",
+  "suggestionsUnsupported": "Предложенията изискват вграден AI, настроен в настолна версия на Chrome или Edge.",
   "suggestionsEnable": "Включване на предложенията",
   "suggestionsDownloading": "Изтегляне на модела на ИИ… {progress}%",
   "suggestionsDownloadingIndeterminate": "Изтегляне на модела на ИИ…",

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "কাস্টম নির্দেশনা",
   "aiCustomInstructionsPlaceholder": "যেমন, ব্যঙ্গাত্মক সুরে কথা বলুন",
   "aiCustomInstructionsHelper": "নিজের ভাষায় পরামর্শগুলো গঠন করুন।",
+  "suggestionsUnsupported": "পরামর্শের জন্য বিল্ট-ইন AI প্রয়োজন, ডেস্কটপ Chrome বা Edge-এ সেট আপ করুন।",
   "suggestionsEnable": "পরামর্শ চালু করুন",
   "suggestionsDownloading": "AI মডেল ডাউনলোড হচ্ছে… {progress}%",
   "suggestionsDownloadingIndeterminate": "AI মডেল ডাউনলোড হচ্ছে…",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Vlastní pokyny",
   "aiCustomInstructionsPlaceholder": "např. mluv sarkastickým tónem",
   "aiCustomInstructionsHelper": "Formulujte návrhy vlastními slovy.",
+  "suggestionsUnsupported": "Návrhy vyžadují vestavěnou AI, nastavenou v desktopovém Chrome nebo Edge.",
   "suggestionsEnable": "Zapnout návrhy",
   "suggestionsDownloading": "Stahování modelu AI… {progress} %",
   "suggestionsDownloadingIndeterminate": "Stahování modelu AI…",

--- a/messages/da.json
+++ b/messages/da.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Tilpassede instruktioner",
   "aiCustomInstructionsPlaceholder": "f.eks. tal i en sarkastisk tone",
   "aiCustomInstructionsHelper": "Form forslagene med dine egne ord.",
+  "suggestionsUnsupported": "Forslag kræver indbygget AI, konfigureret i desktop Chrome eller Edge.",
   "suggestionsEnable": "Slå forslag til",
   "suggestionsDownloading": "Downloader AI-model… {progress}%",
   "suggestionsDownloadingIndeterminate": "Downloader AI-model…",

--- a/messages/de.json
+++ b/messages/de.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Benutzerdefinierte Anweisungen",
   "aiCustomInstructionsPlaceholder": "z. B. in sarkastischem Ton sprechen",
   "aiCustomInstructionsHelper": "Gestalte die Vorschläge mit deinen eigenen Worten.",
+  "suggestionsUnsupported": "Vorschläge benötigen integrierte KI, eingerichtet in Desktop-Chrome oder -Edge.",
   "suggestionsEnable": "Vorschläge aktivieren",
   "suggestionsDownloading": "KI-Modell wird heruntergeladen… {progress}%",
   "suggestionsDownloadingIndeterminate": "KI-Modell wird heruntergeladen…",

--- a/messages/el.json
+++ b/messages/el.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Προσαρμοσμένες οδηγίες",
   "aiCustomInstructionsPlaceholder": "π.χ. μίλα με σαρκαστικό τόνο",
   "aiCustomInstructionsHelper": "Διαμορφώστε τις προτάσεις με τα δικά σας λόγια.",
+  "suggestionsUnsupported": "Οι προτάσεις απαιτούν ενσωματωμένη AI, ρυθμισμένη σε Chrome ή Edge για υπολογιστή.",
   "suggestionsEnable": "Ενεργοποίηση προτάσεων",
   "suggestionsDownloading": "Λήψη μοντέλου AI… {progress}%",
   "suggestionsDownloadingIndeterminate": "Λήψη μοντέλου AI…",

--- a/messages/en.json
+++ b/messages/en.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g. speak in a sarcastic tone",
   "aiCustomInstructionsHelper": "Shape suggestions in your own words.",
+  "suggestionsUnsupported": "Suggestions need built-in AI, set up in desktop Chrome or Edge.",
   "suggestionsEnable": "Enable suggestions",
   "suggestionsDownloading": "Downloading AI model... {progress}%",
   "suggestionsDownloadingIndeterminate": "Downloading AI model...",

--- a/messages/es.json
+++ b/messages/es.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Instrucciones personalizadas",
   "aiCustomInstructionsPlaceholder": "p. ej., habla con un tono sarcástico",
   "aiCustomInstructionsHelper": "Da forma a las sugerencias con tus propias palabras.",
+  "suggestionsUnsupported": "Las sugerencias necesitan IA integrada, configurada en Chrome o Edge de escritorio.",
   "suggestionsEnable": "Activar sugerencias",
   "suggestionsDownloading": "Descargando modelo de IA… {progress}%",
   "suggestionsDownloadingIndeterminate": "Descargando modelo de IA…",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Mukautetut ohjeet",
   "aiCustomInstructionsPlaceholder": "esim. puhu sarkastisella sävyllä",
   "aiCustomInstructionsHelper": "Muotoile ehdotukset omin sanoin.",
+  "suggestionsUnsupported": "Ehdotukset vaativat sisäänrakennetun tekoälyn, joka on määritetty työpöytäversion Chromessa tai Edgessä.",
   "suggestionsEnable": "Ota ehdotukset käyttöön",
   "suggestionsDownloading": "Ladataan tekoälymallia… {progress} %",
   "suggestionsDownloadingIndeterminate": "Ladataan tekoälymallia…",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Instructions personnalisées",
   "aiCustomInstructionsPlaceholder": "p. ex. parler sur un ton sarcastique",
   "aiCustomInstructionsHelper": "Façonnez les suggestions avec vos propres mots.",
+  "suggestionsUnsupported": "Les suggestions nécessitent l’IA intégrée, configurée dans Chrome ou Edge pour ordinateur.",
   "suggestionsEnable": "Activer les suggestions",
   "suggestionsDownloading": "Téléchargement du modèle d'IA… {progress} %",
   "suggestionsDownloadingIndeterminate": "Téléchargement du modèle d'IA…",

--- a/messages/he.json
+++ b/messages/he.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "הוראות מותאמות אישית",
   "aiCustomInstructionsPlaceholder": "למשל: דבר בטון סרקסטי",
   "aiCustomInstructionsHelper": "עצבו את ההצעות במילים שלכם.",
+  "suggestionsUnsupported": "ההצעות דורשות בינה מלאכותית מובנית, המוגדרת בגרסת שולחן העבודה של Chrome או Edge.",
   "suggestionsEnable": "הפעלת הצעות",
   "suggestionsDownloading": "הורדת מודל ה-AI… {progress}%",
   "suggestionsDownloadingIndeterminate": "הורדת מודל ה-AI…",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "कस्टम निर्देश",
   "aiCustomInstructionsPlaceholder": "जैसे, व्यंग्यात्मक लहजे में बोलें",
   "aiCustomInstructionsHelper": "सुझावों को अपने शब्दों में ढालें।",
+  "suggestionsUnsupported": "सुझावों के लिए बिल्ट-इन AI चाहिए, जिसे डेस्कटॉप Chrome या Edge में सेट किया गया हो।",
   "suggestionsEnable": "सुझाव चालू करें",
   "suggestionsDownloading": "AI मॉडल डाउनलोड हो रहा है… {progress}%",
   "suggestionsDownloadingIndeterminate": "AI मॉडल डाउनलोड हो रहा है…",

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Prilagođene upute",
   "aiCustomInstructionsPlaceholder": "npr. govori sarkastičnim tonom",
   "aiCustomInstructionsHelper": "Oblikujte prijedloge svojim riječima.",
+  "suggestionsUnsupported": "Prijedlozi zahtijevaju ugrađenu AI, postavljenu u Chromeu ili Edgeu za računala.",
   "suggestionsEnable": "Uključi prijedloge",
   "suggestionsDownloading": "Preuzimanje AI modela… {progress} %",
   "suggestionsDownloadingIndeterminate": "Preuzimanje AI modela…",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Egyéni utasítások",
   "aiCustomInstructionsPlaceholder": "pl. beszélj szarkasztikus hangnemben",
   "aiCustomInstructionsHelper": "Alakítsd a javaslatokat a saját szavaiddal.",
+  "suggestionsUnsupported": "A javaslatokhoz beépített AI szükséges, asztali Chrome-ban vagy Edge-ben beállítva.",
   "suggestionsEnable": "Javaslatok bekapcsolása",
   "suggestionsDownloading": "MI-modell letöltése… {progress}%",
   "suggestionsDownloadingIndeterminate": "MI-modell letöltése…",

--- a/messages/id.json
+++ b/messages/id.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Instruksi khusus",
   "aiCustomInstructionsPlaceholder": "mis. berbicara dengan nada sarkastis",
   "aiCustomInstructionsHelper": "Bentuk saran dengan kata-katamu sendiri.",
+  "suggestionsUnsupported": "Saran memerlukan AI bawaan, yang disiapkan di Chrome atau Edge versi desktop.",
   "suggestionsEnable": "Aktifkan saran",
   "suggestionsDownloading": "Mengunduh model AI… {progress}%",
   "suggestionsDownloadingIndeterminate": "Mengunduh model AI…",

--- a/messages/it.json
+++ b/messages/it.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Istruzioni personalizzate",
   "aiCustomInstructionsPlaceholder": "ad es. parla con tono sarcastico",
   "aiCustomInstructionsHelper": "Modella i suggerimenti con le tue parole.",
+  "suggestionsUnsupported": "I suggerimenti richiedono l’IA integrata, configurata su Chrome o Edge desktop.",
   "suggestionsEnable": "Attiva i suggerimenti",
   "suggestionsDownloading": "Download del modello IA… {progress}%",
   "suggestionsDownloadingIndeterminate": "Download del modello IA…",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "カスタム指示",
   "aiCustomInstructionsPlaceholder": "例：皮肉っぽい口調で話す",
   "aiCustomInstructionsHelper": "自分の言葉で提案を形づくりましょう。",
+  "suggestionsUnsupported": "提案には組み込みAIが必要です。デスクトップ版のChromeまたはEdgeで設定してください。",
   "suggestionsEnable": "提案を有効にする",
   "suggestionsDownloading": "AI モデルをダウンロード中… {progress}%",
   "suggestionsDownloadingIndeterminate": "AI モデルをダウンロード中…",

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "ಕಸ್ಟಮ್ ಸೂಚನೆಗಳು",
   "aiCustomInstructionsPlaceholder": "ಉದಾ., ವ್ಯಂಗ್ಯ ಧ್ವನಿಯಲ್ಲಿ ಮಾತನಾಡಿ",
   "aiCustomInstructionsHelper": "ನಿಮ್ಮ ಸ್ವಂತ ಮಾತುಗಳಲ್ಲಿ ಸಲಹೆಗಳನ್ನು ರೂಪಿಸಿ.",
+  "suggestionsUnsupported": "ಸಲಹೆಗಳಿಗೆ ಅಂತರ್ನಿರ್ಮಿತ AI ಅಗತ್ಯವಿದೆ, ಡೆಸ್ಕ್‌ಟಾಪ್ Chrome ಅಥವಾ Edge ನಲ್ಲಿ ಹೊಂದಿಸಲಾಗಿದೆ.",
   "suggestionsEnable": "ಸಲಹೆಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ",
   "suggestionsDownloading": "AI ಮಾದರಿ ಡೌನ್‌ಲೋಡ್ ಆಗುತ್ತಿದೆ… {progress}%",
   "suggestionsDownloadingIndeterminate": "AI ಮಾದರಿ ಡೌನ್‌ಲೋಡ್ ಆಗುತ್ತಿದೆ…",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "맞춤 지침",
   "aiCustomInstructionsPlaceholder": "예: 냉소적인 어조로 말하기",
   "aiCustomInstructionsHelper": "자신만의 언어로 제안을 다듬어 보세요.",
+  "suggestionsUnsupported": "제안 기능은 내장 AI가 필요하며, 데스크톱 Chrome 또는 Edge에서 설정해야 합니다.",
   "suggestionsEnable": "제안 켜기",
   "suggestionsDownloading": "AI 모델 다운로드 중… {progress}%",
   "suggestionsDownloadingIndeterminate": "AI 모델 다운로드 중…",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Aangepaste instructies",
   "aiCustomInstructionsPlaceholder": "bijv. spreek op een sarcastische toon",
   "aiCustomInstructionsHelper": "Geef de suggesties vorm in je eigen woorden.",
+  "suggestionsUnsupported": "Suggesties hebben ingebouwde AI nodig, ingesteld in desktop Chrome of Edge.",
   "suggestionsEnable": "Suggesties inschakelen",
   "suggestionsDownloading": "AI-model downloaden… {progress}%",
   "suggestionsDownloadingIndeterminate": "AI-model downloaden…",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Instrukcje niestandardowe",
   "aiCustomInstructionsPlaceholder": "np. mów sarkastycznym tonem",
   "aiCustomInstructionsHelper": "Kształtuj sugestie własnymi słowami.",
+  "suggestionsUnsupported": "Sugestie wymagają wbudowanej AI, skonfigurowanej w wersji Chrome lub Edge na komputer.",
   "suggestionsEnable": "Włącz sugestie",
   "suggestionsDownloading": "Pobieranie modelu AI… {progress}%",
   "suggestionsDownloadingIndeterminate": "Pobieranie modelu AI…",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Instruções personalizadas",
   "aiCustomInstructionsPlaceholder": "ex.: fale com um tom sarcástico",
   "aiCustomInstructionsHelper": "Molde as sugestões com suas próprias palavras.",
+  "suggestionsUnsupported": "As sugestões precisam de IA integrada, configurada no Chrome ou Edge para desktop.",
   "suggestionsEnable": "Ativar sugestões",
   "suggestionsDownloading": "Baixando modelo de IA… {progress}%",
   "suggestionsDownloadingIndeterminate": "Baixando modelo de IA…",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Instrucțiuni personalizate",
   "aiCustomInstructionsPlaceholder": "ex. vorbește pe un ton sarcastic",
   "aiCustomInstructionsHelper": "Modelează sugestiile cu propriile tale cuvinte.",
+  "suggestionsUnsupported": "Sugestiile necesită AI integrată, configurată în Chrome sau Edge pentru desktop.",
   "suggestionsEnable": "Activează sugestiile",
   "suggestionsDownloading": "Se descarcă modelul AI… {progress}%",
   "suggestionsDownloadingIndeterminate": "Se descarcă modelul AI…",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Пользовательские инструкции",
   "aiCustomInstructionsPlaceholder": "напр. говори саркастичным тоном",
   "aiCustomInstructionsHelper": "Формулируйте предложения своими словами.",
+  "suggestionsUnsupported": "Для подсказок нужен встроенный ИИ, настроенный в настольной версии Chrome или Edge.",
   "suggestionsEnable": "Включить предложения",
   "suggestionsDownloading": "Загрузка модели ИИ… {progress}%",
   "suggestionsDownloadingIndeterminate": "Загрузка модели ИИ…",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Vlastné pokyny",
   "aiCustomInstructionsPlaceholder": "napr. hovor sarkastickým tónom",
   "aiCustomInstructionsHelper": "Formulujte návrhy vlastnými slovami.",
+  "suggestionsUnsupported": "Návrhy vyžadujú vstavanú AI nastavenú v desktopovom Chrome alebo Edge.",
   "suggestionsEnable": "Zapnúť návrhy",
   "suggestionsDownloading": "Sťahovanie modelu AI… {progress} %",
   "suggestionsDownloadingIndeterminate": "Sťahovanie modelu AI…",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Navodila po meri",
   "aiCustomInstructionsPlaceholder": "npr. govori sarkastičnim tonom",
   "aiCustomInstructionsHelper": "Oblikujte predloge s svojimi besedami.",
+  "suggestionsUnsupported": "Predlogi zahtevajo vgrajeno umetno inteligenco, nastavljeno v namiznem Chromu ali Edgeu.",
   "suggestionsEnable": "Vklopi predloge",
   "suggestionsDownloading": "Prenašanje modela UI… {progress} %",
   "suggestionsDownloadingIndeterminate": "Prenašanje modela UI…",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Anpassade instruktioner",
   "aiCustomInstructionsPlaceholder": "t.ex. tala med sarkastisk ton",
   "aiCustomInstructionsHelper": "Forma förslagen med dina egna ord.",
+  "suggestionsUnsupported": "Förslag kräver inbyggd AI, konfigurerad i Chrome eller Edge för dator.",
   "suggestionsEnable": "Aktivera förslag",
   "suggestionsDownloading": "Laddar ner AI-modell… {progress}%",
   "suggestionsDownloadingIndeterminate": "Laddar ner AI-modell…",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "தனிப்பயன் வழிமுறைகள்",
   "aiCustomInstructionsPlaceholder": "எ.கா., கிண்டலான தொனியில் பேசு",
   "aiCustomInstructionsHelper": "உங்கள் சொந்த வார்த்தைகளில் பரிந்துரைகளை வடிவமைக்கவும்.",
+  "suggestionsUnsupported": "பரிந்துரைகளுக்கு உள்ளமைக்கப்பட்ட AI தேவை, டெஸ்க்டாப் Chrome அல்லது Edge-இல் அமைக்கப்பட வேண்டும்.",
   "suggestionsEnable": "பரிந்துரைகளை இயக்கு",
   "suggestionsDownloading": "AI மாடல் பதிவிறக்கப்படுகிறது… {progress}%",
   "suggestionsDownloadingIndeterminate": "AI மாடல் பதிவிறக்கப்படுகிறது…",

--- a/messages/te.json
+++ b/messages/te.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "అనుకూల సూచనలు",
   "aiCustomInstructionsPlaceholder": "ఉదా., వ్యంగ్యమైన స్వరంతో మాట్లాడు",
   "aiCustomInstructionsHelper": "మీ సొంత మాటల్లో సూచనలను రూపొందించండి.",
+  "suggestionsUnsupported": "సూచనలకు అంతర్నిర్మిత AI అవసరం, డెస్క్‌టాప్ Chrome లేదా Edge‌లో సెటప్ చేయాలి.",
   "suggestionsEnable": "సూచనలను ప్రారంభించండి",
   "suggestionsDownloading": "AI మోడల్ డౌన్‌లోడ్ అవుతోంది… {progress}%",
   "suggestionsDownloadingIndeterminate": "AI మోడల్ డౌన్‌లోడ్ అవుతోంది…",

--- a/messages/th.json
+++ b/messages/th.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "คำสั่งที่กำหนดเอง",
   "aiCustomInstructionsPlaceholder": "เช่น พูดด้วยน้ำเสียงประชดประชัน",
   "aiCustomInstructionsHelper": "ปรับคำแนะนำให้เป็นสำนวนของคุณเอง",
+  "suggestionsUnsupported": "คำแนะนำต้องใช้ AI ในตัว ซึ่งตั้งค่าไว้ใน Chrome หรือ Edge บนเดสก์ท็อป",
   "suggestionsEnable": "เปิดใช้คำแนะนำ",
   "suggestionsDownloading": "กำลังดาวน์โหลดโมเดล AI… {progress}%",
   "suggestionsDownloadingIndeterminate": "กำลังดาวน์โหลดโมเดล AI…",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Özel talimatlar",
   "aiCustomInstructionsPlaceholder": "ör. alaycı bir tonda konuş",
   "aiCustomInstructionsHelper": "Önerileri kendi kelimelerinizle şekillendirin.",
+  "suggestionsUnsupported": "Önerilerin çalışması için masaüstü Chrome veya Edge’de kurulmuş yerleşik AI gerekir.",
   "suggestionsEnable": "Önerileri aç",
   "suggestionsDownloading": "Yapay zeka modeli indiriliyor… %{progress}",
   "suggestionsDownloadingIndeterminate": "Yapay zeka modeli indiriliyor…",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Власні інструкції",
   "aiCustomInstructionsPlaceholder": "напр. говори саркастичним тоном",
   "aiCustomInstructionsHelper": "Формулюйте пропозиції власними словами.",
+  "suggestionsUnsupported": "Для пропозицій потрібен вбудований ШІ, налаштований у настільній версії Chrome або Edge.",
   "suggestionsEnable": "Увімкнути пропозиції",
   "suggestionsDownloading": "Завантаження моделі ШІ… {progress}%",
   "suggestionsDownloadingIndeterminate": "Завантаження моделі ШІ…",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "Hướng dẫn tùy chỉnh",
   "aiCustomInstructionsPlaceholder": "ví dụ: nói với giọng điệu châm biếm",
   "aiCustomInstructionsHelper": "Định hình gợi ý theo cách nói của riêng bạn.",
+  "suggestionsUnsupported": "Gợi ý cần AI tích hợp sẵn, được thiết lập trên Chrome hoặc Edge phiên bản máy tính.",
   "suggestionsEnable": "Bật gợi ý",
   "suggestionsDownloading": "Đang tải mô hình AI xuống… {progress}%",
   "suggestionsDownloadingIndeterminate": "Đang tải mô hình AI xuống…",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -90,6 +90,7 @@
   "aiCustomInstructions": "自定义指令",
   "aiCustomInstructionsPlaceholder": "例如：以讽刺的语气说话",
   "aiCustomInstructionsHelper": "用你自己的话塑造建议。",
+  "suggestionsUnsupported": "建议功能需要内置 AI，需在桌面版 Chrome 或 Edge 中设置。",
   "suggestionsEnable": "启用建议",
   "suggestionsDownloading": "正在下载 AI 模型… {progress}%",
   "suggestionsDownloadingIndeterminate": "正在下载 AI 模型…",

--- a/src/app/settings/settings-drawer.tsx
+++ b/src/app/settings/settings-drawer.tsx
@@ -17,7 +17,6 @@ import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
 import { ExternalLink } from "@shared/components/external-link";
 import { safeAreaGutter, safeAreaInset } from "@shared/theme/safe-area";
-import { isSupported } from "@shayc/react-built-in-ai";
 import { AppearanceSettings } from "./appearance-settings";
 import { BoardSettings } from "./board-settings";
 import { LanguageSettings } from "./language-settings";
@@ -123,21 +122,13 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
           <SpeechSettings />
         </Stack>
 
-        {isSupported("Rewriter") && (
-          <>
-            <Divider sx={{ my: 3 }} />
+        <Divider sx={{ my: 3 }} />
 
-            <Typography
-              component="h3"
-              variant="subtitle1"
-              sx={sectionHeadingSx}
-            >
-              <AutoAwesomeIcon fontSize="small" />
-              {m.settingsSectionSuggestions()}
-            </Typography>
-            <SuggestionsSettings />
-          </>
-        )}
+        <Typography component="h3" variant="subtitle1" sx={sectionHeadingSx}>
+          <AutoAwesomeIcon fontSize="small" />
+          {m.settingsSectionSuggestions()}
+        </Typography>
+        <SuggestionsSettings />
 
         <Divider sx={{ my: 3 }} />
 

--- a/src/app/settings/suggestions-settings.test.tsx
+++ b/src/app/settings/suggestions-settings.test.tsx
@@ -19,11 +19,14 @@ function renderSuggestionsSettings() {
 }
 
 describe("SuggestionsSettings", () => {
-  test("renders nothing when the rewriter is unsupported", async () => {
+  test("shows an unsupported message instead of controls when the rewriter is unsupported", async () => {
     stubBuiltInAIUnsupported("Proofreader", "Rewriter", "Translator");
 
     const screen = await renderSuggestionsSettings();
 
+    await expect
+      .element(screen.getByText(/Suggestions need built-in AI/i))
+      .toBeVisible();
     await expect
       .element(screen.getByRole("textbox", { name: "Custom instructions" }))
       .not.toBeInTheDocument();

--- a/src/app/settings/suggestions-settings.tsx
+++ b/src/app/settings/suggestions-settings.tsx
@@ -1,5 +1,6 @@
 import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
+import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
 import { rewriterLanguageOptions } from "@shared/built-in-ai/engine-language-options";
 import {
@@ -20,7 +21,11 @@ export function SuggestionsSettings() {
   const toneControlState = deriveToneControlState(rewriter.status);
 
   if (!isSupported("Rewriter")) {
-    return null;
+    return (
+      <Typography sx={{ typography: "body2", color: "text.secondary" }}>
+        {m.suggestionsUnsupported()}
+      </Typography>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- Show a localized message explaining that suggestions need built-in AI (set up in desktop Chrome/Edge) instead of silently hiding the whole suggestions section when the Rewriter API is unsupported
- Add the new `suggestionsUnsupported` string to `en.json` and translate it across all 34 supported locales

## Test plan
- [x] Updated `suggestions-settings.test.tsx` to assert the unsupported message renders when built-in AI APIs are stubbed as unsupported
- [x] Verified all locale JSON files parse and diffs are minimal (single line added per file)