### PR TITLE
test(board-set-info-dialog): drop locale chip assertion

### DIFF
--- a/src/features/board/board-sets/board-set-info-dialog.test.tsx
+++ b/src/features/board/board-sets/board-set-info-dialog.test.tsx
@@ -16,7 +16,7 @@ describe("BoardSetInfoDialog", () => {
     await expect.element(screen.getByText("By Jane")).toBeInTheDocument();
   });
 
-  test("builds chips from grid dimensions, locale, and license", async () => {
+  test("builds chips from grid dimensions and license", async () => {
     const screen = await render(
       <BoardSetInfoDialog
         boardSet={makeBoardSet({
@@ -30,7 +30,6 @@ describe("BoardSetInfoDialog", () => {
     );
 
     await expect.element(screen.getByText("2×3 grid")).toBeInTheDocument();
-    await expect.element(screen.getByText("English")).toBeInTheDocument();
     await expect.element(screen.getByText("CC BY-SA 4.0")).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
- fix(ui) #682 removed the locale chip from the board-set info dialog but left the test asserting `getByText("English")`, breaking CI on main
- Update the test to match current behavior (grid dimensions + license chips only)

## Test plan
- [x] `npx vitest run src/features/board/board-sets/board-set-info-dialog.test.tsx` — 6/6 pass