### PR TITLE
ci: cancel superseded workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ["main"]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary
- Adds a `concurrency` group keyed on `github.ref` with `cancel-in-progress: true` so a new push to the same branch/PR cancels any CI run still in progress for it, instead of both running to completion.

## Test plan
- [ ] Push two commits in quick succession to a PR branch and confirm the first run is cancelled in the Actions tab.