### PR TITLE
Make IDB upgrade version-bump safe and 404 invalid ids

### DIFF
--- a/src/app/routing/loaders/board-loader.test.ts
+++ b/src/app/routing/loaders/board-loader.test.ts
@@ -1,0 +1,31 @@
+import { resetBoardsDB } from "@features/board/testing";
+import type { LoaderFunctionArgs } from "react-router";
+import { beforeEach, describe, expect, test } from "vitest";
+import { boardLoader } from "./board-loader";
+
+function callLoader(setId: string, boardId: string): Promise<unknown> {
+  const args = {
+    request: new Request("http://localhost/"),
+    params: { setId, boardId },
+  } as unknown as LoaderFunctionArgs;
+
+  return boardLoader(args);
+}
+
+describe("boardLoader", () => {
+  beforeEach(async () => {
+    await resetBoardsDB();
+  });
+
+  test("throws 404 for an oversize boardId", async () => {
+    await expect(callLoader("set-1", "x".repeat(256))).rejects.toMatchObject({
+      init: { status: 404 },
+    });
+  });
+
+  test("throws 404 when the board does not exist", async () => {
+    await expect(callLoader("set-1", "missing-board")).rejects.toMatchObject({
+      init: { status: 404 },
+    });
+  });
+});

--- a/src/app/routing/loaders/board-loader.ts
+++ b/src/app/routing/loaders/board-loader.ts
@@ -1,6 +1,7 @@
 import {
   BoardNotFoundError,
   hydrateBoard,
+  InvalidIdError,
   resolveTranslatedBoard,
   type Board,
 } from "@features/board";
@@ -23,7 +24,10 @@ export async function boardLoader({
 
     return await resolveTranslatedBoard(setId, board, language, request.signal);
   } catch (error) {
-    if (error instanceof BoardNotFoundError) {
+    if (
+      error instanceof BoardNotFoundError ||
+      error instanceof InvalidIdError
+    ) {
       throw data(m.errorBoardNotFound(), { status: 404 });
     }
 

--- a/src/app/routing/loaders/board-set-index-loader.test.ts
+++ b/src/app/routing/loaders/board-set-index-loader.test.ts
@@ -33,4 +33,12 @@ describe("boardSetIndexLoader", () => {
       init: { status: 404 },
     });
   });
+
+  test("throws 404 for an oversize setId", async () => {
+    await seedBoardSets([]);
+
+    await expect(callLoader("x".repeat(256))).rejects.toMatchObject({
+      init: { status: 404 },
+    });
+  });
 });

--- a/src/app/routing/loaders/board-set-index-loader.ts
+++ b/src/app/routing/loaders/board-set-index-loader.ts
@@ -1,4 +1,4 @@
-import { boardSetPath, getBoardSet } from "@features/board";
+import { boardSetPath, getBoardSet, InvalidIdError } from "@features/board";
 import { m } from "@paraglide/messages.js";
 import { data, redirect, type LoaderFunctionArgs } from "react-router";
 
@@ -6,7 +6,16 @@ export async function boardSetIndexLoader({
   params,
 }: LoaderFunctionArgs): Promise<Response> {
   const { setId } = params;
-  const boardSet = setId ? await getBoardSet(setId) : undefined;
+  let boardSet;
+  try {
+    boardSet = setId ? await getBoardSet(setId) : undefined;
+  } catch (error) {
+    if (error instanceof InvalidIdError) {
+      boardSet = undefined;
+    } else {
+      throw error;
+    }
+  }
 
   if (!boardSet) {
     throw data(m.errorBoardSetNotFound(), { status: 404 });

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -19,7 +19,11 @@ export {
 export { BoardSwitcher } from "./navigation/board-switcher";
 export { NavButtons } from "./navigation/nav-buttons";
 export { hydrateBoard } from "./storage/board-hydration";
-export { BoardNotFoundError, getBoardSet } from "./storage/boards-db";
+export {
+  BoardNotFoundError,
+  getBoardSet,
+  InvalidIdError,
+} from "./storage/boards-db";
 export { resolveTranslatedBoard } from "./translation/resolve-translated-board";
 
 export type { BoardSetRecord } from "./storage/boards-db";

--- a/src/features/board/storage/boards-db.test.ts
+++ b/src/features/board/storage/boards-db.test.ts
@@ -7,6 +7,7 @@ import {
   getAssetBlob,
   getBoard,
   getBoardsDB,
+  InvalidIdError,
   listBoards,
   listBoardSets,
   replaceBoardSet,
@@ -177,6 +178,16 @@ describe("replaceBoardSet", () => {
         }),
       ),
     ).rejects.toThrow("Invalid setId");
+  });
+
+  test("rejects empty setId with a typed InvalidIdError", async () => {
+    await expect(
+      replaceBoardSet(
+        makeReplaceInput({
+          boardSet: { setId: "", name: "Bad", rootBoardId: "root-1" },
+        }),
+      ),
+    ).rejects.toBeInstanceOf(InvalidIdError);
   });
 
   test("rejects setId longer than 255 characters", async () => {

--- a/src/features/board/storage/boards-db.ts
+++ b/src/features/board/storage/boards-db.ts
@@ -36,6 +36,15 @@ export class BoardNotFoundError extends Error {
   }
 }
 
+const MAX_ID_LENGTH = 255;
+
+export class InvalidIdError extends Error {
+  constructor(fieldName: string) {
+    super(`Invalid ${fieldName}: must be 1-${MAX_ID_LENGTH} characters`);
+    this.name = "InvalidIdError";
+  }
+}
+
 export interface UpsertBoardSetInput {
   setId: string;
   name: string;
@@ -95,13 +104,9 @@ function normalizePath(rawPath: string): string {
   return normalized;
 }
 
-const MAX_ID_LENGTH = 255;
-
 function validateId(id: string, fieldName: string): void {
   if (!id || id.length > MAX_ID_LENGTH) {
-    throw new Error(
-      `Invalid ${fieldName}: must be 1-${MAX_ID_LENGTH} characters`,
-    );
+    throw new InvalidIdError(fieldName);
   }
 }
 
@@ -128,19 +133,31 @@ export async function closeBoardsDB(): Promise<void> {
 
 function openConnection(): Promise<BoardsDB> {
   return openDB<BoardsDBSchema>(DB_NAME, DB_VERSION, {
-    upgrade(db) {
-      const boardSets = db.createObjectStore("boardSets", { keyPath: "setId" });
-      boardSets.createIndex("byUpdatedAt", "updatedAt");
+    upgrade(db, oldVersion) {
+      if (oldVersion < 1) {
+        const boardSets = db.createObjectStore("boardSets", {
+          keyPath: "setId",
+        });
+        boardSets.createIndex("byUpdatedAt", "updatedAt");
 
-      const boards = db.createObjectStore("boards", {
-        keyPath: ["setId", "boardId"],
-      });
-      boards.createIndex("bySetId", "setId");
+        const boards = db.createObjectStore("boards", {
+          keyPath: ["setId", "boardId"],
+        });
+        boards.createIndex("bySetId", "setId");
 
-      const assets = db.createObjectStore("assets", {
-        keyPath: ["setId", "path"],
-      });
-      assets.createIndex("bySetId", "setId");
+        const assets = db.createObjectStore("assets", {
+          keyPath: ["setId", "path"],
+        });
+        assets.createIndex("bySetId", "setId");
+      }
+    },
+    blocked(currentVersion, blockedVersion) {
+      console.warn(
+        `boards-db upgrade to v${blockedVersion} blocked by a tab holding v${currentVersion}`,
+      );
+    },
+    blocking() {
+      void closeBoardsDB();
     },
     terminated() {
       connection = null;


### PR DESCRIPTION
## Summary
- `upgrade()` in `boards-db.ts` unconditionally created object stores; wrap in a version staircase (`if (oldVersion < 1)`) so the next `DB_VERSION` bump doesn't throw `ConstraintError`.
- Add `blocked`/`blocking` handlers: a version bump with multiple tabs open now closes the stale connection instead of hanging silently (with a `console.warn` on the blocked side).
- Add a typed `InvalidIdError` (instead of a generic `Error`) for empty/oversize ids, and route it to the existing localized 404 path in `board-loader.ts` and `board-set-index-loader.ts`, alongside `BoardNotFoundError`.

No behavior change today except crash → 404 for malformed URLs (e.g. an oversize `setId`/`boardId`).

## Test plan
- [x] `npx vitest run src/features/board/storage/boards-db.test.ts src/app/routing/loaders` — new + existing tests pass
- [x] `npm test` (full suite) — 479 tests pass
- [x] `npx tsc -b` — clean
- [x] `npm run lint` — clean
- [ ] Manual: dev server, navigate to `/sets/<300-char-id>` → localized 404 page, not a crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)