### PR TITLE
fix: correct spell merge bug and remove play button rtl fix

### DIFF
--- a/src/features/board/activation/button-activation.test.ts
+++ b/src/features/board/activation/button-activation.test.ts
@@ -119,7 +119,7 @@ describe("createButtonActivation", () => {
     expect(committed[0].id).toBeTruthy();
   });
 
-  test("backspace removes the last part via setParts", () => {
+  test("backspace removes a character from a text-only last part via setParts", () => {
     const message = createMessageStub([
       { id: "1", label: "hello" },
       { id: "2", label: "world" },
@@ -130,6 +130,7 @@ describe("createButtonActivation", () => {
 
     expect(message.setParts).toHaveBeenCalledWith([
       { id: "1", label: "hello" },
+      { id: "2", label: "worl" },
     ]);
   });
 

--- a/src/features/board/keyboard/use-board-keyboard.test.tsx
+++ b/src/features/board/keyboard/use-board-keyboard.test.tsx
@@ -15,7 +15,7 @@ describe("board keyboard shortcuts", () => {
     stubAudio();
   });
 
-  test("Backspace from a focused tile removes the last message part", async () => {
+  test("Backspace from a focused tile removes a character from a text-only message part", async () => {
     const screen = await renderBoardViewer(TWO_TILE_BOARD);
     await screen.getByRole("button", { name: "hello" }).click();
     await screen.getByRole("button", { name: "world" }).click();
@@ -30,7 +30,7 @@ describe("board keyboard shortcuts", () => {
 
     await vi.waitFor(() => {
       expect(speech.speak.mock.calls).toHaveLength(1);
-      expect(speech.speak.mock.calls[0][0].text).toBe("hello");
+      expect(speech.speak.mock.calls[0][0].text).toBe("hello worl");
     });
   });
 
@@ -46,7 +46,7 @@ describe("board keyboard shortcuts", () => {
     await screen.getByRole("button", { name: "Play message" }).click();
 
     await vi.waitFor(() => {
-      expect(speech.speak.mock.calls[0][0].text).toBe("hello");
+      expect(speech.speak.mock.calls[0][0].text).toBe("hello worl");
     });
   });
 

--- a/src/features/board/message/message-transforms.test.ts
+++ b/src/features/board/message/message-transforms.test.ts
@@ -51,16 +51,25 @@ describe("appendTextToLastPart", () => {
     expect(parts[0].id).toBeTruthy();
   });
 
-  test("appends text to the last part without mangling its id or other content", () => {
-    const original: MessagePart[] = [
-      { id: "1", label: "ca", imageSrc: "img.png" },
-    ];
+  test("appends text to a purely text-only last part", () => {
+    const original: MessagePart[] = [{ id: "1", label: "ca" }];
 
     const parts = appendTextToLastPart(original, "t");
 
     expect(parts).toHaveLength(1);
     expect(parts[0].id).toBe("1");
     expect(parts[0].label).toBe("cat");
+  });
+
+  test("starts a new part if the last part has media", () => {
+    const original: MessagePart[] = [
+      { id: "1", label: "ca", imageSrc: "img.png" },
+    ];
+
+    const parts = appendTextToLastPart(original, "t");
+
+    expect(parts).toHaveLength(2);
+    expect(parts[1].label).toBe("t");
     expect(parts[0].imageSrc).toBe("img.png");
   });
 

--- a/src/features/board/message/message-transforms.test.ts
+++ b/src/features/board/message/message-transforms.test.ts
@@ -92,17 +92,38 @@ describe("appendTextToLastPart", () => {
 });
 
 describe("dropLastPart", () => {
-  test("removes the last part", () => {
+  test("removes a single character if the last part is text-only", () => {
     const parts = dropLastPart([
       { id: "1", label: "hello" },
       { id: "2", label: "world" },
     ]);
 
+    expect(parts).toEqual([
+      { id: "1", label: "hello" },
+      { id: "2", label: "worl" },
+    ]);
+  });
+
+  test("removes the entire part if it is text-only but has 1 or 0 characters", () => {
+    const parts = dropLastPart([
+      { id: "1", label: "hello" },
+      { id: "2", label: "w" },
+    ]);
+
     expect(parts).toEqual([{ id: "1", label: "hello" }]);
   });
 
-  test("returns an empty array when there is only one part", () => {
-    expect(dropLastPart([{ id: "1", label: "hi" }])).toEqual([]);
+  test("removes the entire part if it is not text-only", () => {
+    const parts = dropLastPart([
+      { id: "1", label: "hello" },
+      { id: "2", label: "world", imageSrc: "img.png" },
+    ]);
+
+    expect(parts).toEqual([{ id: "1", label: "hello" }]);
+  });
+
+  test("returns an empty array when there is only one part and it gets removed", () => {
+    expect(dropLastPart([{ id: "1", label: "h" }])).toEqual([]);
   });
 
   test("returns an empty array when already empty", () => {

--- a/src/features/board/message/message-transforms.ts
+++ b/src/features/board/message/message-transforms.ts
@@ -21,8 +21,14 @@ export function appendTextToLastPart(
   text: string,
 ): MessagePart[] {
   const lastPart = parts.at(-1);
-  if (!lastPart) {
-    return [createPart({ label: text })];
+  const isTextOnly =
+    lastPart &&
+    !lastPart.imageSrc &&
+    !lastPart.soundSrc &&
+    !lastPart.vocalization;
+
+  if (!lastPart || !isTextOnly) {
+    return appendPart(parts, { label: text });
   }
 
   return parts.with(-1, {

--- a/src/features/board/message/message-transforms.ts
+++ b/src/features/board/message/message-transforms.ts
@@ -38,5 +38,20 @@ export function appendTextToLastPart(
 }
 
 export function dropLastPart(parts: MessagePart[]): MessagePart[] {
+  const lastPart = parts.at(-1);
+  if (!lastPart) {
+    return parts;
+  }
+
+  const isTextOnly =
+    !lastPart.imageSrc && !lastPart.soundSrc && !lastPart.vocalization;
+
+  if (isTextOnly && lastPart.label && lastPart.label.length > 1) {
+    return parts.with(-1, {
+      ...lastPart,
+      label: lastPart.label.slice(0, -1),
+    });
+  }
+
   return parts.slice(0, -1);
 }

--- a/src/features/board/message/play-button.test.tsx
+++ b/src/features/board/message/play-button.test.tsx
@@ -1,9 +1,4 @@
-import {
-  createTheme,
-  ThemeProvider as MUIThemeProvider,
-} from "@mui/material/styles";
 import { describe, expect, test, vi } from "vitest";
-import { assertDefined } from "@shared/testing/assert-defined";
 import { render } from "vitest-browser-react";
 import { PlayButton } from "./play-button";
 
@@ -37,62 +32,5 @@ describe("PlayButton", () => {
 
     expect(handlers.onStopClick).toHaveBeenCalledTimes(1);
     expect(handlers.onPlayClick).not.toHaveBeenCalled();
-  });
-
-  describe("RTL icon mirroring", () => {
-    test("play arrow icon is flipped in RTL", async () => {
-      const theme = createTheme({ direction: "rtl" });
-      const handlers = createHandlers();
-
-      const screen = await render(
-        <MUIThemeProvider theme={theme}>
-          <PlayButton isPlaying={false} {...handlers} />
-        </MUIThemeProvider>,
-      );
-
-      const button = screen.getByRole("button", { name: "Play message" });
-      const icon = button.element().querySelector("svg");
-
-      assertDefined(icon);
-      // Browsers resolve scaleX(-1) to its matrix equivalent
-      const styles = getComputedStyle(icon);
-      expect(styles.transform).toBe("matrix(-1, 0, 0, 1, 0, 0)");
-    });
-
-    test("play arrow icon is not flipped in LTR", async () => {
-      const theme = createTheme({ direction: "ltr" });
-      const handlers = createHandlers();
-
-      const screen = await render(
-        <MUIThemeProvider theme={theme}>
-          <PlayButton isPlaying={false} {...handlers} />
-        </MUIThemeProvider>,
-      );
-
-      const button = screen.getByRole("button", { name: "Play message" });
-      const icon = button.element().querySelector("svg");
-
-      assertDefined(icon);
-      const styles = getComputedStyle(icon);
-      expect(styles.transform).not.toBe("matrix(-1, 0, 0, 1, 0, 0)");
-    });
-
-    test("stop icon is not flipped in RTL", async () => {
-      const theme = createTheme({ direction: "rtl" });
-      const handlers = createHandlers();
-
-      const screen = await render(
-        <MUIThemeProvider theme={theme}>
-          <PlayButton isPlaying={true} {...handlers} />
-        </MUIThemeProvider>,
-      );
-
-      const button = screen.getByRole("button", { name: "Stop message" });
-      const icon = button.element().querySelector("svg");
-
-      assertDefined(icon);
-      const styles = getComputedStyle(icon);
-      expect(styles.transform).not.toBe("matrix(-1, 0, 0, 1, 0, 0)");
-    });
   });
 });

--- a/src/features/board/message/play-button.tsx
+++ b/src/features/board/message/play-button.tsx
@@ -2,7 +2,6 @@ import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import StopIcon from "@mui/icons-material/Stop";
 import Fab from "@mui/material/Fab";
 import { m } from "@paraglide/messages.js";
-import { flipForRtl } from "@shared/theme/rtl";
 
 const iconSx = { fontSize: 32 };
 
@@ -37,11 +36,7 @@ export function PlayButton({
         alignSelf: "center",
       }}
     >
-      {isPlaying ? (
-        <StopIcon sx={iconSx} />
-      ) : (
-        <PlayArrowIcon sx={[flipForRtl, iconSx]} />
-      )}
+      {isPlaying ? <StopIcon sx={iconSx} /> : <PlayArrowIcon sx={iconSx} />}
     </Fab>
   );
 }

--- a/src/features/board/message/use-message.test.ts
+++ b/src/features/board/message/use-message.test.ts
@@ -25,7 +25,7 @@ describe("useMessage", () => {
     expect(first.id).not.toBe(second.id);
   });
 
-  test("removes the last-added part", async () => {
+  test("removes a single character from the last-added text-only part", async () => {
     const { result, rerender } = await renderHook(() => useMessage());
 
     result.current.setFromText("hello world");
@@ -34,8 +34,8 @@ describe("useMessage", () => {
     result.current.removeLastPart();
     await rerender();
 
-    expect(result.current.parts).toHaveLength(1);
-    expect(result.current.text).toBe("hello");
+    expect(result.current.parts).toHaveLength(2);
+    expect(result.current.text).toBe("hello worl");
   });
 
   test("keeps trailing punctuation attached to its word for TTS prosody", async () => {


### PR DESCRIPTION
This PR addresses two atomic bugs:

1. **Spell Merge Bug**: 
   - A `:spell` action was automatically merging with any previous message part (even those generated from standard buttons with media). 
   - Fixed to only merge when the previous part is specifically text-only. Backspace behavior was also updated to drop single characters for these text-only parts, rather than dropping the whole part at once.

2. **Play Button RTL**:
   - Removed an incorrect RTL directional flip fix for the play button icon.

All related tests have been updated and are passing.