### PR TITLE
chore: bump @shayc/open-board-format to ^1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mui/icons-material": "^9.2.0",
         "@mui/material": "^9.2.0",
         "@mui/stylis-plugin-rtl": "^9.1.1",
-        "@shayc/open-board-format": "^1.1.0",
+        "@shayc/open-board-format": "^1.2.0",
         "@shayc/react-built-in-ai": "^0.10.0",
         "idb": "^8.0.3",
         "mrmime": "^2.0.1",
@@ -3456,9 +3456,9 @@
       ]
     },
     "node_modules/@shayc/open-board-format": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@shayc/open-board-format/-/open-board-format-1.1.0.tgz",
-      "integrity": "sha512-FmGey1xthdX9ZXSYOEO04uxaPelJR3f2JpVeC35BCILXqwHWqg/vLDMAth5m893yuI6HavV+aIHETtmjFp5kVg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@shayc/open-board-format/-/open-board-format-1.2.0.tgz",
+      "integrity": "sha512-5f8uUmPleP+sXqrk4AL/SpkOfI+r9DRHA1zbl9xb7Y5VkTcJXgq4efu8LSMnFJDxH5TA6ZIUgPc0aw01l4Rj0Q==",
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.3"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@mui/icons-material": "^9.2.0",
     "@mui/material": "^9.2.0",
     "@mui/stylis-plugin-rtl": "^9.1.1",
-    "@shayc/open-board-format": "^1.1.0",
+    "@shayc/open-board-format": "^1.2.0",
     "@shayc/react-built-in-ai": "^0.10.0",
     "idb": "^8.0.3",
     "mrmime": "^2.0.1",


### PR DESCRIPTION
## Summary
- Bump `@shayc/open-board-format` dependency from `^1.1.0` to `^1.2.0` in package.json and package-lock.json

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)