### PR TITLE
refactor(import): content-addressed board imports, kill silent-replace vulnerability

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -253,7 +253,14 @@ Each is the one place to change a concern:
   import/export compatibility.
 - **Import boundary (write) — `src/features/board/import/`.** The only place a file
   becomes database records. All four entry points (picker, drag-drop, `?board=` URL,
-  PWA file handler) converge on `importBoardFiles`.
+  PWA file handler) converge on `importBoardSets`. Imports are **insert-only**: every
+  import gets a fresh `crypto.randomUUID()` identity, so no import can ever address,
+  modify, or replace an existing set — a crafted filename or URL can add data but
+  never overwrite it. A SHA-256 `sourceHash` of the imported bytes dedups a
+  byte-identical re-import to the existing set instead of duplicating it. Additive
+  derived data (cached translations via `updateBoardStrings`) preserves `sourceHash`;
+  a future feature that edits source content (labels, grid, images) must clear it, or
+  re-importing the pristine file would wrongly dedup to the edited set.
 - **AI provider boundary — `@shayc/react-built-in-ai`.** App code only consumes its
   hooks; swap models or providers in the library, not in features.
 - **Speech boundary — `src/shared/speech/`.** The only wrapper over the Web Speech
@@ -262,7 +269,13 @@ Each is the one place to change a concern:
 - **i18n boundary — Paraglide `m` + `src/shared/language/`.** The only source of UI
   strings and the active locale.
 - **Routing / data boundary — `src/app/routing/loaders/` + React Router.** The only path
-  from storage into the render tree.
+  from storage into the render tree. No loader creates, replaces, or deletes board
+  sets: the `?board=` URL import and the first-run default-board bootstrap live in
+  `src/pages/root-index-page.tsx`, not `rootIndexLoader` (which only reads/redirects),
+  so a bad or malicious link renders a localized in-app error, never the route error
+  boundary. `boardLoader`'s translation-cache write (`resolveTranslatedBoard` →
+  `updateBoardStrings`) is a pre-existing exception — background derived-data caching
+  triggered by viewing a board, not board-set creation.
 
 ## Cross-cutting concerns
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -254,13 +254,15 @@ Each is the one place to change a concern:
 - **Import boundary (write) — `src/features/board/import/`.** The only place a file
   becomes database records. All four entry points (picker, drag-drop, `?board=` URL,
   PWA file handler) converge on `importBoardSets`. Imports are **insert-only**: every
-  import gets a fresh `crypto.randomUUID()` identity, so no import can ever address,
+  import gets a fresh random identity, so no import can ever address,
   modify, or replace an existing set — a crafted filename or URL can add data but
   never overwrite it. A SHA-256 `sourceHash` of the imported bytes dedups a
   byte-identical re-import to the existing set instead of duplicating it. Additive
   derived data (cached translations via `updateBoardStrings`) preserves `sourceHash`;
   a future feature that edits source content (labels, grid, images) must clear it, or
-  re-importing the pristine file would wrongly dedup to the edited set.
+  re-importing the pristine file would wrongly dedup to the edited set. Dedup requires
+  `crypto.subtle`, which is only available in secure contexts; on plain-http origins
+  it's skipped and imports still work, just without dedup.
 - **AI provider boundary — `@shayc/react-built-in-ai`.** App code only consumes its
   hooks; swap models or providers in the library, not in features.
 - **Speech boundary — `src/shared/speech/`.** The only wrapper over the Web Speech

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "تم استبدال اللوحة",
-        "countPlural=*": "تم استبدال اللوحات"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "حدث خطأ ما",
   "errorGoHome": "الانتقال إلى الرئيسية",
   "errorBoardNotFound": "اللوحة غير موجودة",
-  "errorBoardSetNotFound": "اللوحة غير موجودة"
+  "errorBoardSetNotFound": "اللوحة غير موجودة",
+  "importAlreadyInLibrary": "اللوحة موجودة بالفعل في مكتبتك",
+  "importUrlNotSupported": "لا يمكن استيراد هذا النوع من الروابط",
+  "importTooLarge": "حجم ملف اللوحة كبير جدًا على الاستيراد",
+  "importFailedTitle": "تعذّر استيراد اللوحة",
+  "importRetry": "إعادة المحاولة",
+  "importGoToBoards": "الانتقال إلى لوحاتي"
 }

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Дъската е заменена",
-        "countPlural=*": "Дъските са заменени"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Нещо се обърка",
   "errorGoHome": "Към началото",
   "errorBoardNotFound": "Дъската не е намерена",
-  "errorBoardSetNotFound": "Дъската не е намерена"
+  "errorBoardSetNotFound": "Дъската не е намерена",
+  "importAlreadyInLibrary": "Дъската вече е във вашата библиотека",
+  "importUrlNotSupported": "Този тип връзка не може да се импортира",
+  "importTooLarge": "Файлът на дъската е твърде голям за импортиране",
+  "importFailedTitle": "Дъската не можа да бъде импортирана",
+  "importRetry": "Опитайте отново",
+  "importGoToBoards": "Към моите дъски"
 }

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "বোর্ড প্রতিস্থাপিত হয়েছে",
-        "countPlural=*": "বোর্ড প্রতিস্থাপিত হয়েছে"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "কিছু একটা ভুল হয়েছে",
   "errorGoHome": "হোমে যান",
   "errorBoardNotFound": "বোর্ড পাওয়া যায়নি",
-  "errorBoardSetNotFound": "বোর্ড পাওয়া যায়নি"
+  "errorBoardSetNotFound": "বোর্ড পাওয়া যায়নি",
+  "importAlreadyInLibrary": "বোর্ডটি ইতিমধ্যে আপনার লাইব্রেরিতে আছে",
+  "importUrlNotSupported": "এই ধরনের লিঙ্ক আমদানি করা যায় না",
+  "importTooLarge": "বোর্ড ফাইলটি আমদানি করার জন্য অনেক বড়",
+  "importFailedTitle": "বোর্ড আমদানি করা যায়নি",
+  "importRetry": "আবার চেষ্টা করুন",
+  "importGoToBoards": "আমার বোর্ডে যান"
 }

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Tabulka nahrazena",
-        "countPlural=*": "Tabulky nahrazeny"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Něco se pokazilo",
   "errorGoHome": "Přejít domů",
   "errorBoardNotFound": "Tabulka nebyla nalezena",
-  "errorBoardSetNotFound": "Tabulka nebyla nalezena"
+  "errorBoardSetNotFound": "Tabulka nebyla nalezena",
+  "importAlreadyInLibrary": "Tabulka je již ve vaší knihovně",
+  "importUrlNotSupported": "Tento typ odkazu nelze importovat",
+  "importTooLarge": "Soubor tabulky je příliš velký pro import",
+  "importFailedTitle": "Tabulku se nepodařilo importovat",
+  "importRetry": "Zkusit znovu",
+  "importGoToBoards": "Přejít na mé tabulky"
 }

--- a/messages/da.json
+++ b/messages/da.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Tavle erstattet",
-        "countPlural=*": "Tavler erstattet"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Noget gik galt",
   "errorGoHome": "Gå til start",
   "errorBoardNotFound": "Tavlen blev ikke fundet",
-  "errorBoardSetNotFound": "Tavlen blev ikke fundet"
+  "errorBoardSetNotFound": "Tavlen blev ikke fundet",
+  "importAlreadyInLibrary": "Tavlen er allerede i dit bibliotek",
+  "importUrlNotSupported": "Denne linktype kan ikke importeres",
+  "importTooLarge": "Tavlefilen er for stor til at blive importeret",
+  "importFailedTitle": "Tavlen kunne ikke importeres",
+  "importRetry": "Prøv igen",
+  "importGoToBoards": "Gå til mine tavler"
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Tafel ersetzt",
-        "countPlural=*": "Tafeln ersetzt"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Etwas ist schiefgelaufen",
   "errorGoHome": "Zur Startseite",
   "errorBoardNotFound": "Tafel nicht gefunden",
-  "errorBoardSetNotFound": "Tafel nicht gefunden"
+  "errorBoardSetNotFound": "Tafel nicht gefunden",
+  "importAlreadyInLibrary": "Tafel ist bereits in deiner Bibliothek",
+  "importUrlNotSupported": "Dieser Linktyp kann nicht importiert werden",
+  "importTooLarge": "Tafeldatei ist zu groß zum Importieren",
+  "importFailedTitle": "Tafel konnte nicht importiert werden",
+  "importRetry": "Erneut versuchen",
+  "importGoToBoards": "Zu meinen Tafeln"
 }

--- a/messages/el.json
+++ b/messages/el.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Ο πίνακας αντικαταστάθηκε",
-        "countPlural=*": "Οι πίνακες αντικαταστάθηκαν"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Κάτι πήγε στραβά",
   "errorGoHome": "Μετάβαση στην αρχική",
   "errorBoardNotFound": "Ο πίνακας δεν βρέθηκε",
-  "errorBoardSetNotFound": "Ο πίνακας δεν βρέθηκε"
+  "errorBoardSetNotFound": "Ο πίνακας δεν βρέθηκε",
+  "importAlreadyInLibrary": "Ο πίνακας υπάρχει ήδη στη βιβλιοθήκη σας",
+  "importUrlNotSupported": "Αυτός ο τύπος συνδέσμου δεν μπορεί να εισαχθεί",
+  "importTooLarge": "Το αρχείο του πίνακα είναι πολύ μεγάλο για εισαγωγή",
+  "importFailedTitle": "Δεν ήταν δυνατή η εισαγωγή του πίνακα",
+  "importRetry": "Δοκιμάστε ξανά",
+  "importGoToBoards": "Μετάβαση στους πίνακές μου"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Board replaced",
-        "countPlural=*": "Boards replaced"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardNotFound": "Board not found",
-  "errorBoardSetNotFound": "Board not found"
+  "errorBoardSetNotFound": "Board not found",
+  "importAlreadyInLibrary": "Board already in your library",
+  "importUrlNotSupported": "This link type can't be imported",
+  "importTooLarge": "Board file is too large to import",
+  "importFailedTitle": "Couldn't import board",
+  "importRetry": "Try again",
+  "importGoToBoards": "Go to my boards"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Tablero reemplazado",
-        "countPlural=*": "Tableros reemplazados"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Algo salió mal",
   "errorGoHome": "Ir al inicio",
   "errorBoardNotFound": "Tablero no encontrado",
-  "errorBoardSetNotFound": "Tablero no encontrado"
+  "errorBoardSetNotFound": "Tablero no encontrado",
+  "importAlreadyInLibrary": "El tablero ya está en tu biblioteca",
+  "importUrlNotSupported": "Este tipo de enlace no se puede importar",
+  "importTooLarge": "El archivo del tablero es demasiado grande para importarlo",
+  "importFailedTitle": "No se pudo importar el tablero",
+  "importRetry": "Reintentar",
+  "importGoToBoards": "Ir a mis tableros"
 }

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Taulu korvattu",
-        "countPlural=*": "Taulut korvattu"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Jokin meni pieleen",
   "errorGoHome": "Siirry etusivulle",
   "errorBoardNotFound": "Taulua ei löytynyt",
-  "errorBoardSetNotFound": "Taulua ei löytynyt"
+  "errorBoardSetNotFound": "Taulua ei löytynyt",
+  "importAlreadyInLibrary": "Taulu on jo kirjastossasi",
+  "importUrlNotSupported": "Tämäntyyppistä linkkiä ei voi tuoda",
+  "importTooLarge": "Taulutiedosto on liian suuri tuotavaksi",
+  "importFailedTitle": "Taulun tuonti epäonnistui",
+  "importRetry": "Yritä uudelleen",
+  "importGoToBoards": "Siirry omiin tauluihini"
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Tableau remplacé",
-        "countPlural=*": "Tableaux remplacés"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Une erreur s'est produite",
   "errorGoHome": "Aller à l'accueil",
   "errorBoardNotFound": "Tableau introuvable",
-  "errorBoardSetNotFound": "Tableau introuvable"
+  "errorBoardSetNotFound": "Tableau introuvable",
+  "importAlreadyInLibrary": "Ce tableau est déjà dans votre bibliothèque",
+  "importUrlNotSupported": "Ce type de lien ne peut pas être importé",
+  "importTooLarge": "Le fichier du tableau est trop volumineux pour être importé",
+  "importFailedTitle": "Impossible d'importer le tableau",
+  "importRetry": "Réessayer",
+  "importGoToBoards": "Aller à mes tableaux"
 }

--- a/messages/he.json
+++ b/messages/he.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "הלוח הוחלף בהצלחה",
-        "countPlural=*": "הלוחות הוחלפו בהצלחה"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "משהו השתבש",
   "errorGoHome": "חזרה לעמוד הבית",
   "errorBoardNotFound": "הלוח לא נמצא",
-  "errorBoardSetNotFound": "הלוח לא נמצא"
+  "errorBoardSetNotFound": "הלוח לא נמצא",
+  "importAlreadyInLibrary": "הלוח כבר נמצא בספרייה שלך",
+  "importUrlNotSupported": "לא ניתן לייבא סוג קישור זה",
+  "importTooLarge": "קובץ הלוח גדול מדי לייבוא",
+  "importFailedTitle": "ייבוא הלוח נכשל",
+  "importRetry": "ניסיון חוזר",
+  "importGoToBoards": "מעבר ללוחות שלי"
 }

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "बोर्ड बदल दिया गया",
-        "countPlural=*": "बोर्ड बदल दिए गए"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "कुछ गलत हो गया",
   "errorGoHome": "होम पर जाएँ",
   "errorBoardNotFound": "बोर्ड नहीं मिला",
-  "errorBoardSetNotFound": "बोर्ड नहीं मिला"
+  "errorBoardSetNotFound": "बोर्ड नहीं मिला",
+  "importAlreadyInLibrary": "बोर्ड पहले से आपकी लाइब्रेरी में है",
+  "importUrlNotSupported": "इस प्रकार के लिंक को आयात नहीं किया जा सकता",
+  "importTooLarge": "बोर्ड फ़ाइल आयात करने के लिए बहुत बड़ी है",
+  "importFailedTitle": "बोर्ड आयात नहीं किया जा सका",
+  "importRetry": "पुनः प्रयास करें",
+  "importGoToBoards": "अपने बोर्ड पर जाएँ"
 }

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Ploča zamijenjena",
-        "countPlural=*": "Ploče zamijenjene"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Nešto je pošlo po zlu",
   "errorGoHome": "Idi na početnu",
   "errorBoardNotFound": "Ploča nije pronađena",
-  "errorBoardSetNotFound": "Ploča nije pronađena"
+  "errorBoardSetNotFound": "Ploča nije pronađena",
+  "importAlreadyInLibrary": "Ploča je već u vašoj knjižnici",
+  "importUrlNotSupported": "Ovu vrstu poveznice nije moguće uvesti",
+  "importTooLarge": "Datoteka ploče je prevelika za uvoz",
+  "importFailedTitle": "Ploču nije moguće uvesti",
+  "importRetry": "Pokušaj ponovno",
+  "importGoToBoards": "Idi na moje ploče"
 }

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Tábla lecserélve",
-        "countPlural=*": "Táblák lecserélve"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Hiba történt",
   "errorGoHome": "Ugrás a kezdőlapra",
   "errorBoardNotFound": "A tábla nem található",
-  "errorBoardSetNotFound": "A tábla nem található"
+  "errorBoardSetNotFound": "A tábla nem található",
+  "importAlreadyInLibrary": "A tábla már megvan a könyvtáradban",
+  "importUrlNotSupported": "Ezt a linktípust nem lehet importálni",
+  "importTooLarge": "A táblafájl túl nagy az importáláshoz",
+  "importFailedTitle": "A tábla importálása nem sikerült",
+  "importRetry": "Próbáld újra",
+  "importGoToBoards": "Ugrás a tábláimhoz"
 }

--- a/messages/id.json
+++ b/messages/id.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Papan diganti",
-        "countPlural=*": "Papan diganti"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Terjadi kesalahan",
   "errorGoHome": "Ke beranda",
   "errorBoardNotFound": "Papan tidak ditemukan",
-  "errorBoardSetNotFound": "Papan tidak ditemukan"
+  "errorBoardSetNotFound": "Papan tidak ditemukan",
+  "importAlreadyInLibrary": "Papan sudah ada di pustaka Anda",
+  "importUrlNotSupported": "Jenis tautan ini tidak dapat diimpor",
+  "importTooLarge": "Berkas papan terlalu besar untuk diimpor",
+  "importFailedTitle": "Tidak dapat mengimpor papan",
+  "importRetry": "Coba lagi",
+  "importGoToBoards": "Ke papan saya"
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Tabella sostituita",
-        "countPlural=*": "Tabelle sostituite"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Qualcosa è andato storto",
   "errorGoHome": "Vai alla home",
   "errorBoardNotFound": "Tabella non trovata",
-  "errorBoardSetNotFound": "Tabella non trovata"
+  "errorBoardSetNotFound": "Tabella non trovata",
+  "importAlreadyInLibrary": "Tabella già presente nella tua libreria",
+  "importUrlNotSupported": "Questo tipo di link non può essere importato",
+  "importTooLarge": "Il file della tabella è troppo grande per essere importato",
+  "importFailedTitle": "Impossibile importare la tabella",
+  "importRetry": "Riprova",
+  "importGoToBoards": "Vai alle mie tabelle"
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "ボードを置き換えました",
-        "countPlural=*": "ボードを置き換えました"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "問題が発生しました",
   "errorGoHome": "ホームに戻る",
   "errorBoardNotFound": "ボードが見つかりません",
-  "errorBoardSetNotFound": "ボードが見つかりません"
+  "errorBoardSetNotFound": "ボードが見つかりません",
+  "importAlreadyInLibrary": "このボードはすでにライブラリにあります",
+  "importUrlNotSupported": "このリンクの種類はインポートできません",
+  "importTooLarge": "ボードファイルが大きすぎてインポートできません",
+  "importFailedTitle": "ボードをインポートできませんでした",
+  "importRetry": "再試行",
+  "importGoToBoards": "マイボードに移動"
 }

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "ಬೋರ್ಡ್ ಬದಲಾಯಿಸಲಾಗಿದೆ",
-        "countPlural=*": "ಬೋರ್ಡ್‌ಗಳು ಬದಲಾಯಿಸಲಾಗಿವೆ"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "ಏನೋ ತಪ್ಪಾಗಿದೆ",
   "errorGoHome": "ಮುಖಪುಟಕ್ಕೆ ಹೋಗಿ",
   "errorBoardNotFound": "ಬೋರ್ಡ್ ಕಂಡುಬಂದಿಲ್ಲ",
-  "errorBoardSetNotFound": "ಬೋರ್ಡ್ ಕಂಡುಬಂದಿಲ್ಲ"
+  "errorBoardSetNotFound": "ಬೋರ್ಡ್ ಕಂಡುಬಂದಿಲ್ಲ",
+  "importAlreadyInLibrary": "ಬೋರ್ಡ್ ಈಗಾಗಲೇ ನಿಮ್ಮ ಗ್ರಂಥಾಲಯದಲ್ಲಿದೆ",
+  "importUrlNotSupported": "ಈ ಲಿಂಕ್ ಪ್ರಕಾರವನ್ನು ಆಮದು ಮಾಡಲಾಗುವುದಿಲ್ಲ",
+  "importTooLarge": "ಬೋರ್ಡ್ ಫೈಲ್ ಆಮದು ಮಾಡಲು ತುಂಬಾ ದೊಡ್ಡದಾಗಿದೆ",
+  "importFailedTitle": "ಬೋರ್ಡ್ ಆಮದು ಮಾಡಲಾಗಲಿಲ್ಲ",
+  "importRetry": "ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ",
+  "importGoToBoards": "ನನ್ನ ಬೋರ್ಡ್‌ಗಳಿಗೆ ಹೋಗಿ"
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "보드를 교체했습니다",
-        "countPlural=*": "보드를 교체했습니다"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "문제가 발생했습니다",
   "errorGoHome": "홈으로",
   "errorBoardNotFound": "보드를 찾을 수 없음",
-  "errorBoardSetNotFound": "보드를 찾을 수 없음"
+  "errorBoardSetNotFound": "보드를 찾을 수 없음",
+  "importAlreadyInLibrary": "이미 라이브러리에 있는 보드입니다",
+  "importUrlNotSupported": "이 링크 유형은 가져올 수 없습니다",
+  "importTooLarge": "보드 파일이 너무 커서 가져올 수 없습니다",
+  "importFailedTitle": "보드를 가져올 수 없습니다",
+  "importRetry": "다시 시도",
+  "importGoToBoards": "내 보드로 이동"
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Bord vervangen",
-        "countPlural=*": "Borden vervangen"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Er is iets misgegaan",
   "errorGoHome": "Naar start",
   "errorBoardNotFound": "Bord niet gevonden",
-  "errorBoardSetNotFound": "Bord niet gevonden"
+  "errorBoardSetNotFound": "Bord niet gevonden",
+  "importAlreadyInLibrary": "Bord staat al in je bibliotheek",
+  "importUrlNotSupported": "Dit linktype kan niet worden geïmporteerd",
+  "importTooLarge": "Bordbestand is te groot om te importeren",
+  "importFailedTitle": "Kan bord niet importeren",
+  "importRetry": "Opnieuw proberen",
+  "importGoToBoards": "Naar mijn borden"
 }

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Zastąpiono tablicę",
-        "countPlural=*": "Zastąpiono tablice"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Coś poszło nie tak",
   "errorGoHome": "Przejdź do strony głównej",
   "errorBoardNotFound": "Nie znaleziono tablicy",
-  "errorBoardSetNotFound": "Nie znaleziono tablicy"
+  "errorBoardSetNotFound": "Nie znaleziono tablicy",
+  "importAlreadyInLibrary": "Tablica jest już w Twojej bibliotece",
+  "importUrlNotSupported": "Tego typu linku nie można zaimportować",
+  "importTooLarge": "Plik tablicy jest zbyt duży, aby go zaimportować",
+  "importFailedTitle": "Nie udało się zaimportować tablicy",
+  "importRetry": "Spróbuj ponownie",
+  "importGoToBoards": "Przejdź do moich tablic"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Prancha substituída",
-        "countPlural=*": "Pranchas substituídas"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Algo deu errado",
   "errorGoHome": "Ir para o início",
   "errorBoardNotFound": "Prancha não encontrada",
-  "errorBoardSetNotFound": "Prancha não encontrada"
+  "errorBoardSetNotFound": "Prancha não encontrada",
+  "importAlreadyInLibrary": "A prancha já está na sua biblioteca",
+  "importUrlNotSupported": "Esse tipo de link não pode ser importado",
+  "importTooLarge": "O arquivo da prancha é muito grande para importar",
+  "importFailedTitle": "Não foi possível importar a prancha",
+  "importRetry": "Tentar novamente",
+  "importGoToBoards": "Ir para minhas pranchas"
 }

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Tablă înlocuită",
-        "countPlural=*": "Table înlocuite"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Ceva nu a mers bine",
   "errorGoHome": "Mergi la pagina principală",
   "errorBoardNotFound": "Tabla nu a fost găsită",
-  "errorBoardSetNotFound": "Tabla nu a fost găsită"
+  "errorBoardSetNotFound": "Tabla nu a fost găsită",
+  "importAlreadyInLibrary": "Tabla există deja în biblioteca ta",
+  "importUrlNotSupported": "Acest tip de link nu poate fi importat",
+  "importTooLarge": "Fișierul tablei este prea mare pentru a fi importat",
+  "importFailedTitle": "Tabla nu a putut fi importată",
+  "importRetry": "Încearcă din nou",
+  "importGoToBoards": "Mergi la tablele mele"
 }

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Доска заменена",
-        "countPlural=*": "Доски заменены"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Что-то пошло не так",
   "errorGoHome": "На главную",
   "errorBoardNotFound": "Доска не найдена",
-  "errorBoardSetNotFound": "Доска не найдена"
+  "errorBoardSetNotFound": "Доска не найдена",
+  "importAlreadyInLibrary": "Эта доска уже есть в вашей библиотеке",
+  "importUrlNotSupported": "Этот тип ссылки нельзя импортировать",
+  "importTooLarge": "Файл доски слишком большой для импорта",
+  "importFailedTitle": "Не удалось импортировать доску",
+  "importRetry": "Повторить",
+  "importGoToBoards": "Перейти к моим доскам"
 }

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Tabuľka nahradená",
-        "countPlural=*": "Tabuľky nahradené"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Niečo sa pokazilo",
   "errorGoHome": "Prejsť domov",
   "errorBoardNotFound": "Tabuľka sa nenašla",
-  "errorBoardSetNotFound": "Tabuľka sa nenašla"
+  "errorBoardSetNotFound": "Tabuľka sa nenašla",
+  "importAlreadyInLibrary": "Tabuľka je už vo vašej knižnici",
+  "importUrlNotSupported": "Tento typ odkazu sa nedá importovať",
+  "importTooLarge": "Súbor tabuľky je príliš veľký na import",
+  "importFailedTitle": "Tabuľku sa nepodarilo importovať",
+  "importRetry": "Skúsiť znova",
+  "importGoToBoards": "Prejsť na moje tabuľky"
 }

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Tabla zamenjana",
-        "countPlural=*": "Table zamenjane"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Nekaj je šlo narobe",
   "errorGoHome": "Pojdi domov",
   "errorBoardNotFound": "Table ni mogoče najti",
-  "errorBoardSetNotFound": "Table ni mogoče najti"
+  "errorBoardSetNotFound": "Table ni mogoče najti",
+  "importAlreadyInLibrary": "Tabla je že v vaši knjižnici",
+  "importUrlNotSupported": "Te vrste povezave ni mogoče uvoziti",
+  "importTooLarge": "Datoteka table je prevelika za uvoz",
+  "importFailedTitle": "Table ni bilo mogoče uvoziti",
+  "importRetry": "Poskusi znova",
+  "importGoToBoards": "Pojdi na moje table"
 }

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Tavla ersatt",
-        "countPlural=*": "Tavlor ersatta"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Något gick fel",
   "errorGoHome": "Till startsidan",
   "errorBoardNotFound": "Tavlan hittades inte",
-  "errorBoardSetNotFound": "Tavlan hittades inte"
+  "errorBoardSetNotFound": "Tavlan hittades inte",
+  "importAlreadyInLibrary": "Tavlan finns redan i ditt bibliotek",
+  "importUrlNotSupported": "Den här länktypen går inte att importera",
+  "importTooLarge": "Tavelfilen är för stor för att importeras",
+  "importFailedTitle": "Det gick inte att importera tavlan",
+  "importRetry": "Försök igen",
+  "importGoToBoards": "Till mina tavlor"
 }

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "பலகை மாற்றப்பட்டது",
-        "countPlural=*": "பலகைகள் மாற்றப்பட்டன"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "ஏதோ தவறு நடந்தது",
   "errorGoHome": "முகப்புக்குச் செல்",
   "errorBoardNotFound": "பலகை கிடைக்கவில்லை",
-  "errorBoardSetNotFound": "பலகை கிடைக்கவில்லை"
+  "errorBoardSetNotFound": "பலகை கிடைக்கவில்லை",
+  "importAlreadyInLibrary": "இந்தப் பலகை ஏற்கனவே உங்கள் நூலகத்தில் உள்ளது",
+  "importUrlNotSupported": "இந்த வகை இணைப்பை இறக்குமதி செய்ய முடியாது",
+  "importTooLarge": "பலகைக் கோப்பு இறக்குமதி செய்ய மிகப் பெரியது",
+  "importFailedTitle": "பலகையை இறக்குமதி செய்ய முடியவில்லை",
+  "importRetry": "மீண்டும் முயற்சி செய்",
+  "importGoToBoards": "எனது பலகைகளுக்குச் செல்"
 }

--- a/messages/te.json
+++ b/messages/te.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "బోర్డు భర్తీ చేయబడింది",
-        "countPlural=*": "బోర్డులు భర్తీ చేయబడ్డాయి"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "ఏదో తప్పు జరిగింది",
   "errorGoHome": "హోమ్‌కు వెళ్లు",
   "errorBoardNotFound": "బోర్డు కనుగొనబడలేదు",
-  "errorBoardSetNotFound": "బోర్డు కనుగొనబడలేదు"
+  "errorBoardSetNotFound": "బోర్డు కనుగొనబడలేదు",
+  "importAlreadyInLibrary": "బోర్డు ఇప్పటికే మీ లైబ్రరీలో ఉంది",
+  "importUrlNotSupported": "ఈ లింక్ రకాన్ని దిగుమతి చేయడం సాధ్యం కాదు",
+  "importTooLarge": "బోర్డు ఫైల్ దిగుమతి చేయడానికి చాలా పెద్దదిగా ఉంది",
+  "importFailedTitle": "బోర్డును దిగుమతి చేయలేకపోయాం",
+  "importRetry": "మళ్లీ ప్రయత్నించండి",
+  "importGoToBoards": "నా బోర్డులకు వెళ్లండి"
 }

--- a/messages/th.json
+++ b/messages/th.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "แทนที่บอร์ดแล้ว",
-        "countPlural=*": "แทนที่บอร์ดแล้ว"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "เกิดข้อผิดพลาดบางอย่าง",
   "errorGoHome": "ไปที่หน้าแรก",
   "errorBoardNotFound": "ไม่พบบอร์ด",
-  "errorBoardSetNotFound": "ไม่พบบอร์ด"
+  "errorBoardSetNotFound": "ไม่พบบอร์ด",
+  "importAlreadyInLibrary": "บอร์ดนี้อยู่ในคลังของคุณแล้ว",
+  "importUrlNotSupported": "ลิงก์ประเภทนี้ไม่สามารถนำเข้าได้",
+  "importTooLarge": "ไฟล์บอร์ดมีขนาดใหญ่เกินกว่าจะนำเข้าได้",
+  "importFailedTitle": "นำเข้าบอร์ดไม่สำเร็จ",
+  "importRetry": "ลองอีกครั้ง",
+  "importGoToBoards": "ไปที่บอร์ดของฉัน"
 }

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Pano değiştirildi",
-        "countPlural=*": "Panolar değiştirildi"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Bir şeyler ters gitti",
   "errorGoHome": "Ana sayfaya git",
   "errorBoardNotFound": "Pano bulunamadı",
-  "errorBoardSetNotFound": "Pano bulunamadı"
+  "errorBoardSetNotFound": "Pano bulunamadı",
+  "importAlreadyInLibrary": "Pano zaten kitaplığınızda",
+  "importUrlNotSupported": "Bu bağlantı türü içe aktarılamıyor",
+  "importTooLarge": "Pano dosyası içe aktarılamayacak kadar büyük",
+  "importFailedTitle": "Pano içe aktarılamadı",
+  "importRetry": "Tekrar dene",
+  "importGoToBoards": "Panolarıma git"
 }

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Дошку замінено",
-        "countPlural=*": "Дошки замінено"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Щось пішло не так",
   "errorGoHome": "На головну",
   "errorBoardNotFound": "Дошку не знайдено",
-  "errorBoardSetNotFound": "Дошку не знайдено"
+  "errorBoardSetNotFound": "Дошку не знайдено",
+  "importAlreadyInLibrary": "Дошка вже є у вашій бібліотеці",
+  "importUrlNotSupported": "Цей тип посилання неможливо імпортувати",
+  "importTooLarge": "Файл дошки занадто великий для імпорту",
+  "importFailedTitle": "Не вдалося імпортувати дошку",
+  "importRetry": "Спробувати ще раз",
+  "importGoToBoards": "Перейти до моїх дошок"
 }

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Đã thay thế bảng",
-        "countPlural=*": "Đã thay thế các bảng"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "Đã xảy ra lỗi",
   "errorGoHome": "Về trang chủ",
   "errorBoardNotFound": "Không tìm thấy bảng",
-  "errorBoardSetNotFound": "Không tìm thấy bảng"
+  "errorBoardSetNotFound": "Không tìm thấy bảng",
+  "importAlreadyInLibrary": "Bảng đã có trong thư viện của bạn",
+  "importUrlNotSupported": "Không thể nhập loại liên kết này",
+  "importTooLarge": "Tệp bảng quá lớn để nhập",
+  "importFailedTitle": "Không thể nhập bảng",
+  "importRetry": "Thử lại",
+  "importGoToBoards": "Về các bảng của tôi"
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -30,16 +30,6 @@
       }
     }
   ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "已替换沟通板",
-        "countPlural=*": "已替换沟通板"
-      }
-    }
-  ],
   "libraryImportFailedBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
@@ -116,5 +106,11 @@
   "errorGenericTitle": "出了点问题",
   "errorGoHome": "返回主页",
   "errorBoardNotFound": "未找到沟通板",
-  "errorBoardSetNotFound": "未找到沟通板"
+  "errorBoardSetNotFound": "未找到沟通板",
+  "importAlreadyInLibrary": "沟通板已在你的板库中",
+  "importUrlNotSupported": "此链接类型不支持导入",
+  "importTooLarge": "沟通板文件过大，无法导入",
+  "importFailedTitle": "无法导入沟通板",
+  "importRetry": "重试",
+  "importGoToBoards": "前往我的沟通板"
 }

--- a/src/app/routing/app-routes.tsx
+++ b/src/app/routing/app-routes.tsx
@@ -15,7 +15,11 @@ export const appRoutes: RouteObject[] = [
         ErrorBoundary: RouteErrorBoundary,
         HydrateFallback: LoadingState,
         children: [
-          { index: true, loader: rootIndexLoader },
+          {
+            index: true,
+            loader: rootIndexLoader,
+            lazy: () => import("@pages/root-index-page"),
+          },
           {
             path: BOARD_SET_PATTERN,
             children: [

--- a/src/app/routing/loaders/root-index-loader.test.ts
+++ b/src/app/routing/loaders/root-index-loader.test.ts
@@ -1,14 +1,15 @@
-import { beforeEach, describe, expect, test } from "vitest";
-import type { LoaderFunctionArgs } from "react-router";
 import { getBoardSets } from "@features/board";
 import { resetBoardsDB, seedBoardSets } from "@features/board/testing";
-import { rootIndexLoader } from "./root-index-loader";
+import type { LoaderFunctionArgs } from "react-router";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { rootIndexLoader, type RootIndexLoaderData } from "./root-index-loader";
 
 const FIXTURE_BOARD_URL =
   "/src/features/board/testing/sample-boards/lots-of-stuff.obz";
-const DEFAULT_BOARD_PATH = "/quick-core-24.obz";
 
-function callLoader(searchParams = ""): Promise<Response> {
+function callLoader(
+  searchParams = "",
+): Promise<Response | RootIndexLoaderData> {
   const args = {
     request: new Request(`http://localhost/${searchParams}`),
     params: {},
@@ -22,17 +23,18 @@ describe("rootIndexLoader", () => {
     await resetBoardsDB();
   });
 
-  test("imports the URL from ?board and redirects to its board route", async () => {
-    const response = await callLoader(
+  test("returns the ?board URL for the page to import, without touching the DB", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const result = await callLoader(
       `?board=${encodeURIComponent(FIXTURE_BOARD_URL)}`,
     );
 
-    expect(response.status).toBe(302);
-    const location = response.headers.get("Location");
-    expect(location).toMatch(/^\/sets\/[^/]+\/boards\/[^/]+$/);
+    expect(result).toEqual({ importUrl: FIXTURE_BOARD_URL });
+    expect(fetchSpy).not.toHaveBeenCalled();
 
     const sets = await getBoardSets();
-    expect(sets).toHaveLength(1);
+    expect(sets).toHaveLength(0);
   });
 
   test("redirects to the root board of the most recently updated set when no param is given", async () => {
@@ -41,26 +43,22 @@ describe("rootIndexLoader", () => {
       { setId: "set-2", rootBoardId: "root-2" },
     ]);
 
-    const response = await callLoader();
+    const result = await callLoader();
 
+    expect(result).toBeInstanceOf(Response);
+    const response = result as Response;
     expect(response.status).toBe(302);
     expect(response.headers.get("Location")).toBe("/sets/set-2/boards/root-2");
   });
 
-  test("imports the default board when no param is given and IDB is empty", async () => {
-    const probe = await fetch(DEFAULT_BOARD_PATH);
-    if (!probe.ok) {
-      throw new Error(`Default board fixture missing at ${DEFAULT_BOARD_PATH}`);
-    }
+  test("returns the default board URL when no param is given and IDB is empty", async () => {
+    const result = await callLoader();
 
-    const response = await callLoader();
-
-    expect(response.status).toBe(302);
-    expect(response.headers.get("Location")).toMatch(
-      /^\/sets\/[^/]+\/boards\/[^/]+$/,
-    );
+    expect(result).not.toBeInstanceOf(Response);
+    const { importUrl } = result as RootIndexLoaderData;
+    expect(importUrl).toMatch(/quick-core-24\.obz$/);
 
     const sets = await getBoardSets();
-    expect(sets).toHaveLength(1);
+    expect(sets).toHaveLength(0);
   });
 });

--- a/src/app/routing/loaders/root-index-loader.ts
+++ b/src/app/routing/loaders/root-index-loader.ts
@@ -1,32 +1,25 @@
-import {
-  boardSetPath,
-  getBoardSets,
-  importBoardFromUrl,
-} from "@features/board";
+import { boardSetPath, getBoardSets } from "@features/board";
 import { redirect, type LoaderFunctionArgs } from "react-router";
 
 const DEFAULT_BOARD_URL = `${import.meta.env.BASE_URL}quick-core-24.obz`;
 
-async function resolveInitialRedirectPath(
-  boardUrl: string | null,
-): Promise<string> {
-  if (boardUrl) {
-    return boardSetPath(await importBoardFromUrl(boardUrl));
-  }
-
-  const [boardSet] = await getBoardSets();
-  if (boardSet) {
-    return boardSetPath(boardSet);
-  }
-
-  return boardSetPath(await importBoardFromUrl(DEFAULT_BOARD_URL));
+export interface RootIndexLoaderData {
+  importUrl: string;
 }
 
 export async function rootIndexLoader({
   request,
-}: LoaderFunctionArgs): Promise<Response> {
-  const boardUrl = new URL(request.url).searchParams.get("board");
-  const path = await resolveInitialRedirectPath(boardUrl);
+}: LoaderFunctionArgs): Promise<Response | RootIndexLoaderData> {
+  const importUrl = new URL(request.url).searchParams.get("board");
 
-  return redirect(path);
+  if (importUrl) {
+    return { importUrl };
+  }
+
+  const [boardSet] = await getBoardSets();
+  if (boardSet) {
+    return redirect(boardSetPath(boardSet));
+  }
+
+  return { importUrl: DEFAULT_BOARD_URL };
 }

--- a/src/features/board/import/board-import.test.ts
+++ b/src/features/board/import/board-import.test.ts
@@ -1,22 +1,71 @@
 import { assertDefined } from "@shared/testing/assert-defined";
-import { loadOBF, loadOBZ, type OBFBoard } from "@shayc/open-board-format";
+import {
+  loadOBF,
+  loadOBZ,
+  OBFError,
+  type OBFBoard,
+} from "@shayc/open-board-format";
 import { beforeEach, describe, expect, test } from "vitest";
 import {
   getAssetBlob,
   getBoard,
   getBoardsDB,
   listBoardSets,
+  updateBoardStrings,
 } from "../storage/boards-db";
-import { loadFixtureFile, resetBoardsDB } from "../testing";
+import { loadFixtureFile, makeOBFBoard, resetBoardsDB } from "../testing";
 import {
   buildAssetInputs,
   importBoardSets,
   resolveLoadBoardPaths,
 } from "./board-import";
+import { BoardFileTooLargeError, MAX_BOARD_FILE_BYTES } from "./import-limits";
 
 const OBZ_FIXTURE = "lots-of-stuff.obz";
 const OBF_FIXTURE = "lots-of-stuff.obf";
-const IMPORTED_SET_ID = "lots-of-stuff";
+const SET_ID_PATTERN = /^[0-9a-f-]{36}$/;
+
+/** Patches declared uncompressed sizes in a ZIP's central directory, without touching entry data — for exercising decompression-bomb limits. */
+async function declareEntrySizes(
+  file: File,
+  sizesByName: Record<string, number>,
+): Promise<File> {
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const view = new DataView(bytes.buffer);
+
+  let eocd = bytes.length - 22;
+  while (view.getUint32(eocd, true) !== 0x06054b50) {
+    eocd -= 1;
+  }
+
+  const entryCount = view.getUint16(eocd + 8, true);
+  let offset = view.getUint32(eocd + 16, true);
+  const remaining = new Set(Object.keys(sizesByName));
+
+  for (let i = 0; i < entryCount; i++) {
+    const fileNameLength = view.getUint16(offset + 28, true);
+    const extraLength = view.getUint16(offset + 30, true);
+    const commentLength = view.getUint16(offset + 32, true);
+    const name = new TextDecoder().decode(
+      bytes.subarray(offset + 46, offset + 46 + fileNameLength),
+    );
+
+    if (name in sizesByName) {
+      view.setUint32(offset + 24, sizesByName[name], true);
+      remaining.delete(name);
+    }
+
+    offset += 46 + fileNameLength + extraLength + commentLength;
+  }
+
+  if (remaining.size > 0) {
+    throw new Error(
+      `Entries not found in archive: ${[...remaining].join(", ")}`,
+    );
+  }
+
+  return new File([bytes], file.name, { type: file.type });
+}
 
 describe("importBoardSets", () => {
   beforeEach(async () => {
@@ -29,20 +78,22 @@ describe("importBoardSets", () => {
 
     const importResults = await importBoardSets(fixtureFile);
 
-    expect(importResults).toEqual([
-      {
-        setId: IMPORTED_SET_ID,
-        rootBoardId: board.id,
-        replacedExisting: false,
-      },
-    ]);
+    expect(importResults).toHaveLength(1);
+    const [result] = importResults;
+    assertDefined(result);
+    expect(result.setId).toMatch(SET_ID_PATTERN);
+    expect(result).toEqual({
+      setId: result.setId,
+      rootBoardId: board.id,
+      alreadyExisted: false,
+    });
 
     const db = await getBoardsDB();
     const boardSets = await listBoardSets();
 
     expect(boardSets).toHaveLength(1);
     expect(boardSets[0]).toMatchObject({
-      setId: IMPORTED_SET_ID,
+      setId: result.setId,
       rootBoardId: board.id,
       boardCount: 1,
       name: board.name,
@@ -51,7 +102,7 @@ describe("importBoardSets", () => {
       gridColumns: board.grid.columns,
     });
 
-    const storedBoard = await getBoard(IMPORTED_SET_ID, board.id);
+    const storedBoard = await getBoard(result.setId, board.id);
     assertDefined(storedBoard);
 
     expect(storedBoard.name).toBe(board.name ?? board.id);
@@ -61,7 +112,7 @@ describe("importBoardSets", () => {
     const assetCount = await db.countFromIndex(
       "assets",
       "bySetId",
-      IMPORTED_SET_ID,
+      result.setId,
     );
     expect(assetCount).toBe(0);
   });
@@ -69,8 +120,6 @@ describe("importBoardSets", () => {
   test("imports an OBZ file into IndexedDB", async () => {
     const fixtureFile = await loadFixtureFile(OBZ_FIXTURE);
     const archive = await loadOBZ(fixtureFile);
-
-    const rootBoardId = archive.rootBoard.id;
 
     const assetEntries = Array.from(archive.resources.entries()).filter(
       ([path]) => !path.endsWith(".obf") && path !== "manifest.json",
@@ -82,40 +131,42 @@ describe("importBoardSets", () => {
 
     const importResults = await importBoardSets(fixtureFile);
 
-    expect(importResults).toEqual([
-      {
-        setId: IMPORTED_SET_ID,
-        rootBoardId,
-        replacedExisting: false,
-      },
-    ]);
+    expect(importResults).toHaveLength(1);
+    const [result] = importResults;
+    assertDefined(result);
+    expect(result.setId).toMatch(SET_ID_PATTERN);
+    expect(result).toEqual({
+      setId: result.setId,
+      rootBoardId: archive.rootBoard.id,
+      alreadyExisted: false,
+    });
 
     const db = await getBoardsDB();
     const boardSets = await listBoardSets();
 
     expect(boardSets).toHaveLength(1);
     expect(boardSets[0]).toMatchObject({
-      setId: IMPORTED_SET_ID,
-      rootBoardId,
+      setId: result.setId,
+      rootBoardId: archive.rootBoard.id,
       boardCount: archive.boards.size,
-      name: archive.boards.get(rootBoardId)?.name,
+      name: archive.boards.get(archive.rootBoard.id)?.name,
     });
 
     const readTx = db.transaction(["boards", "assets"], "readonly");
     const storedBoardCount = await readTx
       .objectStore("boards")
       .index("bySetId")
-      .count(IMPORTED_SET_ID);
+      .count(result.setId);
     const storedAssetCount = await readTx
       .objectStore("assets")
       .index("bySetId")
-      .count(IMPORTED_SET_ID);
+      .count(result.setId);
     await readTx.done;
 
     expect(storedBoardCount).toBe(archive.boards.size);
     expect(storedAssetCount).toBe(assetEntries.length);
 
-    const storedRootBoard = await getBoard(IMPORTED_SET_ID, rootBoardId);
+    const storedRootBoard = await getBoard(result.setId, archive.rootBoard.id);
     assertDefined(storedRootBoard);
 
     const boardLinks = storedRootBoard.obf.buttons.flatMap((button) =>
@@ -140,13 +191,13 @@ describe("importBoardSets", () => {
       expect(link.id).toBe(expectedChildBoardId);
 
       const storedChildBoard = await getBoard(
-        IMPORTED_SET_ID,
+        result.setId,
         expectedChildBoardId,
       );
       expect(storedChildBoard).toBeDefined();
     }
 
-    const storedAsset = await getAssetBlob(IMPORTED_SET_ID, sampleAssetPath);
+    const storedAsset = await getAssetBlob(result.setId, sampleAssetPath);
 
     expect(storedAsset).toBeInstanceOf(Blob);
     expect(storedAsset?.size).toBe(sampleAssetBytes.byteLength);
@@ -162,49 +213,132 @@ describe("importBoardSets", () => {
     const importResults = await importBoardSets(zipNamedFile);
 
     expect(importResults).toHaveLength(1);
-    expect(importResults[0].setId).toBe(IMPORTED_SET_ID);
+    const [result] = importResults;
+    assertDefined(result);
+    expect(result.setId).toMatch(SET_ID_PATTERN);
 
     const boardSets = await listBoardSets();
     expect(archive.boards.size).toBeGreaterThan(1);
     expect(boardSets[0]).toMatchObject({
-      setId: IMPORTED_SET_ID,
+      setId: result.setId,
       boardCount: archive.boards.size,
     });
   });
 
-  test("falls back to a default setId when the filename is only an extension", async () => {
-    const obzFile = await loadFixtureFile(OBZ_FIXTURE);
-    const extensionOnlyFile = new File([obzFile], ".obz", {
-      type: "application/octet-stream",
+  test("two different files with the same filename import as independent sets", async () => {
+    const fixtureFile = await loadFixtureFile(OBF_FIXTURE);
+    const firstFile = new File([fixtureFile], "shared-name.obf", {
+      type: fixtureFile.type,
     });
 
-    const importResults = await importBoardSets(extensionOnlyFile);
+    const otherBoard = makeOBFBoard({ id: "other-board", name: "Other Board" });
+    const secondFile = new File(
+      [JSON.stringify(otherBoard)],
+      "shared-name.obf",
+      { type: "application/json" },
+    );
 
-    expect(importResults[0].setId).toBe("imported-board");
+    const [firstResult] = await importBoardSets(firstFile);
+    assertDefined(firstResult);
+    const firstBoardBefore = await getBoard(
+      firstResult.setId,
+      firstResult.rootBoardId,
+    );
+    assertDefined(firstBoardBefore);
+
+    const [secondResult] = await importBoardSets(secondFile);
+    assertDefined(secondResult);
+
+    expect(secondResult.setId).not.toBe(firstResult.setId);
+
+    const boardSets = await listBoardSets();
+    expect(boardSets).toHaveLength(2);
+
+    const firstBoardAfter = await getBoard(
+      firstResult.setId,
+      firstResult.rootBoardId,
+    );
+    expect(firstBoardAfter).toEqual(firstBoardBefore);
   });
 
-  test("clamps the derived setId to 255 characters", async () => {
-    const obfFile = await loadFixtureFile(OBF_FIXTURE);
-    const longNamedFile = new File([obfFile], `${"x".repeat(300)}.obf`, {
-      type: "application/octet-stream",
-    });
-
-    const importResults = await importBoardSets(longNamedFile);
-
-    expect(importResults[0].setId).toBe("x".repeat(255));
-  });
-
-  test("re-importing the same filename replaces the existing set", async () => {
+  test("re-importing the same file dedups to the existing set", async () => {
     const fixtureFile = await loadFixtureFile(OBF_FIXTURE);
 
-    const first = await importBoardSets(fixtureFile);
-    expect(first[0].replacedExisting).toBe(false);
+    const [first] = await importBoardSets(fixtureFile);
+    assertDefined(first);
+    expect(first.alreadyExisted).toBe(false);
 
-    const second = await importBoardSets(fixtureFile);
-    expect(second[0].replacedExisting).toBe(true);
+    const [second] = await importBoardSets(fixtureFile);
+    expect(second).toEqual({ ...first, alreadyExisted: true });
 
     const boardSets = await listBoardSets();
     expect(boardSets).toHaveLength(1);
+  });
+
+  test("importing the same file twice in one batch writes once and dedups the second", async () => {
+    const fixtureFile = await loadFixtureFile(OBF_FIXTURE);
+
+    const [first, second] = await importBoardSets([fixtureFile, fixtureFile]);
+    assertDefined(first);
+    expect(first.alreadyExisted).toBe(false);
+    expect(second).toEqual({ ...first, alreadyExisted: true });
+
+    const boardSets = await listBoardSets();
+    expect(boardSets).toHaveLength(1);
+  });
+
+  test("caching a translation does not break dedup on re-import", async () => {
+    const fixtureFile = await loadFixtureFile(OBF_FIXTURE);
+
+    const [result] = await importBoardSets(fixtureFile);
+    assertDefined(result);
+
+    await updateBoardStrings(result.setId, result.rootBoardId, "es", {
+      hello: "hola",
+    });
+
+    const [reImportResult] = await importBoardSets(fixtureFile);
+    assertDefined(reImportResult);
+
+    expect(reImportResult.alreadyExisted).toBe(true);
+    expect(reImportResult.setId).toBe(result.setId);
+
+    const boardSets = await listBoardSets();
+    expect(boardSets).toHaveLength(1);
+  });
+
+  test("rejects a local file over the byte limit before any read", async () => {
+    const hugeFile = new File(
+      [new ArrayBuffer(MAX_BOARD_FILE_BYTES + 1)],
+      "big.obz",
+    );
+
+    await expect(importBoardSets(hugeFile)).rejects.toThrow(
+      BoardFileTooLargeError,
+    );
+
+    expect(await listBoardSets()).toHaveLength(0);
+  });
+
+  test("rejects an archive whose declared uncompressed size exceeds the total limit", async () => {
+    const fixtureFile = await loadFixtureFile(OBZ_FIXTURE);
+    const oversizedFile = await declareEntrySizes(fixtureFile, {
+      "boards/inline_images.obf": 150_000_000,
+      "boards/linked_board.obf": 150_000_000,
+      "boards/root_board.obf": 150_000_000,
+      "images/happy.png": 150_000_000,
+    });
+
+    const error: unknown = await importBoardSets(oversizedFile).catch(
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toBeInstanceOf(OBFError);
+    expect((error as InstanceType<typeof OBFError>).info.code).toBe(
+      "archive-too-large",
+    );
+
+    expect(await listBoardSets()).toHaveLength(0);
   });
 
   test("a failure partway through a multi-file import still leaves the earlier set visible", async () => {
@@ -216,7 +350,7 @@ describe("importBoardSets", () => {
     await expect(importBoardSets([goodFile, corruptFile])).rejects.toThrow();
 
     const boardSets = await listBoardSets();
-    expect(boardSets.map((set) => set.setId)).toContain(IMPORTED_SET_ID);
+    expect(boardSets).toHaveLength(1);
   });
 });
 

--- a/src/features/board/import/board-import.test.ts
+++ b/src/features/board/import/board-import.test.ts
@@ -5,7 +5,7 @@ import {
   OBFError,
   type OBFBoard,
 } from "@shayc/open-board-format";
-import { beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   getAssetBlob,
   getBoard,
@@ -351,6 +351,37 @@ describe("importBoardSets", () => {
 
     const boardSets = await listBoardSets();
     expect(boardSets).toHaveLength(1);
+  });
+
+  describe("without crypto.subtle (insecure context)", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    test("imports without a sourceHash and re-imports create separate sets", async () => {
+      vi.stubGlobal("crypto", {
+        getRandomValues: crypto.getRandomValues.bind(crypto),
+      });
+
+      const fixtureFile = await loadFixtureFile(OBF_FIXTURE);
+
+      const [first] = await importBoardSets(fixtureFile);
+      assertDefined(first);
+      expect(first.alreadyExisted).toBe(false);
+
+      const storedFirst = await listBoardSets();
+      expect(
+        storedFirst.find((set) => set.setId === first.setId)?.sourceHash,
+      ).toBeUndefined();
+
+      const [second] = await importBoardSets(fixtureFile);
+      assertDefined(second);
+      expect(second.alreadyExisted).toBe(false);
+      expect(second.setId).not.toBe(first.setId);
+
+      const boardSets = await listBoardSets();
+      expect(boardSets).toHaveLength(2);
+    });
   });
 });
 

--- a/src/features/board/import/board-import.ts
+++ b/src/features/board/import/board-import.ts
@@ -8,17 +8,32 @@ import {
 } from "@shayc/open-board-format";
 import { lookup } from "mrmime";
 import { notifyBoardSetsChanged } from "../board-sets/board-sets-store";
-import type {
-  UpsertAssetInput,
-  UpsertBoardInput,
-  UpsertBoardSetInput,
+import {
+  createBoardSet,
+  findBoardSetBySourceHash,
+  type AssetInput,
+  type BoardInput,
+  type BoardSetInput,
 } from "../storage/boards-db";
-import { replaceBoardSet } from "../storage/boards-db";
+import {
+  BOARD_UNZIP_LIMITS,
+  BoardFileTooLargeError,
+  MAX_BOARD_FILE_BYTES,
+} from "./import-limits";
 
 export interface ImportResult {
   setId: string;
   rootBoardId: string;
-  replacedExisting: boolean;
+  alreadyExisted: boolean;
+}
+
+async function hashFile(file: File): Promise<string> {
+  const bytes = await file.arrayBuffer();
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
 }
 
 export async function importBoardSets(
@@ -26,20 +41,48 @@ export async function importBoardSets(
 ): Promise<ImportResult[]> {
   const fileList = Array.isArray(files) ? files : [files];
   const results: ImportResult[] = [];
+  const importedInBatch = new Map<string, ImportResult>();
 
   try {
     for (const file of fileList) {
-      const setId = deriveSetId(file.name);
-      const loaded = await loadBoard(file);
+      if (file.size > MAX_BOARD_FILE_BYTES) {
+        throw new BoardFileTooLargeError();
+      }
 
-      results.push(
+      const sourceHash = await hashFile(file);
+      const batchHit = importedInBatch.get(sourceHash);
+
+      if (batchHit) {
+        results.push({ ...batchHit, alreadyExisted: true });
+        continue;
+      }
+
+      const existing = await findBoardSetBySourceHash(sourceHash);
+
+      if (existing) {
+        const result: ImportResult = {
+          setId: existing.setId,
+          rootBoardId: existing.rootBoardId,
+          alreadyExisted: true,
+        };
+        results.push(result);
+        importedInBatch.set(sourceHash, result);
+        continue;
+      }
+
+      const setId = crypto.randomUUID();
+      const loaded = await loadBoard(file, { limits: BOARD_UNZIP_LIMITS });
+
+      const result =
         loaded.format === "obz"
-          ? await importOBZArchive(loaded.archive, setId, file.name)
-          : await importOBFBoard(loaded.board, setId, file.name),
-      );
+          ? await importOBZArchive(loaded.archive, setId, file.name, sourceHash)
+          : await importOBFBoard(loaded.board, setId, file.name, sourceHash);
+
+      results.push(result);
+      importedInBatch.set(sourceHash, result);
     }
   } finally {
-    if (results.length > 0) {
+    if (results.some((result) => !result.alreadyExisted)) {
       await notifyBoardSetsChanged();
     }
   }
@@ -51,31 +94,33 @@ async function importOBZArchive(
   archive: ParsedOBZ,
   setId: string,
   fileName: string,
+  sourceHash: string,
 ): Promise<ImportResult> {
   const { manifest, boards, rootBoard, resources } = archive;
   const boardPathToId = buildBoardPathToId(manifest);
 
-  const { replacedExisting } = await replaceBoardSet({
-    boardSet: buildBoardSetInput(setId, rootBoard, fileName),
+  await createBoardSet({
+    boardSet: { ...buildBoardSetInput(setId, rootBoard, fileName), sourceHash },
     boards: buildBoardInputs(boards, boardPathToId),
     assets: buildAssetInputs(resources),
   });
 
-  return { setId, rootBoardId: rootBoard.id, replacedExisting };
+  return { setId, rootBoardId: rootBoard.id, alreadyExisted: false };
 }
 
 async function importOBFBoard(
   board: OBFBoard,
   setId: string,
   fileName: string,
+  sourceHash: string,
 ): Promise<ImportResult> {
-  const { replacedExisting } = await replaceBoardSet({
-    boardSet: buildBoardSetInput(setId, board, fileName),
+  await createBoardSet({
+    boardSet: { ...buildBoardSetInput(setId, board, fileName), sourceHash },
     boards: [{ boardId: board.id, name: board.name ?? board.id, obf: board }],
     assets: [],
   });
 
-  return { setId, rootBoardId: board.id, replacedExisting };
+  return { setId, rootBoardId: board.id, alreadyExisted: false };
 }
 
 function buildBoardPathToId(manifest: OBFManifest): Map<string, string> {
@@ -110,7 +155,7 @@ export function resolveLoadBoardPaths(
 function buildBoardInputs(
   boards: Map<string, OBFBoard>,
   boardPathToId: Map<string, string>,
-): UpsertBoardInput[] {
+): BoardInput[] {
   return Array.from(boards.entries()).map(([id, board]) => ({
     boardId: id,
     name: board.name ?? id,
@@ -120,7 +165,7 @@ function buildBoardInputs(
 
 export function buildAssetInputs(
   resources: Map<string, Uint8Array>,
-): UpsertAssetInput[] {
+): AssetInput[] {
   return Array.from(resources.entries())
     .filter(([path]) => {
       const lowerPath = path.toLowerCase();
@@ -140,7 +185,7 @@ function buildBoardSetInput(
   setId: string,
   board: OBFBoard,
   fallbackSetName: string,
-): UpsertBoardSetInput {
+): BoardSetInput {
   return {
     setId,
     name: board.name ?? fallbackSetName,
@@ -154,10 +199,4 @@ function buildBoardSetInput(
     gridRows: board.grid.rows,
     gridColumns: board.grid.columns,
   };
-}
-
-function deriveSetId(fileName: string): string {
-  const stem = fileName.replace(/\.(obz|obf|zip|json)$/i, "").toLowerCase();
-
-  return stem.slice(0, 255) || "imported-board";
 }

--- a/src/features/board/import/board-import.ts
+++ b/src/features/board/import/board-import.ts
@@ -1,5 +1,6 @@
 import { htmlToText } from "@shared/utils/html";
 import { normalizeLocale } from "@shared/utils/locale";
+import { randomId } from "@shared/utils/random-id";
 import {
   loadBoard,
   type OBFBoard,
@@ -27,7 +28,11 @@ export interface ImportResult {
   alreadyExisted: boolean;
 }
 
-async function hashFile(file: File): Promise<string> {
+async function hashFile(file: File): Promise<string | undefined> {
+  if (typeof crypto.subtle === "undefined") {
+    return undefined;
+  }
+
   const bytes = await file.arrayBuffer();
   const digest = await crypto.subtle.digest("SHA-256", bytes);
 
@@ -50,27 +55,30 @@ export async function importBoardSets(
       }
 
       const sourceHash = await hashFile(file);
-      const batchHit = importedInBatch.get(sourceHash);
 
-      if (batchHit) {
-        results.push({ ...batchHit, alreadyExisted: true });
-        continue;
+      if (sourceHash) {
+        const batchHit = importedInBatch.get(sourceHash);
+
+        if (batchHit) {
+          results.push({ ...batchHit, alreadyExisted: true });
+          continue;
+        }
+
+        const existing = await findBoardSetBySourceHash(sourceHash);
+
+        if (existing) {
+          const result: ImportResult = {
+            setId: existing.setId,
+            rootBoardId: existing.rootBoardId,
+            alreadyExisted: true,
+          };
+          results.push(result);
+          importedInBatch.set(sourceHash, result);
+          continue;
+        }
       }
 
-      const existing = await findBoardSetBySourceHash(sourceHash);
-
-      if (existing) {
-        const result: ImportResult = {
-          setId: existing.setId,
-          rootBoardId: existing.rootBoardId,
-          alreadyExisted: true,
-        };
-        results.push(result);
-        importedInBatch.set(sourceHash, result);
-        continue;
-      }
-
-      const setId = crypto.randomUUID();
+      const setId = randomId();
       const loaded = await loadBoard(file, { limits: BOARD_UNZIP_LIMITS });
 
       const result =
@@ -79,7 +87,9 @@ export async function importBoardSets(
           : await importOBFBoard(loaded.board, setId, file.name, sourceHash);
 
       results.push(result);
-      importedInBatch.set(sourceHash, result);
+      if (sourceHash) {
+        importedInBatch.set(sourceHash, result);
+      }
     }
   } finally {
     if (results.some((result) => !result.alreadyExisted)) {
@@ -94,7 +104,7 @@ async function importOBZArchive(
   archive: ParsedOBZ,
   setId: string,
   fileName: string,
-  sourceHash: string,
+  sourceHash: string | undefined,
 ): Promise<ImportResult> {
   const { manifest, boards, rootBoard, resources } = archive;
   const boardPathToId = buildBoardPathToId(manifest);
@@ -112,7 +122,7 @@ async function importOBFBoard(
   board: OBFBoard,
   setId: string,
   fileName: string,
-  sourceHash: string,
+  sourceHash: string | undefined,
 ): Promise<ImportResult> {
   await createBoardSet({
     boardSet: { ...buildBoardSetInput(setId, board, fileName), sourceHash },

--- a/src/features/board/import/import-from-url.test.ts
+++ b/src/features/board/import/import-from-url.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { loadFixtureFile, resetBoardsDB } from "../testing";
+import { listBoardSets } from "../storage/boards-db";
+import { makeOBFBoard, resetBoardsDB } from "../testing";
 import { importBoardFromUrl } from "./import-from-url";
+import {
+  BoardFileTooLargeError,
+  MAX_BOARD_FILE_BYTES,
+  UnsupportedBoardUrlError,
+} from "./import-limits";
 
 const SAMPLE_BOARDS_DIR = "/src/features/board/testing/sample-boards";
 const OBZ_FIXTURE = "lots-of-stuff.obz";
@@ -14,31 +20,89 @@ describe("importBoardFromUrl", () => {
     vi.restoreAllMocks();
   });
 
-  test("imports a board from a URL and derives the setId from the filename", async () => {
+  test.each([
+    "data:text/plain;base64,Zm9v",
+    "javascript:alert(1)",
+    "blob:https://example.com/00000000-0000-0000-0000-000000000000",
+  ])("rejects the unsupported URL scheme in %s", async (url) => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await expect(importBoardFromUrl(url)).rejects.toThrow(
+      UnsupportedBoardUrlError,
+    );
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(await listBoardSets()).toHaveLength(0);
+  });
+
+  test("rejects without reading the body when Content-Length exceeds the limit", async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(new Uint8Array(1024));
+      },
+    });
+    const response = new Response(stream, {
+      headers: { "content-length": String(MAX_BOARD_FILE_BYTES + 1) },
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+
+    await expect(
+      importBoardFromUrl("https://example.com/huge.obz"),
+    ).rejects.toThrow(BoardFileTooLargeError);
+
+    // The body's ReadableStream is only ever locked by calling getReader() —
+    // still unlocked here proves our code never touched it.
+    expect(response.body?.locked).toBe(false);
+    expect(await listBoardSets()).toHaveLength(0);
+  });
+
+  test("aborts mid-stream when a response with no Content-Length exceeds the limit", async () => {
+    const chunkSize = 8 * 1024 * 1024;
+    let pulls = 0;
+    const endlessStream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulls += 1;
+        controller.enqueue(new Uint8Array(chunkSize));
+      },
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(endlessStream),
+    );
+
+    await expect(
+      importBoardFromUrl("https://example.com/endless.obz"),
+    ).rejects.toThrow(BoardFileTooLargeError);
+
+    expect(pulls).toBeLessThan(25);
+    expect(await listBoardSets()).toHaveLength(0);
+  });
+
+  test("imports a board from a URL", async () => {
     const result = await importBoardFromUrl(
       `${SAMPLE_BOARDS_DIR}/${OBZ_FIXTURE}`,
     );
 
-    expect(result.setId).toBe("lots-of-stuff");
+    expect(result.alreadyExisted).toBe(false);
     expect(result.rootBoardId).toBeTruthy();
+
+    const boardSets = await listBoardSets();
+    expect(boardSets).toHaveLength(1);
   });
 
-  test("derives the setId from the last non-empty segment when the URL path ends with a slash", async () => {
-    const fixtureFile = await loadFixtureFile(OBZ_FIXTURE);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(fixtureFile));
+  test("uses the URL's filename as a fallback board-set name", async () => {
+    const namelessBoard = makeOBFBoard({ name: undefined });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(namelessBoard), {
+        headers: { "content-type": "application/json" },
+      }),
+    );
 
-    const result = await importBoardFromUrl("https://example.com/boards/");
+    const result = await importBoardFromUrl("https://example.com/my-board.obf");
 
-    expect(result.setId).toBe("boards");
-  });
-
-  test("falls back to the default filename when the URL has no path segments", async () => {
-    const fixtureFile = await loadFixtureFile(OBZ_FIXTURE);
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(fixtureFile));
-
-    const result = await importBoardFromUrl("https://example.com/");
-
-    expect(result.setId).toBe("board");
+    const boardSets = await listBoardSets();
+    expect(boardSets.find((set) => set.setId === result.setId)?.name).toBe(
+      "my-board.obf",
+    );
   });
 
   test("throws on HTTP error responses", async () => {

--- a/src/features/board/import/import-from-url.ts
+++ b/src/features/board/import/import-from-url.ts
@@ -1,15 +1,77 @@
 import { importBoardSets, type ImportResult } from "./board-import";
+import {
+  BoardFileTooLargeError,
+  MAX_BOARD_FILE_BYTES,
+  UnsupportedBoardUrlError,
+} from "./import-limits";
+
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
+
+function resolveAllowedUrl(url: string): URL {
+  let resolved: URL;
+
+  try {
+    resolved = new URL(url, window.location.origin);
+  } catch {
+    throw new UnsupportedBoardUrlError(url);
+  }
+
+  if (!ALLOWED_PROTOCOLS.has(resolved.protocol)) {
+    throw new UnsupportedBoardUrlError(url);
+  }
+
+  return resolved;
+}
+
+async function readBoundedBody(response: Response): Promise<Blob> {
+  const contentLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > MAX_BOARD_FILE_BYTES) {
+    throw new BoardFileTooLargeError();
+  }
+
+  const reader = response.body?.getReader();
+  if (!reader) {
+    const blob = await response.blob();
+    if (blob.size > MAX_BOARD_FILE_BYTES) {
+      throw new BoardFileTooLargeError();
+    }
+    return blob;
+  }
+
+  const chunks: Uint8Array[] = [];
+  let receivedBytes = 0;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    receivedBytes += value.byteLength;
+    if (receivedBytes > MAX_BOARD_FILE_BYTES) {
+      await reader.cancel();
+      throw new BoardFileTooLargeError();
+    }
+
+    chunks.push(value);
+  }
+
+  return new Blob(chunks as BlobPart[], {
+    type: response.headers.get("content-type") ?? undefined,
+  });
+}
 
 export async function importBoardFromUrl(url: string): Promise<ImportResult> {
-  const response = await fetch(url);
+  const resolved = resolveAllowedUrl(url);
+  const response = await fetch(resolved);
 
   if (!response.ok) {
     throw new Error(`Failed to fetch board: HTTP ${response.status}`);
   }
 
-  const blob = await response.blob();
-  const pathname = new URL(url, window.location.origin).pathname;
-  const filename = pathname.split("/").filter(Boolean).at(-1) ?? "board.obz";
+  const blob = await readBoundedBody(response);
+  const filename =
+    resolved.pathname.split("/").filter(Boolean).at(-1) ?? "board.obz";
 
   const file = new File([blob], filename, {
     type: blob.type || "application/octet-stream",

--- a/src/features/board/import/import-from-url.ts
+++ b/src/features/board/import/import-from-url.ts
@@ -61,9 +61,12 @@ async function readBoundedBody(response: Response): Promise<Blob> {
   });
 }
 
-export async function importBoardFromUrl(url: string): Promise<ImportResult> {
+export async function importBoardFromUrl(
+  url: string,
+  signal?: AbortSignal,
+): Promise<ImportResult> {
   const resolved = resolveAllowedUrl(url);
-  const response = await fetch(resolved);
+  const response = await fetch(resolved, { signal });
 
   if (!response.ok) {
     throw new Error(`Failed to fetch board: HTTP ${response.status}`);

--- a/src/features/board/import/import-limits.ts
+++ b/src/features/board/import/import-limits.ts
@@ -1,0 +1,25 @@
+import type { UnzipLimits } from "@shayc/open-board-format";
+
+// Real boards reach ~70 MB; headroom, not open-ended.
+export const MAX_BOARD_FILE_BYTES = 150 * 1024 * 1024;
+
+export const BOARD_UNZIP_LIMITS = {
+  maxEntrySize: MAX_BOARD_FILE_BYTES,
+  // Board media is already-compressed PNG/JPEG/MP3 — real inflation is ~1x.
+  maxTotalOriginalSize: 500 * 1024 * 1024,
+  maxEntries: 10_000,
+} satisfies UnzipLimits;
+
+export class BoardFileTooLargeError extends Error {
+  constructor() {
+    super(`Board file exceeds the ${MAX_BOARD_FILE_BYTES} byte limit`);
+    this.name = "BoardFileTooLargeError";
+  }
+}
+
+export class UnsupportedBoardUrlError extends Error {
+  constructor(url: string) {
+    super(`Unsupported board URL scheme: ${url}`);
+    this.name = "UnsupportedBoardUrlError";
+  }
+}

--- a/src/features/board/import/use-board-file-drop.test.tsx
+++ b/src/features/board/import/use-board-file-drop.test.tsx
@@ -7,7 +7,6 @@ import { loadFixtureFile, resetBoardsDB } from "../testing";
 import { useBoardFileDrop } from "./use-board-file-drop";
 
 const OBF_FIXTURE = "lots-of-stuff.obf";
-const IMPORTED_SET_ID = "lots-of-stuff";
 
 function DropHarness() {
   const { isDraggingFiles, dropHandlers } = useBoardFileDrop();
@@ -121,14 +120,16 @@ describe("useBoardFileDrop", () => {
 
     fireDrag(zone, "drop", dataTransferWithFiles(boardFile));
 
+    let setId = "";
     await vi.waitFor(async () => {
       const boardSets = await listBoardSets();
       expect(boardSets).toHaveLength(1);
-      expect(boardSets[0]?.setId).toBe(IMPORTED_SET_ID);
+      setId = boardSets[0]?.setId ?? "";
+      expect(setId).not.toBe("");
     });
 
     await expect
       .element(screen.getByTestId("path"))
-      .toHaveTextContent(`/sets/${IMPORTED_SET_ID}/boards/`);
+      .toHaveTextContent(`/sets/${setId}/boards/`);
   });
 });

--- a/src/features/board/import/use-file-handler-launch.test.tsx
+++ b/src/features/board/import/use-file-handler-launch.test.tsx
@@ -7,7 +7,6 @@ import { loadFixtureFile, resetBoardsDB } from "../testing";
 import { useFileHandlerLaunch } from "./use-file-handler-launch";
 
 const OBF_FIXTURE = "lots-of-stuff.obf";
-const IMPORTED_SET_ID = "lots-of-stuff";
 
 function LaunchHarness() {
   useFileHandlerLaunch();
@@ -64,14 +63,16 @@ describe("useFileHandlerLaunch", () => {
       fileHandle(await loadFixtureFile(OBF_FIXTURE)),
     );
 
+    let setId = "";
     await vi.waitFor(async () => {
       const boardSets = await listBoardSets();
       expect(boardSets).toHaveLength(1);
-      expect(boardSets[0]?.setId).toBe(IMPORTED_SET_ID);
+      setId = boardSets[0]?.setId ?? "";
+      expect(setId).not.toBe("");
     });
 
     await expect
       .element(screen.getByTestId("path"))
-      .toHaveTextContent(`/sets/${IMPORTED_SET_ID}/boards/`);
+      .toHaveTextContent(`/sets/${setId}/boards/`);
   });
 });

--- a/src/features/board/import/use-import-board-files.test.tsx
+++ b/src/features/board/import/use-import-board-files.test.tsx
@@ -40,7 +40,7 @@ describe("useImportBoardFiles", () => {
       .toHaveTextContent("Board imported");
   });
 
-  test("shows the replaced message when the set already exists", async () => {
+  test("shows the already-in-library message when the set already exists", async () => {
     const file = await loadFixtureFile(OBF_FIXTURE);
     await importBoardSets(file);
 
@@ -49,6 +49,6 @@ describe("useImportBoardFiles", () => {
 
     await expect
       .element(screen.getByRole("alert"))
-      .toHaveTextContent("Board replaced");
+      .toHaveTextContent("Board already in your library");
   });
 });

--- a/src/features/board/import/use-import-board-files.ts
+++ b/src/features/board/import/use-import-board-files.ts
@@ -30,14 +30,15 @@ export function useImportBoardFiles(): UseImportBoardFilesReturn {
     try {
       const results = await importBoardSets(files);
 
-      const replacedExisting = results.some(
-        (result) => result.replacedExisting,
-      );
+      const importedCount = results.filter(
+        (result) => !result.alreadyExisted,
+      ).length;
 
       showSnackbar({
-        message: replacedExisting
-          ? m.libraryReplacedBoards({ count })
-          : m.libraryImportedBoards({ count }),
+        message:
+          importedCount === 0
+            ? m.importAlreadyInLibrary()
+            : m.libraryImportedBoards({ count: importedCount }),
         severity: "success",
       });
 

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -7,6 +7,11 @@ export { useBoardSets } from "./board-sets/use-board-sets";
 export { BoardViewer } from "./board-viewer";
 export { BoardFileDropOverlay } from "./import/board-file-drop-overlay";
 export { importBoardFromUrl } from "./import/import-from-url";
+export {
+  BoardFileTooLargeError,
+  MAX_BOARD_FILE_BYTES,
+  UnsupportedBoardUrlError,
+} from "./import/import-limits";
 export { useBoardFileDrop } from "./import/use-board-file-drop";
 export { useFileHandlerLaunch } from "./import/use-file-handler-launch";
 export { useImportBoardFiles } from "./import/use-import-board-files";

--- a/src/features/board/navigation/board-switcher.test.tsx
+++ b/src/features/board/navigation/board-switcher.test.tsx
@@ -9,7 +9,7 @@ import { RouterProvider } from "react-router/dom";
 import { beforeEach, describe, expect, test } from "vitest";
 import { render } from "vitest-browser-react";
 import { userEvent } from "vitest/browser";
-import { replaceBoardSet } from "../storage/boards-db";
+import { createBoardSet } from "../storage/boards-db";
 import { makeOBFBoard, resetBoardsDB } from "../testing";
 import { BoardSwitcher } from "./board-switcher";
 
@@ -36,7 +36,7 @@ async function renderSwitcher(initialPath: string) {
 beforeEach(async () => {
   setStoredLanguage(DEFAULT_LANGUAGE);
   await resetBoardsDB();
-  await replaceBoardSet({
+  await createBoardSet({
     boardSet: { setId: "set-1", name: "Set", rootBoardId: "root" },
     boards: [
       {
@@ -157,7 +157,7 @@ describe("BoardSwitcher", () => {
   });
 
   test("shows the cached translated name for the active language, falling back to the raw name otherwise", async () => {
-    await replaceBoardSet({
+    await createBoardSet({
       boardSet: { setId: "set-2", name: "Set", rootBoardId: "root" },
       boards: [
         {

--- a/src/features/board/storage/board-hydration.test.ts
+++ b/src/features/board/storage/board-hydration.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, test } from "vitest";
 import { assertDefined } from "@shared/testing/assert-defined";
 import { refreshBoardSets } from "../board-sets/board-sets-store";
 import { hydrateBoard } from "./board-hydration";
-import { BoardNotFoundError, replaceBoardSet } from "./boards-db";
+import { BoardNotFoundError, createBoardSet } from "./boards-db";
 import { resetBoardsDB } from "../testing";
 
 const SET_ID = "loader-test-set";
@@ -28,7 +28,7 @@ async function seedTestBoard(): Promise<void> {
     images: [{ id: "img-1", path: IMAGE_PATH, content_type: "image/png" }],
   };
 
-  await replaceBoardSet({
+  await createBoardSet({
     boardSet: { setId: SET_ID, name: "Loader Test", rootBoardId: BOARD_ID },
     boards: [{ boardId: BOARD_ID, name: "Test Board", obf: obfBoard }],
     assets: [{ path: IMAGE_PATH, blob: pngBlob }],

--- a/src/features/board/storage/boards-db.test.ts
+++ b/src/features/board/storage/boards-db.test.ts
@@ -1,24 +1,26 @@
+import { assertDefined } from "@shared/testing/assert-defined";
 import type { OBFBoard } from "@shayc/open-board-format";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { assertDefined } from "@shared/testing/assert-defined";
+import { makeOBFBoard, resetBoardsDB } from "../testing";
 import {
   closeBoardsDB,
+  createBoardSet,
   deleteBoardSetData,
+  findBoardSetBySourceHash,
   getAssetBlob,
   getBoard,
+  getBoardSet,
   getBoardsDB,
   InvalidIdError,
   listBoards,
   listBoardSets,
-  replaceBoardSet,
   updateBoardStrings,
-  type ReplaceBoardSetInput,
+  type CreateBoardSetInput,
 } from "./boards-db";
-import { makeOBFBoard, resetBoardsDB } from "../testing";
 
-function makeReplaceInput(
-  overrides: Partial<ReplaceBoardSetInput> = {},
-): ReplaceBoardSetInput {
+function makeCreateInput(
+  overrides: Partial<CreateBoardSetInput> = {},
+): CreateBoardSetInput {
   return {
     boardSet: { setId: "set-1", name: "Set", rootBoardId: "root-1" },
     boards: [],
@@ -33,15 +35,13 @@ beforeEach(async () => {
 
 afterEach(closeBoardsDB);
 
-describe("replaceBoardSet", () => {
+describe("createBoardSet", () => {
   test("inserts a new board set", async () => {
-    const { replacedExisting } = await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeCreateInput({
         boardSet: { setId: "set-1", name: "My Set", rootBoardId: "root-1" },
       }),
     );
-
-    expect(replacedExisting).toBe(false);
 
     const sets = await listBoardSets();
     expect(sets).toHaveLength(1);
@@ -57,7 +57,7 @@ describe("replaceBoardSet", () => {
       { boardId: "b3", name: "B3", obf: makeOBFBoard({ id: "b3" }) },
     ];
 
-    await replaceBoardSet(makeReplaceInput({ boards }));
+    await createBoardSet(makeCreateInput({ boards }));
 
     const sets = await listBoardSets();
     expect(sets[0].boardCount).toBe(3);
@@ -68,8 +68,8 @@ describe("replaceBoardSet", () => {
   });
 
   test("stores and retrieves asset blobs, normalizing paths", async () => {
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeCreateInput({
         assets: [
           { path: "images\\photo.png", blob: new Blob(["data"]) },
           { path: "/leading.png", blob: new Blob(["a"]) },
@@ -89,54 +89,54 @@ describe("replaceBoardSet", () => {
     );
   });
 
-  test("replaces an existing set wholesale: dropped boards, assets and metadata are gone", async () => {
-    await replaceBoardSet(
-      makeReplaceInput({
-        boardSet: {
-          setId: "set-1",
-          name: "Set v1",
-          rootBoardId: "a",
-          author: "Alice",
-        },
-        boards: [
-          { boardId: "a", name: "A", obf: makeOBFBoard({ id: "a" }) },
-          { boardId: "b", name: "B", obf: makeOBFBoard({ id: "b" }) },
-        ],
-        assets: [
-          { path: "x.png", blob: new Blob(["x"]) },
-          { path: "y.png", blob: new Blob(["y"]) },
-        ],
+  test("rejects creating a set whose id already exists", async () => {
+    await createBoardSet(
+      makeCreateInput({
+        boardSet: { setId: "set-1", name: "Set v1", rootBoardId: "a" },
       }),
     );
 
-    const { replacedExisting } = await replaceBoardSet(
-      makeReplaceInput({
-        boardSet: { setId: "set-1", name: "Set v2", rootBoardId: "a" },
-        boards: [{ boardId: "a", name: "A", obf: makeOBFBoard({ id: "a" }) }],
-        assets: [{ path: "x.png", blob: new Blob(["x"]) }],
-      }),
-    );
-
-    expect(replacedExisting).toBe(true);
+    await expect(
+      createBoardSet(
+        makeCreateInput({
+          boardSet: { setId: "set-1", name: "Set v2", rootBoardId: "b" },
+        }),
+      ),
+    ).rejects.toThrow();
 
     const sets = await listBoardSets();
     expect(sets).toHaveLength(1);
-    expect(sets[0].boardCount).toBe(1);
-    expect(sets[0].author).toBeUndefined();
-    expect(sets[0].rootBoardId).toBe("a");
-
-    expect(await getBoard("set-1", "a")).toBeDefined();
-    expect(await getBoard("set-1", "b")).toBeUndefined();
-    expect(await getAssetBlob("set-1", "x.png")).toBeInstanceOf(Blob);
-    expect(await getAssetBlob("set-1", "y.png")).toBeUndefined();
+    expect(sets[0].name).toBe("Set v1");
   });
 
-  test("aborts the entire transaction when a board fails to clone, leaving the prior set intact", async () => {
-    await replaceBoardSet(
-      makeReplaceInput({
+  test("creating a second set never touches an existing one", async () => {
+    await createBoardSet(
+      makeCreateInput({
+        boardSet: { setId: "set-1", name: "Set 1", rootBoardId: "a" },
+        boards: [{ boardId: "a", name: "A", obf: makeOBFBoard({ id: "a" }) }],
+      }),
+    );
+
+    await createBoardSet(
+      makeCreateInput({
+        boardSet: { setId: "set-2", name: "Set 2", rootBoardId: "b" },
+        boards: [{ boardId: "b", name: "B", obf: makeOBFBoard({ id: "b" }) }],
+      }),
+    );
+
+    const setOne = await getBoardSet("set-1");
+    expect(setOne?.name).toBe("Set 1");
+    expect(await getBoard("set-1", "a")).toBeDefined();
+    expect(await getBoard("set-1", "b")).toBeUndefined();
+    expect(await getBoard("set-2", "a")).toBeUndefined();
+  });
+
+  test("aborts the entire transaction when a board fails to clone, leaving other sets intact", async () => {
+    await createBoardSet(
+      makeCreateInput({
         boardSet: {
           setId: "set-1",
-          name: "Set v1",
+          name: "Set 1",
           rootBoardId: "a",
           author: "Alice",
         },
@@ -151,9 +151,9 @@ describe("replaceBoardSet", () => {
     } as unknown as OBFBoard;
 
     await expect(
-      replaceBoardSet(
-        makeReplaceInput({
-          boardSet: { setId: "set-1", name: "Set v2", rootBoardId: "b" },
+      createBoardSet(
+        makeCreateInput({
+          boardSet: { setId: "set-2", name: "Set 2", rootBoardId: "b" },
           boards: [{ boardId: "b", name: "B", obf: uncloneableObf }],
           assets: [],
         }),
@@ -162,18 +162,18 @@ describe("replaceBoardSet", () => {
 
     const sets = await listBoardSets();
     expect(sets).toHaveLength(1);
+    expect(sets[0].setId).toBe("set-1");
     expect(sets[0].author).toBe("Alice");
-    expect(sets[0].rootBoardId).toBe("a");
-    expect(sets[0].boardCount).toBe(1);
 
     expect(await getBoard("set-1", "a")).toBeDefined();
     expect(await getAssetBlob("set-1", "x.png")).toBeInstanceOf(Blob);
+    expect(await getBoard("set-2", "b")).toBeUndefined();
   });
 
   test("rejects empty setId", async () => {
     await expect(
-      replaceBoardSet(
-        makeReplaceInput({
+      createBoardSet(
+        makeCreateInput({
           boardSet: { setId: "", name: "Bad", rootBoardId: "root-1" },
         }),
       ),
@@ -182,8 +182,8 @@ describe("replaceBoardSet", () => {
 
   test("rejects empty setId with a typed InvalidIdError", async () => {
     await expect(
-      replaceBoardSet(
-        makeReplaceInput({
+      createBoardSet(
+        makeCreateInput({
           boardSet: { setId: "", name: "Bad", rootBoardId: "root-1" },
         }),
       ),
@@ -192,8 +192,8 @@ describe("replaceBoardSet", () => {
 
   test("rejects setId longer than 255 characters", async () => {
     await expect(
-      replaceBoardSet(
-        makeReplaceInput({
+      createBoardSet(
+        makeCreateInput({
           boardSet: {
             setId: "x".repeat(256),
             name: "Bad",
@@ -206,8 +206,8 @@ describe("replaceBoardSet", () => {
 
   test("rejects empty rootBoardId", async () => {
     await expect(
-      replaceBoardSet(
-        makeReplaceInput({
+      createBoardSet(
+        makeCreateInput({
           boardSet: { setId: "set-1", name: "Bad", rootBoardId: "" },
         }),
       ),
@@ -216,8 +216,8 @@ describe("replaceBoardSet", () => {
 
   test("rejects empty boardId", async () => {
     await expect(
-      replaceBoardSet(
-        makeReplaceInput({
+      createBoardSet(
+        makeCreateInput({
           boards: [{ boardId: "", name: "B", obf: makeOBFBoard() }],
         }),
       ),
@@ -226,14 +226,53 @@ describe("replaceBoardSet", () => {
 
   test("rejects boardId longer than 255 characters", async () => {
     await expect(
-      replaceBoardSet(
-        makeReplaceInput({
+      createBoardSet(
+        makeCreateInput({
           boards: [
             { boardId: "x".repeat(256), name: "B", obf: makeOBFBoard() },
           ],
         }),
       ),
     ).rejects.toThrow("Invalid boardId");
+  });
+});
+
+describe("findBoardSetBySourceHash", () => {
+  test("finds a set by its sourceHash", async () => {
+    await createBoardSet(
+      makeCreateInput({
+        boardSet: {
+          setId: "set-1",
+          name: "Set",
+          rootBoardId: "root-1",
+          sourceHash: "hash-a",
+        },
+      }),
+    );
+
+    const found = await findBoardSetBySourceHash("hash-a");
+    expect(found?.setId).toBe("set-1");
+  });
+
+  test("returns undefined when no set matches the hash", async () => {
+    await createBoardSet(
+      makeCreateInput({
+        boardSet: {
+          setId: "set-1",
+          name: "Set",
+          rootBoardId: "root-1",
+          sourceHash: "hash-a",
+        },
+      }),
+    );
+
+    expect(await findBoardSetBySourceHash("hash-b")).toBeUndefined();
+  });
+
+  test("never matches a set with no sourceHash", async () => {
+    await createBoardSet(makeCreateInput());
+
+    expect(await findBoardSetBySourceHash("hash-a")).toBeUndefined();
   });
 });
 
@@ -247,13 +286,13 @@ describe("listBoardSets", () => {
     let now = 1000;
     vi.spyOn(Date, "now").mockImplementation(() => (now += 1000));
 
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeCreateInput({
         boardSet: { setId: "old", name: "Old", rootBoardId: "root-1" },
       }),
     );
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeCreateInput({
         boardSet: { setId: "new", name: "New", rootBoardId: "root-1" },
       }),
     );
@@ -267,7 +306,7 @@ describe("listBoardSets", () => {
 
 describe("getBoard", () => {
   test("returns undefined for nonexistent board", async () => {
-    await replaceBoardSet(makeReplaceInput());
+    await createBoardSet(makeCreateInput());
 
     const board = await getBoard("set-1", "nonexistent");
     expect(board).toBeUndefined();
@@ -276,8 +315,8 @@ describe("getBoard", () => {
 
 describe("listBoards", () => {
   test("returns only the set's boards", async () => {
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeCreateInput({
         boardSet: { setId: "set-1", name: "Set 1", rootBoardId: "a" },
         boards: [
           { boardId: "a", name: "A", obf: makeOBFBoard({ id: "a" }) },
@@ -285,8 +324,8 @@ describe("listBoards", () => {
         ],
       }),
     );
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeCreateInput({
         boardSet: { setId: "set-2", name: "Set 2", rootBoardId: "c" },
         boards: [{ boardId: "c", name: "C", obf: makeOBFBoard({ id: "c" }) }],
       }),
@@ -298,7 +337,7 @@ describe("listBoards", () => {
   });
 
   test("returns empty array for a set with no boards", async () => {
-    await replaceBoardSet(makeReplaceInput());
+    await createBoardSet(makeCreateInput());
 
     const boards = await listBoards("set-1");
 
@@ -309,8 +348,8 @@ describe("listBoards", () => {
 describe("updateBoardStrings", () => {
   test("adds localized strings to a board", async () => {
     const obf = makeOBFBoard({ id: "b1" });
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeCreateInput({
         boards: [{ boardId: "b1", name: "B1", obf }],
       }),
     );
@@ -332,8 +371,8 @@ describe("updateBoardStrings", () => {
       id: "b1",
       strings: { fr: { hello: "bonjour" } },
     });
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeCreateInput({
         boards: [{ boardId: "b1", name: "B1", obf }],
       }),
     );
@@ -350,8 +389,8 @@ describe("updateBoardStrings", () => {
 
   test("replaces all strings when updating an existing locale", async () => {
     const obf = makeOBFBoard({ id: "b1" });
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeCreateInput({
         boards: [{ boardId: "b1", name: "B1", obf }],
       }),
     );
@@ -368,7 +407,7 @@ describe("updateBoardStrings", () => {
   });
 
   test("throws when board does not exist", async () => {
-    await replaceBoardSet(makeReplaceInput());
+    await createBoardSet(makeCreateInput());
 
     await expect(
       updateBoardStrings("set-1", "nonexistent", "es", {}),
@@ -378,7 +417,7 @@ describe("updateBoardStrings", () => {
 
 describe("deleteBoardSetData", () => {
   test("removes the board set record", async () => {
-    await replaceBoardSet(makeReplaceInput());
+    await createBoardSet(makeCreateInput());
 
     await deleteBoardSetData("set-1");
 
@@ -387,8 +426,8 @@ describe("deleteBoardSetData", () => {
   });
 
   test("cascade-deletes all boards in the set", async () => {
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeCreateInput({
         boards: [
           { boardId: "b1", name: "B1", obf: makeOBFBoard({ id: "b1" }) },
           { boardId: "b2", name: "B2", obf: makeOBFBoard({ id: "b2" }) },
@@ -403,8 +442,8 @@ describe("deleteBoardSetData", () => {
   });
 
   test("cascade-deletes all assets in the set", async () => {
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeCreateInput({
         assets: [
           { path: "img1.png", blob: new Blob(["a"]) },
           { path: "img2.png", blob: new Blob(["b"]) },
@@ -419,16 +458,16 @@ describe("deleteBoardSetData", () => {
   });
 
   test("does not affect other board sets", async () => {
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeCreateInput({
         boardSet: { setId: "set-1", name: "Set 1", rootBoardId: "root-1" },
         boards: [
           { boardId: "b1", name: "B1", obf: makeOBFBoard({ id: "b1" }) },
         ],
       }),
     );
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeCreateInput({
         boardSet: { setId: "set-2", name: "Set 2", rootBoardId: "root-1" },
         boards: [
           { boardId: "b2", name: "B2", obf: makeOBFBoard({ id: "b2" }) },
@@ -465,8 +504,8 @@ describe("getBoardsDB", () => {
     const second = await getBoardsDB();
     expect(second).not.toBe(first);
 
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeCreateInput({
         boardSet: { setId: "set-1", name: "Persisted", rootBoardId: "root-1" },
       }),
     );

--- a/src/features/board/storage/boards-db.ts
+++ b/src/features/board/storage/boards-db.ts
@@ -14,6 +14,15 @@ export interface BoardSetRecord {
   locale?: string;
   gridRows?: number;
   gridColumns?: number;
+  /**
+   * SHA-256 hex of the originally imported file's bytes — "this set's source
+   * content is byte-identical to the file it was imported from." Additive
+   * derived data (e.g. cached translations via `updateBoardStrings`)
+   * preserves it; any future feature that edits source content (button
+   * labels, grid layout, images) must clear it, or re-importing the pristine
+   * file will dedup to the edited set instead of importing a fresh copy.
+   */
+  sourceHash?: string;
 }
 
 export interface BoardRecord {
@@ -45,7 +54,7 @@ export class InvalidIdError extends Error {
   }
 }
 
-export interface UpsertBoardSetInput {
+export interface BoardSetInput {
   setId: string;
   name: string;
   rootBoardId: string;
@@ -55,15 +64,16 @@ export interface UpsertBoardSetInput {
   locale?: string;
   gridRows?: number;
   gridColumns?: number;
+  sourceHash?: string;
 }
 
-export interface UpsertBoardInput {
+export interface BoardInput {
   boardId: string;
   name: string;
   obf: OBFBoard;
 }
 
-export interface UpsertAssetInput {
+export interface AssetInput {
   path: string;
   blob: Blob;
 }
@@ -201,15 +211,15 @@ export async function deleteBoardSetData(setId: string): Promise<void> {
   ]);
 }
 
-export interface ReplaceBoardSetInput {
-  boardSet: UpsertBoardSetInput;
-  boards: UpsertBoardInput[];
-  assets: UpsertAssetInput[];
+export interface CreateBoardSetInput {
+  boardSet: BoardSetInput;
+  boards: BoardInput[];
+  assets: AssetInput[];
 }
 
-export async function replaceBoardSet(
-  input: ReplaceBoardSetInput,
-): Promise<{ replacedExisting: boolean }> {
+export async function createBoardSet(
+  input: CreateBoardSetInput,
+): Promise<void> {
   const { boardSet, boards, assets } = input;
   validateId(boardSet.setId, "setId");
   validateId(boardSet.rootBoardId, "rootBoardId");
@@ -224,9 +234,6 @@ export async function replaceBoardSet(
   const boardStore = tx.objectStore("boards");
   const assetStore = tx.objectStore("assets");
 
-  const existing = await boardSetStore.get(setId);
-  const setRange = boardSetRange(setId);
-
   const record: BoardSetRecord = {
     setId,
     name: boardSet.name,
@@ -239,6 +246,7 @@ export async function replaceBoardSet(
     locale: boardSet.locale,
     gridRows: boardSet.gridRows,
     gridColumns: boardSet.gridColumns,
+    sourceHash: boardSet.sourceHash,
   };
 
   // idb creates tx.done eagerly when the transaction is opened, and requests
@@ -248,7 +256,6 @@ export async function replaceBoardSet(
   const requests: Promise<unknown>[] = [tx.done];
 
   try {
-    requests.push(boardStore.delete(setRange), assetStore.delete(setRange));
     for (const board of boards) {
       requests.push(
         boardStore.put({
@@ -268,7 +275,7 @@ export async function replaceBoardSet(
         }),
       );
     }
-    requests.push(boardSetStore.put(record));
+    requests.push(boardSetStore.add(record));
 
     await Promise.all(requests);
   } catch (error) {
@@ -280,8 +287,15 @@ export async function replaceBoardSet(
     await Promise.allSettled(requests);
     throw error;
   }
+}
 
-  return { replacedExisting: existing !== undefined };
+export async function findBoardSetBySourceHash(
+  sourceHash: string,
+): Promise<BoardSetRecord | undefined> {
+  const db = await getBoardsDB();
+  const boardSets = await db.getAll("boardSets");
+
+  return boardSets.find((boardSet) => boardSet.sourceHash === sourceHash);
 }
 
 export async function getBoard(

--- a/src/features/board/testing/db.ts
+++ b/src/features/board/testing/db.ts
@@ -1,8 +1,8 @@
 import type { OBFBoard } from "@shayc/open-board-format";
 import { refreshBoardSets } from "../board-sets/board-sets-store";
 import {
+  createBoardSet,
   getBoardsDB,
-  replaceBoardSet,
   type BoardRecord,
   type BoardSetRecord,
 } from "../storage/boards-db";
@@ -48,7 +48,7 @@ export async function resetBoardsDB(): Promise<void> {
 export async function seedBoardSets(records: SeedBoardSet[]): Promise<void> {
   await clearBoardsDB();
   for (const { boards = [], ...record } of records) {
-    await replaceBoardSet({
+    await createBoardSet({
       boardSet: { name: record.setId, ...record },
       boards,
       assets: [],

--- a/src/features/board/translation/resolve-translated-board.test.ts
+++ b/src/features/board/translation/resolve-translated-board.test.ts
@@ -3,7 +3,7 @@ import {
   stubTranslator,
 } from "@shared/testing/built-in-ai";
 import { beforeEach, describe, expect, test } from "vitest";
-import { getBoard, replaceBoardSet } from "../storage/boards-db";
+import { getBoard, createBoardSet } from "../storage/boards-db";
 import { resetBoardsDB } from "../testing";
 import type { Board } from "../types";
 import { resolveTranslatedBoard } from "./resolve-translated-board";
@@ -76,7 +76,7 @@ describe("resolveTranslatedBoard", () => {
   });
 
   test("persists a fresh translation so the next load hits the cache", async () => {
-    await replaceBoardSet({
+    await createBoardSet({
       boardSet: { setId: "set-1", name: "set-1", rootBoardId: "board-1" },
       boards: [
         {

--- a/src/pages/root-index-page.test.tsx
+++ b/src/pages/root-index-page.test.tsx
@@ -6,6 +6,7 @@ import {
   seedBoardSets,
 } from "@features/board/testing";
 import { AppProviders } from "@shared/providers/app-providers";
+import { StrictMode } from "react";
 import { createMemoryRouter } from "react-router";
 import { RouterProvider } from "react-router/dom";
 import { beforeEach, describe, expect, test, vi } from "vitest";
@@ -18,9 +19,11 @@ async function renderAt(path: string) {
   const router = createMemoryRouter(appRoutes, { initialEntries: [path] });
 
   const screen = await render(
-    <AppProviders>
-      <RouterProvider router={router} />
-    </AppProviders>,
+    <StrictMode>
+      <AppProviders>
+        <RouterProvider router={router} />
+      </AppProviders>
+    </StrictMode>,
   );
 
   const continueButton = screen.getByRole("button", { name: "Continue" });
@@ -113,12 +116,16 @@ describe("root index route", () => {
     await expect
       .element(screen.getByText("Couldn't import board"))
       .toBeVisible();
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    // StrictMode double-invokes the mount effect: the first (aborted) run
+    // still calls fetch before its cleanup fires, so the initial mount
+    // accounts for two calls, not one.
+    const callsBeforeRetry = fetchSpy.mock.calls.length;
+    expect(callsBeforeRetry).toBeGreaterThanOrEqual(1);
 
     await screen.getByRole("button", { name: "Try again" }).click();
 
     await vi.waitFor(() => {
-      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(fetchSpy.mock.calls.length).toBeGreaterThan(callsBeforeRetry);
     });
   });
 

--- a/src/pages/root-index-page.test.tsx
+++ b/src/pages/root-index-page.test.tsx
@@ -1,0 +1,132 @@
+import { appRoutes } from "@app/routing/app-routes";
+import { getBoardSets } from "@features/board";
+import {
+  makeOBFBoard,
+  resetBoardsDB,
+  seedBoardSets,
+} from "@features/board/testing";
+import { AppProviders } from "@shared/providers/app-providers";
+import { createMemoryRouter } from "react-router";
+import { RouterProvider } from "react-router/dom";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+const OBF_FIXTURE_URL =
+  "/src/features/board/testing/sample-boards/lots-of-stuff.obf";
+
+async function renderAt(path: string) {
+  const router = createMemoryRouter(appRoutes, { initialEntries: [path] });
+
+  const screen = await render(
+    <AppProviders>
+      <RouterProvider router={router} />
+    </AppProviders>,
+  );
+
+  const continueButton = screen.getByRole("button", { name: "Continue" });
+  if (continueButton.query()) {
+    await continueButton.click();
+  }
+
+  return screen;
+}
+
+describe("root index route", () => {
+  beforeEach(async () => {
+    await resetBoardsDB();
+  });
+
+  test("imports the ?board URL and opens the board", async () => {
+    const screen = await renderAt(
+      `/?board=${encodeURIComponent(OBF_FIXTURE_URL)}`,
+    );
+
+    await expect
+      .element(screen.getByRole("grid", { name: "Lots of Stuff Board" }))
+      .toBeVisible();
+
+    expect(await getBoardSets()).toHaveLength(1);
+  });
+
+  test("re-visiting the same ?board URL dedups instead of importing again", async () => {
+    const firstScreen = await renderAt(
+      `/?board=${encodeURIComponent(OBF_FIXTURE_URL)}`,
+    );
+    await vi.waitFor(async () => {
+      expect(await getBoardSets()).toHaveLength(1);
+    });
+    await firstScreen.unmount();
+
+    const screen = await renderAt(
+      `/?board=${encodeURIComponent(OBF_FIXTURE_URL)}`,
+    );
+
+    await expect
+      .element(screen.getByRole("grid", { name: "Lots of Stuff Board" }))
+      .toBeVisible();
+    await expect
+      .element(screen.getByRole("alert"))
+      .toHaveTextContent("Board already in your library");
+
+    expect(await getBoardSets()).toHaveLength(1);
+  });
+
+  test("shows a localized error for an unsupported URL scheme, with a way back to an existing set", async () => {
+    await seedBoardSets([
+      {
+        setId: "existing-set",
+        rootBoardId: "root",
+        boards: [
+          {
+            boardId: "root",
+            name: "Home",
+            obf: makeOBFBoard({ id: "root", name: "Home" }),
+          },
+        ],
+      },
+    ]);
+
+    const screen = await renderAt(
+      `/?board=${encodeURIComponent("data:text/plain;base64,Zm9v")}`,
+    );
+
+    await expect
+      .element(screen.getByText("This link type can't be imported"))
+      .toBeVisible();
+
+    await screen.getByRole("button", { name: "Go to my boards" }).click();
+
+    await expect
+      .element(screen.getByRole("grid", { name: "Home" }))
+      .toBeVisible();
+  });
+
+  test("shows a generic import-failed error and retries on request", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("not a valid board"));
+
+    const screen = await renderAt(
+      `/?board=${encodeURIComponent("https://example.com/broken.obz")}`,
+    );
+
+    await expect
+      .element(screen.getByText("Couldn't import board"))
+      .toBeVisible();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    await screen.getByRole("button", { name: "Try again" }).click();
+
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  test("empty database: auto-imports the bundled starter board", async () => {
+    const screen = await renderAt("/");
+
+    await expect
+      .element(screen.getByRole("grid", { name: "Quick Core 24" }))
+      .toBeVisible();
+  });
+});

--- a/src/pages/root-index-page.tsx
+++ b/src/pages/root-index-page.tsx
@@ -1,0 +1,60 @@
+import type { RootIndexLoaderData } from "@app/routing/loaders/root-index-loader";
+import {
+  boardSetPath,
+  BoardFileTooLargeError,
+  UnsupportedBoardUrlError,
+  useBoardSets,
+} from "@features/board";
+import Button from "@mui/material/Button";
+import Stack from "@mui/material/Stack";
+import { m } from "@paraglide/messages.js";
+import { ErrorState } from "@shared/components/error-state";
+import { LoadingState } from "@shared/components/loading-state";
+import { OBFError } from "@shayc/open-board-format";
+import { useLoaderData, useNavigate } from "react-router";
+import { useUrlBoardImport } from "./use-url-board-import";
+
+function describeImportError(error: unknown): string | undefined {
+  if (error instanceof UnsupportedBoardUrlError) {
+    return m.importUrlNotSupported();
+  }
+
+  if (
+    error instanceof BoardFileTooLargeError ||
+    (error instanceof OBFError && error.info.code === "archive-too-large")
+  ) {
+    return m.importTooLarge();
+  }
+
+  return undefined;
+}
+
+export const Component = function RootIndexPage() {
+  const { importUrl } = useLoaderData<RootIndexLoaderData>();
+  const state = useUrlBoardImport(importUrl);
+  const { boardSets } = useBoardSets();
+  const navigate = useNavigate();
+
+  if (state.status === "importing") {
+    return <LoadingState />;
+  }
+
+  return (
+    <ErrorState
+      title={m.importFailedTitle()}
+      description={describeImportError(state.error)}
+      action={
+        <Stack direction="row" spacing={2}>
+          <Button variant="contained" onClick={state.retry}>
+            {m.importRetry()}
+          </Button>
+          {boardSets.length > 0 && (
+            <Button onClick={() => void navigate(boardSetPath(boardSets[0]))}>
+              {m.importGoToBoards()}
+            </Button>
+          )}
+        </Stack>
+      }
+    />
+  );
+};

--- a/src/pages/use-url-board-import.ts
+++ b/src/pages/use-url-board-import.ts
@@ -1,0 +1,63 @@
+import { boardSetPath, importBoardFromUrl } from "@features/board";
+import { m } from "@paraglide/messages.js";
+import { useSnackbar } from "@shared/snackbar/use-snackbar";
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router";
+
+export type UrlBoardImportState =
+  | { status: "importing" }
+  | { status: "error"; error: unknown; retry: () => void };
+
+interface ImportOutcome {
+  key: string;
+  error: unknown;
+}
+
+export function useUrlBoardImport(importUrl: string): UrlBoardImportState {
+  const { showSnackbar } = useSnackbar();
+  const navigate = useNavigate();
+  const [attempt, setAttempt] = useState(0);
+  const [outcome, setOutcome] = useState<ImportOutcome | null>(null);
+  const startedKey = useRef<string | null>(null);
+  const key = `${importUrl}:${String(attempt)}`;
+
+  useEffect(() => {
+    if (startedKey.current === key) {
+      return;
+    }
+    startedKey.current = key;
+
+    let cancelled = false;
+
+    importBoardFromUrl(importUrl).then(
+      (result) => {
+        if (cancelled) {
+          return;
+        }
+        if (result.alreadyExisted) {
+          showSnackbar({ message: m.importAlreadyInLibrary() });
+        }
+        void navigate(boardSetPath(result), { replace: true });
+      },
+      (error: unknown) => {
+        if (!cancelled) {
+          setOutcome({ key, error });
+        }
+      },
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [importUrl, key, navigate, showSnackbar]);
+
+  if (outcome?.key === key) {
+    return {
+      status: "error",
+      error: outcome.error,
+      retry: () => setAttempt((n) => n + 1),
+    };
+  }
+
+  return { status: "importing" };
+}

--- a/src/pages/use-url-board-import.ts
+++ b/src/pages/use-url-board-import.ts
@@ -1,63 +1,37 @@
 import { boardSetPath, importBoardFromUrl } from "@features/board";
 import { m } from "@paraglide/messages.js";
+import { useLatestAsync } from "@shared/hooks/use-latest-async";
 import { useSnackbar } from "@shared/snackbar/use-snackbar";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router";
 
 export type UrlBoardImportState =
   | { status: "importing" }
   | { status: "error"; error: unknown; retry: () => void };
 
-interface ImportOutcome {
-  key: string;
-  error: unknown;
-}
-
 export function useUrlBoardImport(importUrl: string): UrlBoardImportState {
   const { showSnackbar } = useSnackbar();
   const navigate = useNavigate();
   const [attempt, setAttempt] = useState(0);
-  const [outcome, setOutcome] = useState<ImportOutcome | null>(null);
-  const startedKey = useRef<string | null>(null);
-  const key = `${importUrl}:${String(attempt)}`;
+
+  const { value, error } = useLatestAsync({
+    enabled: true,
+    deps: [importUrl, attempt],
+    fetch: (signal) => importBoardFromUrl(importUrl, signal),
+  });
 
   useEffect(() => {
-    if (startedKey.current === key) {
+    if (!value) {
       return;
     }
-    startedKey.current = key;
+    if (value.alreadyExisted) {
+      showSnackbar({ message: m.importAlreadyInLibrary() });
+    }
+    void navigate(boardSetPath(value), { replace: true });
+  }, [value, navigate, showSnackbar]);
 
-    let cancelled = false;
-
-    importBoardFromUrl(importUrl).then(
-      (result) => {
-        if (cancelled) {
-          return;
-        }
-        if (result.alreadyExisted) {
-          showSnackbar({ message: m.importAlreadyInLibrary() });
-        }
-        void navigate(boardSetPath(result), { replace: true });
-      },
-      (error: unknown) => {
-        if (!cancelled) {
-          setOutcome({ key, error });
-        }
-      },
-    );
-
-    return () => {
-      cancelled = true;
-    };
-  }, [importUrl, key, navigate, showSnackbar]);
-
-  if (outcome?.key === key) {
-    return {
-      status: "error",
-      error: outcome.error,
-      retry: () => setAttempt((n) => n + 1),
-    };
+  if (error) {
+    return { status: "error", error, retry: () => setAttempt((n) => n + 1) };
   }
-
   return { status: "importing" };
 }


### PR DESCRIPTION
## Summary

- **Vulnerability:** board-set identity (`setId`) was derived from the imported filename. A crafted `?board=` link (advertised in the README, auto-imported with no confirmation) or a plain filename collision from the file picker/drag-drop/OS file-handler could **silently overwrite an existing board set** — a nonverbal user's vocabulary, destroyed with no warning.
- **Fix — insert-only, content-addressed identity:** every import now gets a fresh random `setId`. Filename-derived IDs are gone; imports can never address, modify, or replace an existing set, on any of the four import paths (picker, drag-drop, URL, PWA file handler). A SHA-256 `sourceHash` of the imported bytes dedups a byte-identical re-import to the existing set instead of duplicating it — safe by construction, since a hash match means identical content. Cached translations (`updateBoardStrings`, background derived data) preserve `sourceHash`, so viewing a board in another language doesn't break bookmark idempotence.
- **Root loader is now read-only.** The `?board=` import and first-run default-board bootstrap moved out of `rootIndexLoader` into a new `root-index-page.tsx`, which shows a loading state during import and a localized in-app error (never the route error boundary) on failure, with Retry and a way back to an existing set.
- **Hardened the untrusted-bytes boundary end to end:** `http(s)`-only URL scheme allowlist (rejects `data:`/`blob:`/`javascript:`), a 150 MB cap enforced via `Content-Length`, by counting bytes while streaming (aborts mid-download on a missing/lying header), and via `File.size` for local files; zip-bomb protection via `@shayc/open-board-format`'s `UnzipLimits`, already installed at `^1.2.0`, passed through every import path.

## Follow-up fixes (post-review)

- **StrictMode hang fixed:** `useUrlBoardImport` no longer hand-rolls a keyed async effect; it now rides on the shared `useLatestAsync` hook (AbortController + signature comparison), which correctly cancels the orphaned in-flight import on `<StrictMode>`'s double-mount instead of hanging forever on `<LoadingState />`. `importBoardFromUrl` forwards the abort signal into `fetch` so the aborted run cancels its download rather than racing the real one. Reproduced and fixed under `<StrictMode>` in `root-index-page.test.tsx`.
- **Insecure-origin regression fixed:** `crypto.subtle.digest`/`crypto.randomUUID()` are secure-context-only, so imports (including first-run bootstrap) threw on plain-http LAN origins. Now `setId` comes from the existing `randomId()` helper (falls back to `crypto.getRandomValues`), and content-hash dedup is skipped when `crypto.subtle` is unavailable — imports still work everywhere, just without dedup on insecure origins.

## Intentional behavior changes

- No more in-place update on re-import — a changed file becomes a *second* set; delete the old one via the existing delete dialog.
- `data:` URLs no longer import (previously worked).
- `?board=` fetch/parse failures show a localized in-app error state instead of the router error boundary.
- New `setId`s are random ids (`/sets/<id>/...`); existing sets keep their old ids and URLs — no migration needed.
- First-run bootstrap renders a loading page instead of blocking pre-render inside the loader.
- On insecure (plain-http) origins without `crypto.subtle`, dedup is skipped — imports still work, just without content-based deduplication.

## Explicitly out of scope (residual risks, accepted)

- `?board=` still auto-imports without confirmation — it can *add* sets and consume storage quota (bounded to 150 MB/click), but can never destroy data.
- Two tabs importing the same file concurrently could race past the dedup check and create a duplicate set — harmless, no cross-tab locking added.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` (Vitest browser mode, 74 files / 510 tests) — all pass
- [x] `npm run build` (tsc + vite build) — clean
- [x] `npx vitest run --coverage` — thresholds met
- [x] New regression test: importing two different files under the same filename creates two independent sets, first set's boards untouched (`board-import.test.ts`)
- [x] Dedup tests: same file re-imported (sequential and same-batch) reuses the existing set; translation caching doesn't break dedup
- [x] Insecure-context test: stubbed `crypto` without `subtle`/`randomUUID` — import succeeds, stored record has no `sourceHash`, re-import creates a second set (`board-import.test.ts`)
- [x] Size-cap and zip-bomb tests (byte-patched ZIP central directory) both reject before/without inflating
- [x] URL boundary tests: non-http(s) schemes never reach `fetch`; Content-Length-over-cap rejects without reading the body; missing-Content-Length stream aborts mid-download
- [x] `root-index-page.test.tsx` (now rendered under `<StrictMode>`, matching `main.tsx`): `?board=` import → board opens; re-visit dedups with snackbar; unsupported scheme shows localized error with a way back to an existing set; generic failure shows Retry; empty-DB bootstrap still works
- [x] Message keys (`importAlreadyInLibrary`, `importUrlNotSupported`, `importTooLarge`, `importFailedTitle`, `importRetry`, `importGoToBoards`) added and translated in all 35 locale files; `libraryReplacedBoards` removed everywhere
- [x] `docs/architecture.md` updated: insert-only import invariant, `sourceHash` semantics (including the insecure-context skip), loader read-only invariant (translation-cache write in `boardLoader` is a documented, unchanged exception)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
