### PR TITLE
Reject oversized OBZ archives to defend against zip bombs

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "اللوحة كبيرة جدًا بحيث يتعذّر استيرادها",
+        "countPlural=*": "اللوحات كبيرة جدًا بحيث يتعذّر استيرادها"
+      }
+    }
+  ],
   "libraryDropToImport": "أفلت ملفات اللوحات لاستيرادها",
   "libraryInfo": "معلومات",
   "libraryDelete": "حذف",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Дъската е твърде голяма за импортиране",
+        "countPlural=*": "Дъските са твърде големи за импортиране"
+      }
+    }
+  ],
   "libraryDropToImport": "Пуснете файловете с дъски за импортиране",
   "libraryInfo": "Информация",
   "libraryDelete": "Изтриване",

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "বোর্ডটি আমদানি করার জন্য খুব বড়",
+        "countPlural=*": "বোর্ডগুলি আমদানি করার জন্য খুব বড়"
+      }
+    }
+  ],
   "libraryDropToImport": "আমদানি করতে বোর্ড ফাইল ছাড়ুন",
   "libraryInfo": "তথ্য",
   "libraryDelete": "মুছুন",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tabulka je příliš velká na import",
+        "countPlural=*": "Tabulky jsou příliš velké na import"
+      }
+    }
+  ],
   "libraryDropToImport": "Přetáhněte sem soubory tabulek pro import",
   "libraryInfo": "Informace",
   "libraryDelete": "Smazat",

--- a/messages/da.json
+++ b/messages/da.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tavlen er for stor til at blive importeret",
+        "countPlural=*": "Tavlerne er for store til at blive importeret"
+      }
+    }
+  ],
   "libraryDropToImport": "Slip tavlefiler for at importere",
   "libraryInfo": "Info",
   "libraryDelete": "Slet",

--- a/messages/de.json
+++ b/messages/de.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Die Tafel ist zu groß zum Importieren",
+        "countPlural=*": "Die Tafeln sind zu groß zum Importieren"
+      }
+    }
+  ],
   "libraryDropToImport": "Tafeldateien zum Importieren ablegen",
   "libraryInfo": "Info",
   "libraryDelete": "Löschen",

--- a/messages/el.json
+++ b/messages/el.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Ο πίνακας είναι πολύ μεγάλος για εισαγωγή",
+        "countPlural=*": "Οι πίνακες είναι πολύ μεγάλοι για εισαγωγή"
+      }
+    }
+  ],
   "libraryDropToImport": "Αφήστε αρχεία πινάκων για εισαγωγή",
   "libraryInfo": "Πληροφορίες",
   "libraryDelete": "Διαγραφή",

--- a/messages/en.json
+++ b/messages/en.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Board is too large to import",
+        "countPlural=*": "Boards are too large to import"
+      }
+    }
+  ],
   "libraryDropToImport": "Drop board files to import",
   "libraryInfo": "Info",
   "libraryDelete": "Delete",

--- a/messages/es.json
+++ b/messages/es.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "El tablero es demasiado grande para importarlo",
+        "countPlural=*": "Los tableros son demasiado grandes para importarlos"
+      }
+    }
+  ],
   "libraryDropToImport": "Suelta archivos de tableros para importar",
   "libraryInfo": "Información",
   "libraryDelete": "Eliminar",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Taulu on liian suuri tuotavaksi",
+        "countPlural=*": "Taulut ovat liian suuria tuotaviksi"
+      }
+    }
+  ],
   "libraryDropToImport": "Pudota taulutiedostot tuodaksesi",
   "libraryInfo": "Tiedot",
   "libraryDelete": "Poista",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Le tableau est trop volumineux pour être importé",
+        "countPlural=*": "Les tableaux sont trop volumineux pour être importés"
+      }
+    }
+  ],
   "libraryDropToImport": "Déposez des fichiers de tableaux pour les importer",
   "libraryInfo": "Infos",
   "libraryDelete": "Supprimer",

--- a/messages/he.json
+++ b/messages/he.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "הלוח גדול מדי לייבוא",
+        "countPlural=*": "הלוחות גדולים מדי לייבוא"
+      }
+    }
+  ],
   "libraryDropToImport": "גרירת קובצי לוחות לכאן לייבוא",
   "libraryInfo": "פרטים",
   "libraryDelete": "מחיקה",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "बोर्ड आयात करने के लिए बहुत बड़ा है",
+        "countPlural=*": "बोर्ड आयात करने के लिए बहुत बड़े हैं"
+      }
+    }
+  ],
   "libraryDropToImport": "आयात करने के लिए बोर्ड फ़ाइलें छोड़ें",
   "libraryInfo": "जानकारी",
   "libraryDelete": "हटाएँ",

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Ploča je prevelika za uvoz",
+        "countPlural=*": "Ploče su prevelike za uvoz"
+      }
+    }
+  ],
   "libraryDropToImport": "Ispustite datoteke ploča za uvoz",
   "libraryInfo": "Informacije",
   "libraryDelete": "Izbriši",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "A tábla túl nagy az importáláshoz",
+        "countPlural=*": "A táblák túl nagyok az importáláshoz"
+      }
+    }
+  ],
   "libraryDropToImport": "Ejtsd ide a táblafájlokat az importáláshoz",
   "libraryInfo": "Információ",
   "libraryDelete": "Törlés",

--- a/messages/id.json
+++ b/messages/id.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Papan terlalu besar untuk diimpor",
+        "countPlural=*": "Papan terlalu besar untuk diimpor"
+      }
+    }
+  ],
   "libraryDropToImport": "Lepaskan berkas papan untuk mengimpor",
   "libraryInfo": "Info",
   "libraryDelete": "Hapus",

--- a/messages/it.json
+++ b/messages/it.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "La tabella è troppo grande per essere importata",
+        "countPlural=*": "Le tabelle sono troppo grandi per essere importate"
+      }
+    }
+  ],
   "libraryDropToImport": "Rilascia i file delle tabelle per importare",
   "libraryInfo": "Informazioni",
   "libraryDelete": "Elimina",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "ボードが大きすぎてインポートできません",
+        "countPlural=*": "ボードが大きすぎてインポートできません"
+      }
+    }
+  ],
   "libraryDropToImport": "ボードファイルをドロップしてインポート",
   "libraryInfo": "情報",
   "libraryDelete": "削除",

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "ಬೋರ್ಡ್ ಆಮದು ಮಾಡಲು ತುಂಬಾ ದೊಡ್ಡದಾಗಿದೆ",
+        "countPlural=*": "ಬೋರ್ಡ್‌ಗಳು ಆಮದು ಮಾಡಲು ತುಂಬಾ ದೊಡ್ಡದಾಗಿವೆ"
+      }
+    }
+  ],
   "libraryDropToImport": "ಆಮದು ಮಾಡಲು ಬೋರ್ಡ್ ಫೈಲ್‌ಗಳನ್ನು ಬಿಡಿ",
   "libraryInfo": "ಮಾಹಿತಿ",
   "libraryDelete": "ಅಳಿಸಿ",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "보드가 너무 커서 가져올 수 없습니다",
+        "countPlural=*": "보드가 너무 커서 가져올 수 없습니다"
+      }
+    }
+  ],
   "libraryDropToImport": "가져오려면 보드 파일을 놓으세요",
   "libraryInfo": "정보",
   "libraryDelete": "삭제",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Het bord is te groot om te importeren",
+        "countPlural=*": "De borden zijn te groot om te importeren"
+      }
+    }
+  ],
   "libraryDropToImport": "Zet bordbestanden neer om te importeren",
   "libraryInfo": "Info",
   "libraryDelete": "Verwijderen",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tablica jest zbyt duża, aby ją zaimportować",
+        "countPlural=*": "Tablice są zbyt duże, aby je zaimportować"
+      }
+    }
+  ],
   "libraryDropToImport": "Upuść pliki tablic, aby zaimportować",
   "libraryInfo": "Informacje",
   "libraryDelete": "Usuń",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "A prancha é grande demais para importar",
+        "countPlural=*": "As pranchas são grandes demais para importar"
+      }
+    }
+  ],
   "libraryDropToImport": "Solte arquivos de pranchas para importar",
   "libraryInfo": "Informações",
   "libraryDelete": "Excluir",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tabla este prea mare pentru a fi importată",
+        "countPlural=*": "Tablele sunt prea mari pentru a fi importate"
+      }
+    }
+  ],
   "libraryDropToImport": "Plasează fișierele de table pentru a le importa",
   "libraryInfo": "Informații",
   "libraryDelete": "Șterge",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Доска слишком большая для импорта",
+        "countPlural=*": "Доски слишком большие для импорта"
+      }
+    }
+  ],
   "libraryDropToImport": "Перетащите файлы досок для импорта",
   "libraryInfo": "Сведения",
   "libraryDelete": "Удалить",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tabuľka je príliš veľká na import",
+        "countPlural=*": "Tabuľky sú príliš veľké na import"
+      }
+    }
+  ],
   "libraryDropToImport": "Pustite súbory tabuliek na import",
   "libraryInfo": "Informácie",
   "libraryDelete": "Odstrániť",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tabla je prevelika za uvoz",
+        "countPlural=*": "Table so prevelike za uvoz"
+      }
+    }
+  ],
   "libraryDropToImport": "Spustite datoteke tabel za uvoz",
   "libraryInfo": "Informacije",
   "libraryDelete": "Izbriši",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tavlan är för stor för att importeras",
+        "countPlural=*": "Tavlorna är för stora för att importeras"
+      }
+    }
+  ],
   "libraryDropToImport": "Släpp tavelfiler för att importera",
   "libraryInfo": "Info",
   "libraryDelete": "Ta bort",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "பலகை இறக்குமதி செய்ய மிகப் பெரியது",
+        "countPlural=*": "பலகைகள் இறக்குமதி செய்ய மிகப் பெரியவை"
+      }
+    }
+  ],
   "libraryDropToImport": "இறக்குமதி செய்ய பலகை கோப்புகளை விடுங்கள்",
   "libraryInfo": "தகவல்",
   "libraryDelete": "நீக்கு",

--- a/messages/te.json
+++ b/messages/te.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "బోర్డు దిగుమతి చేయడానికి చాలా పెద్దది",
+        "countPlural=*": "బోర్డులు దిగుమతి చేయడానికి చాలా పెద్దవి"
+      }
+    }
+  ],
   "libraryDropToImport": "దిగుమతి చేయడానికి బోర్డు ఫైళ్లను వదలండి",
   "libraryInfo": "సమాచారం",
   "libraryDelete": "తొలగించు",

--- a/messages/th.json
+++ b/messages/th.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "บอร์ดมีขนาดใหญ่เกินไปที่จะนำเข้า",
+        "countPlural=*": "บอร์ดมีขนาดใหญ่เกินไปที่จะนำเข้า"
+      }
+    }
+  ],
   "libraryDropToImport": "วางไฟล์บอร์ดเพื่อนำเข้า",
   "libraryInfo": "ข้อมูล",
   "libraryDelete": "ลบ",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Pano içe aktarılamayacak kadar büyük",
+        "countPlural=*": "Panolar içe aktarılamayacak kadar büyük"
+      }
+    }
+  ],
   "libraryDropToImport": "İçe aktarmak için pano dosyalarını bırakın",
   "libraryInfo": "Bilgi",
   "libraryDelete": "Sil",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Дошка занадто велика для імпортування",
+        "countPlural=*": "Дошки занадто великі для імпортування"
+      }
+    }
+  ],
   "libraryDropToImport": "Перетягніть файли дошок для імпорту",
   "libraryInfo": "Інформація",
   "libraryDelete": "Видалити",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Bảng quá lớn để nhập",
+        "countPlural=*": "Các bảng quá lớn để nhập"
+      }
+    }
+  ],
   "libraryDropToImport": "Thả tệp bảng để nhập",
   "libraryInfo": "Thông tin",
   "libraryDelete": "Xóa",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -50,6 +50,16 @@
       }
     }
   ],
+  "libraryImportTooLargeBoards": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "沟通板过大，无法导入",
+        "countPlural=*": "沟通板过大，无法导入"
+      }
+    }
+  ],
   "libraryDropToImport": "拖放沟通板文件以导入",
   "libraryInfo": "信息",
   "libraryDelete": "删除",

--- a/src/features/board/import/board-import.test.ts
+++ b/src/features/board/import/board-import.test.ts
@@ -1,5 +1,11 @@
 import { assertDefined } from "@shared/testing/assert-defined";
-import { loadOBF, loadOBZ, type OBFBoard } from "@shayc/open-board-format";
+import {
+  loadOBF,
+  loadOBZ,
+  OBFError,
+  zip,
+  type OBFBoard,
+} from "@shayc/open-board-format";
 import { beforeEach, describe, expect, test } from "vitest";
 import {
   getAssetBlob,
@@ -9,6 +15,7 @@ import {
 } from "../storage/boards-db";
 import { loadFixtureFile, resetBoardsDB } from "../testing";
 import {
+  BOARD_IMPORT_LIMITS,
   buildAssetInputs,
   importBoardSets,
   resolveLoadBoardPaths,
@@ -205,6 +212,26 @@ describe("importBoardSets", () => {
 
     const boardSets = await listBoardSets();
     expect(boardSets).toHaveLength(1);
+  });
+
+  test("rejects an OBZ whose declared uncompressed size exceeds the per-entry limit", async () => {
+    // A buffer of zeros compresses to a tiny archive, but its central-directory
+    // metadata declares the full uncompressed size — so the limit trips on the
+    // declared size before any inflation happens (zip-bomb defense).
+    const oversized = new Uint8Array(BOARD_IMPORT_LIMITS.maxEntrySize! + 1);
+    const zipped = await zip(new Map([["big.bin", oversized]]));
+    const file = new File([zipped as Uint8Array<ArrayBuffer>], "zip-bomb.obz", {
+      type: "application/octet-stream",
+    });
+
+    const error = await importBoardSets(file).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(OBFError);
+    expect(error).toMatchObject({
+      info: { code: "archive-too-large", limit: "maxEntrySize" },
+    });
+
+    const boardSets = await listBoardSets();
+    expect(boardSets).toHaveLength(0);
   });
 
   test("a failure partway through a multi-file import still leaves the earlier set visible", async () => {

--- a/src/features/board/import/board-import.ts
+++ b/src/features/board/import/board-import.ts
@@ -5,6 +5,7 @@ import {
   type OBFBoard,
   type OBFManifest,
   type ParsedOBZ,
+  type UnzipLimits,
 } from "@shayc/open-board-format";
 import { lookup } from "mrmime";
 import { notifyBoardSetsChanged } from "../board-sets/board-sets-store";
@@ -21,6 +22,20 @@ export interface ImportResult {
   replacedExisting: boolean;
 }
 
+/**
+ * Decompression limits enforced against an OBZ archive's declared uncompressed
+ * sizes before any entry is inflated — zip-bomb defense for every import path
+ * (picker, drag-drop, file-handler, URL). The caps are deliberately generous
+ * versus real boards (observed up to ~70MB) but bounded, so a maliciously
+ * crafted archive is rejected before it can exhaust memory. Exceeding a cap
+ * makes `loadBoard` throw an `OBFError` with code `"archive-too-large"`.
+ */
+export const BOARD_IMPORT_LIMITS: UnzipLimits = {
+  maxTotalOriginalSize: 500 * 1024 * 1024, // 500MB across the whole archive
+  maxEntrySize: 100 * 1024 * 1024, // 100MB for any single entry
+  maxEntries: 5000,
+};
+
 export async function importBoardSets(
   files: File | File[],
 ): Promise<ImportResult[]> {
@@ -30,7 +45,7 @@ export async function importBoardSets(
   try {
     for (const file of fileList) {
       const setId = deriveSetId(file.name);
-      const loaded = await loadBoard(file);
+      const loaded = await loadBoard(file, { limits: BOARD_IMPORT_LIMITS });
 
       results.push(
         loaded.format === "obz"

--- a/src/features/board/import/use-import-board-files.test.tsx
+++ b/src/features/board/import/use-import-board-files.test.tsx
@@ -1,9 +1,10 @@
 import { AppProviders } from "@shared/providers/app-providers";
+import { zip } from "@shayc/open-board-format";
 import { beforeEach, describe, expect, test } from "vitest";
 import { render } from "vitest-browser-react";
 import { MemoryRouter } from "react-router";
 import { loadFixtureFile, resetBoardsDB } from "../testing";
-import { importBoardSets } from "./board-import";
+import { BOARD_IMPORT_LIMITS, importBoardSets } from "./board-import";
 import { useImportBoardFiles } from "./use-import-board-files";
 
 const OBF_FIXTURE = "lots-of-stuff.obf";
@@ -11,7 +12,11 @@ const OBF_FIXTURE = "lots-of-stuff.obf";
 function ImportTrigger({ files }: { files: File[] }) {
   const { importBoardFiles } = useImportBoardFiles();
 
-  return <button onClick={() => void importBoardFiles(files)}>import</button>;
+  return (
+    <button onClick={() => void importBoardFiles(files).catch(() => undefined)}>
+      import
+    </button>
+  );
 }
 
 function renderImport(files: File[]) {
@@ -50,5 +55,22 @@ describe("useImportBoardFiles", () => {
     await expect
       .element(screen.getByRole("alert"))
       .toHaveTextContent("Board replaced");
+  });
+
+  test("shows the too-large message when an OBZ exceeds the decompression limit", async () => {
+    // Zeros compress to a tiny archive that still declares an oversized
+    // uncompressed size, so the limit trips before inflation.
+    const oversized = new Uint8Array(BOARD_IMPORT_LIMITS.maxEntrySize! + 1);
+    const zipped = await zip(new Map([["big.bin", oversized]]));
+    const file = new File([zipped as Uint8Array<ArrayBuffer>], "zip-bomb.obz", {
+      type: "application/octet-stream",
+    });
+
+    const screen = await renderImport([file]);
+    await screen.getByRole("button", { name: "import" }).click();
+
+    await expect
+      .element(screen.getByRole("alert"))
+      .toHaveTextContent("Board is too large to import");
   });
 });

--- a/src/features/board/import/use-import-board-files.ts
+++ b/src/features/board/import/use-import-board-files.ts
@@ -1,6 +1,7 @@
 import { m } from "@paraglide/messages.js";
 import { useSnackbar } from "@shared/snackbar/use-snackbar";
 import { openFiles } from "@shared/utils/file-picker";
+import { OBFError } from "@shayc/open-board-format";
 import { useNavigate } from "react-router";
 import { boardSetPath } from "../navigation/board-paths";
 import { BOARD_FILE_ACCEPT } from "./board-file-types";
@@ -43,8 +44,13 @@ export function useImportBoardFiles(): UseImportBoardFilesReturn {
 
       return results;
     } catch (error) {
+      const tooLarge =
+        error instanceof OBFError && error.info.code === "archive-too-large";
+
       showSnackbar({
-        message: m.libraryImportFailedBoards({ count }),
+        message: tooLarge
+          ? m.libraryImportTooLargeBoards({ count })
+          : m.libraryImportFailedBoards({ count }),
         severity: "error",
       });
 


### PR DESCRIPTION
## Summary
- Cap declared uncompressed sizes (per-entry, total across the archive, and entry count) when extracting an OBZ, checked before any inflation happens — so a maliciously crafted archive is rejected before it can exhaust memory
- Wired into every import path (picker, drag-drop, file-handler, URL) via `importBoardSets`
- Surface a dedicated "too large" snackbar message instead of the generic import-failed one, by branching on `OBFError.info.code === "archive-too-large"`
- Added the translated message key to all 34 supported locales

## Test plan
- [x] `board-import.test.ts`: builds a tiny zip whose declared uncompressed size exceeds the per-entry cap and asserts it rejects with `OBFError`/`archive-too-large`, and that no board set is persisted
- [x] `use-import-board-files.test.tsx`: same zip-bomb fixture through the hook, asserts the "too large" snackbar text renders
- [x] Full import test suite passes (31/31)