### PR TITLE
Guard the ?board= URL import against link-based content replacement

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "حدث خطأ ما",
   "errorGoHome": "الانتقال إلى الرئيسية",
   "errorBoardNotFound": "اللوحة غير موجودة",
-  "errorBoardSetNotFound": "اللوحة غير موجودة"
+  "errorBoardSetNotFound": "اللوحة غير موجودة",
+  "boardUrlReplaceConfirmTitle": "استبدال \"{name}\"؟",
+  "boardUrlReplaceConfirmDescription": "الاستيراد من هذا الرابط سيستبدل هذه اللوحة وكل ما فيها. لا يمكن التراجع عن هذا الإجراء.",
+  "boardUrlReplace": "استبدال",
+  "boardUrlImportFailed": "تعذّر استيراد اللوحة من الرابط"
 }

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "اللوحة غير موجودة",
   "errorBoardSetNotFound": "اللوحة غير موجودة",
   "boardUrlReplaceConfirmTitle": "استبدال \"{name}\"؟",
-  "boardUrlReplaceConfirmDescription": "الاستيراد من هذا الرابط سيستبدل هذه اللوحة وكل ما فيها. لا يمكن التراجع عن هذا الإجراء.",
+  "boardUrlReplaceConfirmDescription": "الاستيراد من {host} سيستبدل هذه اللوحة وكل ما فيها. لا يمكن التراجع عن هذا الإجراء.",
   "boardUrlReplace": "استبدال",
   "boardUrlImportFailed": "تعذّر استيراد اللوحة من الرابط"
 }

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Нещо се обърка",
   "errorGoHome": "Към началото",
   "errorBoardNotFound": "Дъската не е намерена",
-  "errorBoardSetNotFound": "Дъската не е намерена"
+  "errorBoardSetNotFound": "Дъската не е намерена",
+  "boardUrlReplaceConfirmTitle": "Да се замени ли „{name}“?",
+  "boardUrlReplaceConfirmDescription": "Импортирането от тази връзка ще замени тази дъска и всичко в нея. Това действие не може да бъде отменено.",
+  "boardUrlReplace": "Замяна",
+  "boardUrlImportFailed": "Дъската не може да бъде импортирана от връзката"
 }

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "Дъската не е намерена",
   "errorBoardSetNotFound": "Дъската не е намерена",
   "boardUrlReplaceConfirmTitle": "Да се замени ли „{name}“?",
-  "boardUrlReplaceConfirmDescription": "Импортирането от тази връзка ще замени тази дъска и всичко в нея. Това действие не може да бъде отменено.",
+  "boardUrlReplaceConfirmDescription": "Импортирането от {host} ще замени тази дъска и всичко в нея. Това действие не може да бъде отменено.",
   "boardUrlReplace": "Замяна",
   "boardUrlImportFailed": "Дъската не може да бъде импортирана от връзката"
 }

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "কিছু একটা ভুল হয়েছে",
   "errorGoHome": "হোমে যান",
   "errorBoardNotFound": "বোর্ড পাওয়া যায়নি",
-  "errorBoardSetNotFound": "বোর্ড পাওয়া যায়নি"
+  "errorBoardSetNotFound": "বোর্ড পাওয়া যায়নি",
+  "boardUrlReplaceConfirmTitle": "\"{name}\" প্রতিস্থাপন করবেন?",
+  "boardUrlReplaceConfirmDescription": "এই লিঙ্ক থেকে আমদানি করলে এই বোর্ড এবং এর ভেতরের সবকিছু প্রতিস্থাপিত হবে। এই ক্রিয়াটি পূর্বাবস্থায় ফেরানো যাবে না।",
+  "boardUrlReplace": "প্রতিস্থাপন করুন",
+  "boardUrlImportFailed": "লিঙ্ক থেকে বোর্ড আমদানি করা যায়নি"
 }

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "বোর্ড পাওয়া যায়নি",
   "errorBoardSetNotFound": "বোর্ড পাওয়া যায়নি",
   "boardUrlReplaceConfirmTitle": "\"{name}\" প্রতিস্থাপন করবেন?",
-  "boardUrlReplaceConfirmDescription": "এই লিঙ্ক থেকে আমদানি করলে এই বোর্ড এবং এর ভেতরের সবকিছু প্রতিস্থাপিত হবে। এই ক্রিয়াটি পূর্বাবস্থায় ফেরানো যাবে না।",
+  "boardUrlReplaceConfirmDescription": "{host} থেকে আমদানি করলে এই বোর্ড এবং এর ভেতরের সবকিছু প্রতিস্থাপিত হবে। এই ক্রিয়াটি পূর্বাবস্থায় ফেরানো যাবে না।",
   "boardUrlReplace": "প্রতিস্থাপন করুন",
   "boardUrlImportFailed": "লিঙ্ক থেকে বোর্ড আমদানি করা যায়নি"
 }

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Něco se pokazilo",
   "errorGoHome": "Přejít domů",
   "errorBoardNotFound": "Tabulka nebyla nalezena",
-  "errorBoardSetNotFound": "Tabulka nebyla nalezena"
+  "errorBoardSetNotFound": "Tabulka nebyla nalezena",
+  "boardUrlReplaceConfirmTitle": "Nahradit „{name}“?",
+  "boardUrlReplaceConfirmDescription": "Import z tohoto odkazu nahradí tuto tabulku a vše v ní. Tuto akci nelze vrátit zpět.",
+  "boardUrlReplace": "Nahradit",
+  "boardUrlImportFailed": "Tabulku se nepodařilo importovat z odkazu"
 }

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "Tabulka nebyla nalezena",
   "errorBoardSetNotFound": "Tabulka nebyla nalezena",
   "boardUrlReplaceConfirmTitle": "Nahradit „{name}“?",
-  "boardUrlReplaceConfirmDescription": "Import z tohoto odkazu nahradí tuto tabulku a vše v ní. Tuto akci nelze vrátit zpět.",
+  "boardUrlReplaceConfirmDescription": "Import z {host} nahradí tuto tabulku a vše v ní. Tuto akci nelze vrátit zpět.",
   "boardUrlReplace": "Nahradit",
   "boardUrlImportFailed": "Tabulku se nepodařilo importovat z odkazu"
 }

--- a/messages/da.json
+++ b/messages/da.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "Tavlen blev ikke fundet",
   "errorBoardSetNotFound": "Tavlen blev ikke fundet",
   "boardUrlReplaceConfirmTitle": "Erstat \"{name}\"?",
-  "boardUrlReplaceConfirmDescription": "Import fra dette link erstatter denne tavle og alt i den. Denne handling kan ikke fortrydes.",
+  "boardUrlReplaceConfirmDescription": "Import fra {host} erstatter denne tavle og alt i den. Denne handling kan ikke fortrydes.",
   "boardUrlReplace": "Erstat",
   "boardUrlImportFailed": "Tavlen kunne ikke importeres fra linket"
 }

--- a/messages/da.json
+++ b/messages/da.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Noget gik galt",
   "errorGoHome": "Gå til start",
   "errorBoardNotFound": "Tavlen blev ikke fundet",
-  "errorBoardSetNotFound": "Tavlen blev ikke fundet"
+  "errorBoardSetNotFound": "Tavlen blev ikke fundet",
+  "boardUrlReplaceConfirmTitle": "Erstat \"{name}\"?",
+  "boardUrlReplaceConfirmDescription": "Import fra dette link erstatter denne tavle og alt i den. Denne handling kan ikke fortrydes.",
+  "boardUrlReplace": "Erstat",
+  "boardUrlImportFailed": "Tavlen kunne ikke importeres fra linket"
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Etwas ist schiefgelaufen",
   "errorGoHome": "Zur Startseite",
   "errorBoardNotFound": "Tafel nicht gefunden",
-  "errorBoardSetNotFound": "Tafel nicht gefunden"
+  "errorBoardSetNotFound": "Tafel nicht gefunden",
+  "boardUrlReplaceConfirmTitle": "„{name}“ ersetzen?",
+  "boardUrlReplaceConfirmDescription": "Der Import über diesen Link ersetzt diese Tafel und alles darin. Diese Aktion kann nicht rückgängig gemacht werden.",
+  "boardUrlReplace": "Ersetzen",
+  "boardUrlImportFailed": "Tafel konnte nicht über den Link importiert werden"
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "Tafel nicht gefunden",
   "errorBoardSetNotFound": "Tafel nicht gefunden",
   "boardUrlReplaceConfirmTitle": "„{name}“ ersetzen?",
-  "boardUrlReplaceConfirmDescription": "Der Import über diesen Link ersetzt diese Tafel und alles darin. Diese Aktion kann nicht rückgängig gemacht werden.",
+  "boardUrlReplaceConfirmDescription": "Der Import von {host} ersetzt diese Tafel und alles darin. Diese Aktion kann nicht rückgängig gemacht werden.",
   "boardUrlReplace": "Ersetzen",
   "boardUrlImportFailed": "Tafel konnte nicht über den Link importiert werden"
 }

--- a/messages/el.json
+++ b/messages/el.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "Ο πίνακας δεν βρέθηκε",
   "errorBoardSetNotFound": "Ο πίνακας δεν βρέθηκε",
   "boardUrlReplaceConfirmTitle": "Αντικατάσταση «{name}»;",
-  "boardUrlReplaceConfirmDescription": "Η εισαγωγή από αυτόν τον σύνδεσμο θα αντικαταστήσει αυτόν τον πίνακα και ό,τι περιέχει. Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.",
+  "boardUrlReplaceConfirmDescription": "Η εισαγωγή από το {host} θα αντικαταστήσει αυτόν τον πίνακα και ό,τι περιέχει. Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.",
   "boardUrlReplace": "Αντικατάσταση",
   "boardUrlImportFailed": "Δεν ήταν δυνατή η εισαγωγή του πίνακα από τον σύνδεσμο"
 }

--- a/messages/el.json
+++ b/messages/el.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Κάτι πήγε στραβά",
   "errorGoHome": "Μετάβαση στην αρχική",
   "errorBoardNotFound": "Ο πίνακας δεν βρέθηκε",
-  "errorBoardSetNotFound": "Ο πίνακας δεν βρέθηκε"
+  "errorBoardSetNotFound": "Ο πίνακας δεν βρέθηκε",
+  "boardUrlReplaceConfirmTitle": "Αντικατάσταση «{name}»;",
+  "boardUrlReplaceConfirmDescription": "Η εισαγωγή από αυτόν τον σύνδεσμο θα αντικαταστήσει αυτόν τον πίνακα και ό,τι περιέχει. Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.",
+  "boardUrlReplace": "Αντικατάσταση",
+  "boardUrlImportFailed": "Δεν ήταν δυνατή η εισαγωγή του πίνακα από τον σύνδεσμο"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Something went wrong",
   "errorGoHome": "Go home",
   "errorBoardNotFound": "Board not found",
-  "errorBoardSetNotFound": "Board not found"
+  "errorBoardSetNotFound": "Board not found",
+  "boardUrlReplaceConfirmTitle": "Replace \"{name}\"?",
+  "boardUrlReplaceConfirmDescription": "Importing from this link will replace this board and everything in it. This cannot be undone.",
+  "boardUrlReplace": "Replace",
+  "boardUrlImportFailed": "Couldn't import board from link"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "Board not found",
   "errorBoardSetNotFound": "Board not found",
   "boardUrlReplaceConfirmTitle": "Replace \"{name}\"?",
-  "boardUrlReplaceConfirmDescription": "Importing from this link will replace this board and everything in it. This cannot be undone.",
+  "boardUrlReplaceConfirmDescription": "Importing from {host} will replace this board and everything in it. This cannot be undone.",
   "boardUrlReplace": "Replace",
   "boardUrlImportFailed": "Couldn't import board from link"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "Tablero no encontrado",
   "errorBoardSetNotFound": "Tablero no encontrado",
   "boardUrlReplaceConfirmTitle": "¿Reemplazar \"{name}\"?",
-  "boardUrlReplaceConfirmDescription": "Importar desde este enlace reemplazará este tablero y todo su contenido. Esta acción no se puede deshacer.",
+  "boardUrlReplaceConfirmDescription": "Importar desde {host} reemplazará este tablero y todo su contenido. Esta acción no se puede deshacer.",
   "boardUrlReplace": "Reemplazar",
   "boardUrlImportFailed": "No se pudo importar el tablero desde el enlace"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Algo salió mal",
   "errorGoHome": "Ir al inicio",
   "errorBoardNotFound": "Tablero no encontrado",
-  "errorBoardSetNotFound": "Tablero no encontrado"
+  "errorBoardSetNotFound": "Tablero no encontrado",
+  "boardUrlReplaceConfirmTitle": "¿Reemplazar \"{name}\"?",
+  "boardUrlReplaceConfirmDescription": "Importar desde este enlace reemplazará este tablero y todo su contenido. Esta acción no se puede deshacer.",
+  "boardUrlReplace": "Reemplazar",
+  "boardUrlImportFailed": "No se pudo importar el tablero desde el enlace"
 }

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "Taulua ei löytynyt",
   "errorBoardSetNotFound": "Taulua ei löytynyt",
   "boardUrlReplaceConfirmTitle": "Korvataanko ”{name}”?",
-  "boardUrlReplaceConfirmDescription": "Tuonti tästä linkistä korvaa tämän taulun ja kaiken sen sisällön. Tätä toimintoa ei voi kumota.",
+  "boardUrlReplaceConfirmDescription": "Tuonti osoitteesta {host} korvaa tämän taulun ja kaiken sen sisällön. Tätä toimintoa ei voi kumota.",
   "boardUrlReplace": "Korvaa",
   "boardUrlImportFailed": "Taulun tuonti linkistä epäonnistui"
 }

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Jokin meni pieleen",
   "errorGoHome": "Siirry etusivulle",
   "errorBoardNotFound": "Taulua ei löytynyt",
-  "errorBoardSetNotFound": "Taulua ei löytynyt"
+  "errorBoardSetNotFound": "Taulua ei löytynyt",
+  "boardUrlReplaceConfirmTitle": "Korvataanko ”{name}”?",
+  "boardUrlReplaceConfirmDescription": "Tuonti tästä linkistä korvaa tämän taulun ja kaiken sen sisällön. Tätä toimintoa ei voi kumota.",
+  "boardUrlReplace": "Korvaa",
+  "boardUrlImportFailed": "Taulun tuonti linkistä epäonnistui"
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Une erreur s'est produite",
   "errorGoHome": "Aller à l'accueil",
   "errorBoardNotFound": "Tableau introuvable",
-  "errorBoardSetNotFound": "Tableau introuvable"
+  "errorBoardSetNotFound": "Tableau introuvable",
+  "boardUrlReplaceConfirmTitle": "Remplacer « {name} » ?",
+  "boardUrlReplaceConfirmDescription": "L'importation depuis ce lien remplacera ce tableau et tout son contenu. Cette action est irréversible.",
+  "boardUrlReplace": "Remplacer",
+  "boardUrlImportFailed": "Impossible d'importer le tableau depuis le lien"
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "Tableau introuvable",
   "errorBoardSetNotFound": "Tableau introuvable",
   "boardUrlReplaceConfirmTitle": "Remplacer « {name} » ?",
-  "boardUrlReplaceConfirmDescription": "L'importation depuis ce lien remplacera ce tableau et tout son contenu. Cette action est irréversible.",
+  "boardUrlReplaceConfirmDescription": "L'importation depuis {host} remplacera ce tableau et tout son contenu. Cette action est irréversible.",
   "boardUrlReplace": "Remplacer",
   "boardUrlImportFailed": "Impossible d'importer le tableau depuis le lien"
 }

--- a/messages/he.json
+++ b/messages/he.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "הלוח לא נמצא",
   "errorBoardSetNotFound": "הלוח לא נמצא",
   "boardUrlReplaceConfirmTitle": "להחליף את \"{name}\"?",
-  "boardUrlReplaceConfirmDescription": "ייבוא מהקישור הזה יחליף את הלוח הזה ואת כל מה שבו. לא ניתן לבטל פעולה זו.",
+  "boardUrlReplaceConfirmDescription": "ייבוא מ-{host} יחליף את הלוח הזה ואת כל מה שבו. לא ניתן לבטל פעולה זו.",
   "boardUrlReplace": "החלפה",
   "boardUrlImportFailed": "ייבוא הלוח מהקישור נכשל"
 }

--- a/messages/he.json
+++ b/messages/he.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "משהו השתבש",
   "errorGoHome": "חזרה לעמוד הבית",
   "errorBoardNotFound": "הלוח לא נמצא",
-  "errorBoardSetNotFound": "הלוח לא נמצא"
+  "errorBoardSetNotFound": "הלוח לא נמצא",
+  "boardUrlReplaceConfirmTitle": "להחליף את \"{name}\"?",
+  "boardUrlReplaceConfirmDescription": "ייבוא מהקישור הזה יחליף את הלוח הזה ואת כל מה שבו. לא ניתן לבטל פעולה זו.",
+  "boardUrlReplace": "החלפה",
+  "boardUrlImportFailed": "ייבוא הלוח מהקישור נכשל"
 }

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "कुछ गलत हो गया",
   "errorGoHome": "होम पर जाएँ",
   "errorBoardNotFound": "बोर्ड नहीं मिला",
-  "errorBoardSetNotFound": "बोर्ड नहीं मिला"
+  "errorBoardSetNotFound": "बोर्ड नहीं मिला",
+  "boardUrlReplaceConfirmTitle": "\"{name}\" को बदलें?",
+  "boardUrlReplaceConfirmDescription": "इस लिंक से आयात करने पर यह बोर्ड और इसमें मौजूद सब कुछ बदल जाएगा। यह क्रिया पूर्ववत नहीं की जा सकती।",
+  "boardUrlReplace": "बदलें",
+  "boardUrlImportFailed": "लिंक से बोर्ड आयात नहीं किया जा सका"
 }

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "बोर्ड नहीं मिला",
   "errorBoardSetNotFound": "बोर्ड नहीं मिला",
   "boardUrlReplaceConfirmTitle": "\"{name}\" को बदलें?",
-  "boardUrlReplaceConfirmDescription": "इस लिंक से आयात करने पर यह बोर्ड और इसमें मौजूद सब कुछ बदल जाएगा। यह क्रिया पूर्ववत नहीं की जा सकती।",
+  "boardUrlReplaceConfirmDescription": "{host} से आयात करने पर यह बोर्ड और इसमें मौजूद सब कुछ बदल जाएगा। यह क्रिया पूर्ववत नहीं की जा सकती।",
   "boardUrlReplace": "बदलें",
   "boardUrlImportFailed": "लिंक से बोर्ड आयात नहीं किया जा सका"
 }

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "Ploča nije pronađena",
   "errorBoardSetNotFound": "Ploča nije pronađena",
   "boardUrlReplaceConfirmTitle": "Zamijeniti „{name}”?",
-  "boardUrlReplaceConfirmDescription": "Uvoz s ove poveznice zamijenit će ovu ploču i sve u njoj. Ovu radnju nije moguće poništiti.",
+  "boardUrlReplaceConfirmDescription": "Uvoz s {host} zamijenit će ovu ploču i sve u njoj. Ovu radnju nije moguće poništiti.",
   "boardUrlReplace": "Zamijeni",
   "boardUrlImportFailed": "Ploču nije moguće uvesti s poveznice"
 }

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Nešto je pošlo po zlu",
   "errorGoHome": "Idi na početnu",
   "errorBoardNotFound": "Ploča nije pronađena",
-  "errorBoardSetNotFound": "Ploča nije pronađena"
+  "errorBoardSetNotFound": "Ploča nije pronađena",
+  "boardUrlReplaceConfirmTitle": "Zamijeniti „{name}”?",
+  "boardUrlReplaceConfirmDescription": "Uvoz s ove poveznice zamijenit će ovu ploču i sve u njoj. Ovu radnju nije moguće poništiti.",
+  "boardUrlReplace": "Zamijeni",
+  "boardUrlImportFailed": "Ploču nije moguće uvesti s poveznice"
 }

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "A tábla nem található",
   "errorBoardSetNotFound": "A tábla nem található",
   "boardUrlReplaceConfirmTitle": "Lecseréled a(z) „{name}” táblát?",
-  "boardUrlReplaceConfirmDescription": "Az importálás erről a hivatkozásról lecseréli ezt a táblát és minden tartalmát. Ez a művelet nem vonható vissza.",
+  "boardUrlReplaceConfirmDescription": "A(z) {host} helyről történő importálás lecseréli ezt a táblát és minden tartalmát. Ez a művelet nem vonható vissza.",
   "boardUrlReplace": "Csere",
   "boardUrlImportFailed": "A tábla importálása a hivatkozásról nem sikerült"
 }

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Hiba történt",
   "errorGoHome": "Ugrás a kezdőlapra",
   "errorBoardNotFound": "A tábla nem található",
-  "errorBoardSetNotFound": "A tábla nem található"
+  "errorBoardSetNotFound": "A tábla nem található",
+  "boardUrlReplaceConfirmTitle": "Lecseréled a(z) „{name}” táblát?",
+  "boardUrlReplaceConfirmDescription": "Az importálás erről a hivatkozásról lecseréli ezt a táblát és minden tartalmát. Ez a művelet nem vonható vissza.",
+  "boardUrlReplace": "Csere",
+  "boardUrlImportFailed": "A tábla importálása a hivatkozásról nem sikerült"
 }

--- a/messages/id.json
+++ b/messages/id.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "Papan tidak ditemukan",
   "errorBoardSetNotFound": "Papan tidak ditemukan",
   "boardUrlReplaceConfirmTitle": "Ganti \"{name}\"?",
-  "boardUrlReplaceConfirmDescription": "Mengimpor dari tautan ini akan mengganti papan ini beserta seluruh isinya. Tindakan ini tidak dapat dibatalkan.",
+  "boardUrlReplaceConfirmDescription": "Mengimpor dari {host} akan mengganti papan ini beserta seluruh isinya. Tindakan ini tidak dapat dibatalkan.",
   "boardUrlReplace": "Ganti",
   "boardUrlImportFailed": "Tidak dapat mengimpor papan dari tautan"
 }

--- a/messages/id.json
+++ b/messages/id.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Terjadi kesalahan",
   "errorGoHome": "Ke beranda",
   "errorBoardNotFound": "Papan tidak ditemukan",
-  "errorBoardSetNotFound": "Papan tidak ditemukan"
+  "errorBoardSetNotFound": "Papan tidak ditemukan",
+  "boardUrlReplaceConfirmTitle": "Ganti \"{name}\"?",
+  "boardUrlReplaceConfirmDescription": "Mengimpor dari tautan ini akan mengganti papan ini beserta seluruh isinya. Tindakan ini tidak dapat dibatalkan.",
+  "boardUrlReplace": "Ganti",
+  "boardUrlImportFailed": "Tidak dapat mengimpor papan dari tautan"
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "Tabella non trovata",
   "errorBoardSetNotFound": "Tabella non trovata",
   "boardUrlReplaceConfirmTitle": "Sostituire \"{name}\"?",
-  "boardUrlReplaceConfirmDescription": "L'importazione da questo link sostituirà questa tabella e tutto il suo contenuto. Questa azione non può essere annullata.",
+  "boardUrlReplaceConfirmDescription": "L'importazione da {host} sostituirà questa tabella e tutto il suo contenuto. Questa azione non può essere annullata.",
   "boardUrlReplace": "Sostituisci",
   "boardUrlImportFailed": "Impossibile importare la tabella dal link"
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Qualcosa è andato storto",
   "errorGoHome": "Vai alla home",
   "errorBoardNotFound": "Tabella non trovata",
-  "errorBoardSetNotFound": "Tabella non trovata"
+  "errorBoardSetNotFound": "Tabella non trovata",
+  "boardUrlReplaceConfirmTitle": "Sostituire \"{name}\"?",
+  "boardUrlReplaceConfirmDescription": "L'importazione da questo link sostituirà questa tabella e tutto il suo contenuto. Questa azione non può essere annullata.",
+  "boardUrlReplace": "Sostituisci",
+  "boardUrlImportFailed": "Impossibile importare la tabella dal link"
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "問題が発生しました",
   "errorGoHome": "ホームに戻る",
   "errorBoardNotFound": "ボードが見つかりません",
-  "errorBoardSetNotFound": "ボードが見つかりません"
+  "errorBoardSetNotFound": "ボードが見つかりません",
+  "boardUrlReplaceConfirmTitle": "「{name}」を置き換えますか？",
+  "boardUrlReplaceConfirmDescription": "このリンクからインポートすると、このボードとその中のすべてが置き換えられます。この操作は取り消せません。",
+  "boardUrlReplace": "置き換える",
+  "boardUrlImportFailed": "リンクからボードをインポートできませんでした"
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "ボードが見つかりません",
   "errorBoardSetNotFound": "ボードが見つかりません",
   "boardUrlReplaceConfirmTitle": "「{name}」を置き換えますか？",
-  "boardUrlReplaceConfirmDescription": "このリンクからインポートすると、このボードとその中のすべてが置き換えられます。この操作は取り消せません。",
+  "boardUrlReplaceConfirmDescription": "{host} からインポートすると、このボードとその中のすべてが置き換えられます。この操作は取り消せません。",
   "boardUrlReplace": "置き換える",
   "boardUrlImportFailed": "リンクからボードをインポートできませんでした"
 }

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "ಬೋರ್ಡ್ ಕಂಡುಬಂದಿಲ್ಲ",
   "errorBoardSetNotFound": "ಬೋರ್ಡ್ ಕಂಡುಬಂದಿಲ್ಲ",
   "boardUrlReplaceConfirmTitle": "\"{name}\" ಅನ್ನು ಬದಲಾಯಿಸುವುದೇ?",
-  "boardUrlReplaceConfirmDescription": "ಈ ಲಿಂಕ್‌ನಿಂದ ಆಮದು ಮಾಡಿದರೆ ಈ ಬೋರ್ಡ್ ಮತ್ತು ಅದರಲ್ಲಿರುವ ಎಲ್ಲವೂ ಬದಲಾಗುತ್ತದೆ. ಈ ಕ್ರಿಯೆಯನ್ನು ರದ್ದುಗೊಳಿಸಲಾಗದು.",
+  "boardUrlReplaceConfirmDescription": "{host} ನಿಂದ ಆಮದು ಮಾಡಿದರೆ ಈ ಬೋರ್ಡ್ ಮತ್ತು ಅದರಲ್ಲಿರುವ ಎಲ್ಲವೂ ಬದಲಾಗುತ್ತದೆ. ಈ ಕ್ರಿಯೆಯನ್ನು ರದ್ದುಗೊಳಿಸಲಾಗದು.",
   "boardUrlReplace": "ಬದಲಾಯಿಸಿ",
   "boardUrlImportFailed": "ಲಿಂಕ್‌ನಿಂದ ಬೋರ್ಡ್ ಆಮದು ಮಾಡಲಾಗಲಿಲ್ಲ"
 }

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "ಏನೋ ತಪ್ಪಾಗಿದೆ",
   "errorGoHome": "ಮುಖಪುಟಕ್ಕೆ ಹೋಗಿ",
   "errorBoardNotFound": "ಬೋರ್ಡ್ ಕಂಡುಬಂದಿಲ್ಲ",
-  "errorBoardSetNotFound": "ಬೋರ್ಡ್ ಕಂಡುಬಂದಿಲ್ಲ"
+  "errorBoardSetNotFound": "ಬೋರ್ಡ್ ಕಂಡುಬಂದಿಲ್ಲ",
+  "boardUrlReplaceConfirmTitle": "\"{name}\" ಅನ್ನು ಬದಲಾಯಿಸುವುದೇ?",
+  "boardUrlReplaceConfirmDescription": "ಈ ಲಿಂಕ್‌ನಿಂದ ಆಮದು ಮಾಡಿದರೆ ಈ ಬೋರ್ಡ್ ಮತ್ತು ಅದರಲ್ಲಿರುವ ಎಲ್ಲವೂ ಬದಲಾಗುತ್ತದೆ. ಈ ಕ್ರಿಯೆಯನ್ನು ರದ್ದುಗೊಳಿಸಲಾಗದು.",
+  "boardUrlReplace": "ಬದಲಾಯಿಸಿ",
+  "boardUrlImportFailed": "ಲಿಂಕ್‌ನಿಂದ ಬೋರ್ಡ್ ಆಮದು ಮಾಡಲಾಗಲಿಲ್ಲ"
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "문제가 발생했습니다",
   "errorGoHome": "홈으로",
   "errorBoardNotFound": "보드를 찾을 수 없음",
-  "errorBoardSetNotFound": "보드를 찾을 수 없음"
+  "errorBoardSetNotFound": "보드를 찾을 수 없음",
+  "boardUrlReplaceConfirmTitle": "\"{name}\"을(를) 교체하시겠어요?",
+  "boardUrlReplaceConfirmDescription": "이 링크에서 가져오면 이 보드와 그 안의 모든 내용이 교체됩니다. 이 작업은 되돌릴 수 없습니다.",
+  "boardUrlReplace": "교체",
+  "boardUrlImportFailed": "링크에서 보드를 가져올 수 없습니다"
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "보드를 찾을 수 없음",
   "errorBoardSetNotFound": "보드를 찾을 수 없음",
   "boardUrlReplaceConfirmTitle": "\"{name}\"을(를) 교체하시겠어요?",
-  "boardUrlReplaceConfirmDescription": "이 링크에서 가져오면 이 보드와 그 안의 모든 내용이 교체됩니다. 이 작업은 되돌릴 수 없습니다.",
+  "boardUrlReplaceConfirmDescription": "{host}에서 가져오면 이 보드와 그 안의 모든 내용이 교체됩니다. 이 작업은 되돌릴 수 없습니다.",
   "boardUrlReplace": "교체",
   "boardUrlImportFailed": "링크에서 보드를 가져올 수 없습니다"
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Er is iets misgegaan",
   "errorGoHome": "Naar start",
   "errorBoardNotFound": "Bord niet gevonden",
-  "errorBoardSetNotFound": "Bord niet gevonden"
+  "errorBoardSetNotFound": "Bord niet gevonden",
+  "boardUrlReplaceConfirmTitle": "\"{name}\" vervangen?",
+  "boardUrlReplaceConfirmDescription": "Importeren via deze link vervangt dit bord en alles erin. Deze actie kan niet ongedaan worden gemaakt.",
+  "boardUrlReplace": "Vervangen",
+  "boardUrlImportFailed": "Kan bord niet importeren via de link"
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "Bord niet gevonden",
   "errorBoardSetNotFound": "Bord niet gevonden",
   "boardUrlReplaceConfirmTitle": "\"{name}\" vervangen?",
-  "boardUrlReplaceConfirmDescription": "Importeren via deze link vervangt dit bord en alles erin. Deze actie kan niet ongedaan worden gemaakt.",
+  "boardUrlReplaceConfirmDescription": "Importeren van {host} vervangt dit bord en alles erin. Deze actie kan niet ongedaan worden gemaakt.",
   "boardUrlReplace": "Vervangen",
   "boardUrlImportFailed": "Kan bord niet importeren via de link"
 }

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "Nie znaleziono tablicy",
   "errorBoardSetNotFound": "Nie znaleziono tablicy",
   "boardUrlReplaceConfirmTitle": "Zastąpić „{name}”?",
-  "boardUrlReplaceConfirmDescription": "Import z tego linku zastąpi tę tablicę i całą jej zawartość. Tej operacji nie można cofnąć.",
+  "boardUrlReplaceConfirmDescription": "Import z {host} zastąpi tę tablicę i całą jej zawartość. Tej operacji nie można cofnąć.",
   "boardUrlReplace": "Zastąp",
   "boardUrlImportFailed": "Nie udało się zaimportować tablicy z linku"
 }

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Coś poszło nie tak",
   "errorGoHome": "Przejdź do strony głównej",
   "errorBoardNotFound": "Nie znaleziono tablicy",
-  "errorBoardSetNotFound": "Nie znaleziono tablicy"
+  "errorBoardSetNotFound": "Nie znaleziono tablicy",
+  "boardUrlReplaceConfirmTitle": "Zastąpić „{name}”?",
+  "boardUrlReplaceConfirmDescription": "Import z tego linku zastąpi tę tablicę i całą jej zawartość. Tej operacji nie można cofnąć.",
+  "boardUrlReplace": "Zastąp",
+  "boardUrlImportFailed": "Nie udało się zaimportować tablicy z linku"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Algo deu errado",
   "errorGoHome": "Ir para o início",
   "errorBoardNotFound": "Prancha não encontrada",
-  "errorBoardSetNotFound": "Prancha não encontrada"
+  "errorBoardSetNotFound": "Prancha não encontrada",
+  "boardUrlReplaceConfirmTitle": "Substituir \"{name}\"?",
+  "boardUrlReplaceConfirmDescription": "Importar deste link substituirá esta prancha e tudo o que há nela. Esta ação não pode ser desfeita.",
+  "boardUrlReplace": "Substituir",
+  "boardUrlImportFailed": "Não foi possível importar a prancha do link"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "Prancha não encontrada",
   "errorBoardSetNotFound": "Prancha não encontrada",
   "boardUrlReplaceConfirmTitle": "Substituir \"{name}\"?",
-  "boardUrlReplaceConfirmDescription": "Importar deste link substituirá esta prancha e tudo o que há nela. Esta ação não pode ser desfeita.",
+  "boardUrlReplaceConfirmDescription": "Importar de {host} substituirá esta prancha e tudo o que há nela. Esta ação não pode ser desfeita.",
   "boardUrlReplace": "Substituir",
   "boardUrlImportFailed": "Não foi possível importar a prancha do link"
 }

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "Tabla nu a fost găsită",
   "errorBoardSetNotFound": "Tabla nu a fost găsită",
   "boardUrlReplaceConfirmTitle": "Înlocuiești „{name}”?",
-  "boardUrlReplaceConfirmDescription": "Importul din acest link va înlocui această tablă și tot conținutul ei. Această acțiune nu poate fi anulată.",
+  "boardUrlReplaceConfirmDescription": "Importul de la {host} va înlocui această tablă și tot conținutul ei. Această acțiune nu poate fi anulată.",
   "boardUrlReplace": "Înlocuiește",
   "boardUrlImportFailed": "Tabla nu a putut fi importată din link"
 }

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Ceva nu a mers bine",
   "errorGoHome": "Mergi la pagina principală",
   "errorBoardNotFound": "Tabla nu a fost găsită",
-  "errorBoardSetNotFound": "Tabla nu a fost găsită"
+  "errorBoardSetNotFound": "Tabla nu a fost găsită",
+  "boardUrlReplaceConfirmTitle": "Înlocuiești „{name}”?",
+  "boardUrlReplaceConfirmDescription": "Importul din acest link va înlocui această tablă și tot conținutul ei. Această acțiune nu poate fi anulată.",
+  "boardUrlReplace": "Înlocuiește",
+  "boardUrlImportFailed": "Tabla nu a putut fi importată din link"
 }

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Что-то пошло не так",
   "errorGoHome": "На главную",
   "errorBoardNotFound": "Доска не найдена",
-  "errorBoardSetNotFound": "Доска не найдена"
+  "errorBoardSetNotFound": "Доска не найдена",
+  "boardUrlReplaceConfirmTitle": "Заменить «{name}»?",
+  "boardUrlReplaceConfirmDescription": "Импорт по этой ссылке заменит эту доску и всё её содержимое. Это действие нельзя отменить.",
+  "boardUrlReplace": "Заменить",
+  "boardUrlImportFailed": "Не удалось импортировать доску по ссылке"
 }

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "Доска не найдена",
   "errorBoardSetNotFound": "Доска не найдена",
   "boardUrlReplaceConfirmTitle": "Заменить «{name}»?",
-  "boardUrlReplaceConfirmDescription": "Импорт по этой ссылке заменит эту доску и всё её содержимое. Это действие нельзя отменить.",
+  "boardUrlReplaceConfirmDescription": "Импорт с сайта {host} заменит эту доску и всё её содержимое. Это действие нельзя отменить.",
   "boardUrlReplace": "Заменить",
   "boardUrlImportFailed": "Не удалось импортировать доску по ссылке"
 }

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "Tabuľka sa nenašla",
   "errorBoardSetNotFound": "Tabuľka sa nenašla",
   "boardUrlReplaceConfirmTitle": "Nahradiť „{name}“?",
-  "boardUrlReplaceConfirmDescription": "Import z tohto odkazu nahradí túto tabuľku a všetko v nej. Túto akciu nie je možné vrátiť späť.",
+  "boardUrlReplaceConfirmDescription": "Import z {host} nahradí túto tabuľku a všetko v nej. Túto akciu nie je možné vrátiť späť.",
   "boardUrlReplace": "Nahradiť",
   "boardUrlImportFailed": "Tabuľku sa nepodarilo importovať z odkazu"
 }

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Niečo sa pokazilo",
   "errorGoHome": "Prejsť domov",
   "errorBoardNotFound": "Tabuľka sa nenašla",
-  "errorBoardSetNotFound": "Tabuľka sa nenašla"
+  "errorBoardSetNotFound": "Tabuľka sa nenašla",
+  "boardUrlReplaceConfirmTitle": "Nahradiť „{name}“?",
+  "boardUrlReplaceConfirmDescription": "Import z tohto odkazu nahradí túto tabuľku a všetko v nej. Túto akciu nie je možné vrátiť späť.",
+  "boardUrlReplace": "Nahradiť",
+  "boardUrlImportFailed": "Tabuľku sa nepodarilo importovať z odkazu"
 }

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "Table ni mogoče najti",
   "errorBoardSetNotFound": "Table ni mogoče najti",
   "boardUrlReplaceConfirmTitle": "Zamenjam »{name}«?",
-  "boardUrlReplaceConfirmDescription": "Uvoz s te povezave bo zamenjal to tablo in vse v njej. Tega dejanja ni mogoče razveljaviti.",
+  "boardUrlReplaceConfirmDescription": "Uvoz s {host} bo zamenjal to tablo in vse v njej. Tega dejanja ni mogoče razveljaviti.",
   "boardUrlReplace": "Zamenjaj",
   "boardUrlImportFailed": "Table ni bilo mogoče uvoziti s povezave"
 }

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Nekaj je šlo narobe",
   "errorGoHome": "Pojdi domov",
   "errorBoardNotFound": "Table ni mogoče najti",
-  "errorBoardSetNotFound": "Table ni mogoče najti"
+  "errorBoardSetNotFound": "Table ni mogoče najti",
+  "boardUrlReplaceConfirmTitle": "Zamenjam »{name}«?",
+  "boardUrlReplaceConfirmDescription": "Uvoz s te povezave bo zamenjal to tablo in vse v njej. Tega dejanja ni mogoče razveljaviti.",
+  "boardUrlReplace": "Zamenjaj",
+  "boardUrlImportFailed": "Table ni bilo mogoče uvoziti s povezave"
 }

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "Tavlan hittades inte",
   "errorBoardSetNotFound": "Tavlan hittades inte",
   "boardUrlReplaceConfirmTitle": "Ersätt ”{name}”?",
-  "boardUrlReplaceConfirmDescription": "Import från den här länken ersätter den här tavlan och allt i den. Den här åtgärden kan inte ångras.",
+  "boardUrlReplaceConfirmDescription": "Import från {host} ersätter den här tavlan och allt i den. Den här åtgärden kan inte ångras.",
   "boardUrlReplace": "Ersätt",
   "boardUrlImportFailed": "Det gick inte att importera tavlan från länken"
 }

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Något gick fel",
   "errorGoHome": "Till startsidan",
   "errorBoardNotFound": "Tavlan hittades inte",
-  "errorBoardSetNotFound": "Tavlan hittades inte"
+  "errorBoardSetNotFound": "Tavlan hittades inte",
+  "boardUrlReplaceConfirmTitle": "Ersätt ”{name}”?",
+  "boardUrlReplaceConfirmDescription": "Import från den här länken ersätter den här tavlan och allt i den. Den här åtgärden kan inte ångras.",
+  "boardUrlReplace": "Ersätt",
+  "boardUrlImportFailed": "Det gick inte att importera tavlan från länken"
 }

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "ஏதோ தவறு நடந்தது",
   "errorGoHome": "முகப்புக்குச் செல்",
   "errorBoardNotFound": "பலகை கிடைக்கவில்லை",
-  "errorBoardSetNotFound": "பலகை கிடைக்கவில்லை"
+  "errorBoardSetNotFound": "பலகை கிடைக்கவில்லை",
+  "boardUrlReplaceConfirmTitle": "\"{name}\" என்பதை மாற்றவா?",
+  "boardUrlReplaceConfirmDescription": "இந்த இணைப்பிலிருந்து இறக்குமதி செய்தால், இந்தப் பலகையும் அதில் உள்ள அனைத்தும் மாற்றப்படும். இந்தச் செயலைச் செயல்தவிர்க்க முடியாது.",
+  "boardUrlReplace": "மாற்று",
+  "boardUrlImportFailed": "இணைப்பிலிருந்து பலகையை இறக்குமதி செய்ய முடியவில்லை"
 }

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "பலகை கிடைக்கவில்லை",
   "errorBoardSetNotFound": "பலகை கிடைக்கவில்லை",
   "boardUrlReplaceConfirmTitle": "\"{name}\" என்பதை மாற்றவா?",
-  "boardUrlReplaceConfirmDescription": "இந்த இணைப்பிலிருந்து இறக்குமதி செய்தால், இந்தப் பலகையும் அதில் உள்ள அனைத்தும் மாற்றப்படும். இந்தச் செயலைச் செயல்தவிர்க்க முடியாது.",
+  "boardUrlReplaceConfirmDescription": "{host} இலிருந்து இறக்குமதி செய்தால், இந்தப் பலகையும் அதில் உள்ள அனைத்தும் மாற்றப்படும். இந்தச் செயலைச் செயல்தவிர்க்க முடியாது.",
   "boardUrlReplace": "மாற்று",
   "boardUrlImportFailed": "இணைப்பிலிருந்து பலகையை இறக்குமதி செய்ய முடியவில்லை"
 }

--- a/messages/te.json
+++ b/messages/te.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "బోర్డు కనుగొనబడలేదు",
   "errorBoardSetNotFound": "బోర్డు కనుగొనబడలేదు",
   "boardUrlReplaceConfirmTitle": "\"{name}\"ను భర్తీ చేయాలా?",
-  "boardUrlReplaceConfirmDescription": "ఈ లింక్ నుండి దిగుమతి చేస్తే ఈ బోర్డు మరియు అందులోని అన్నీ భర్తీ అవుతాయి. ఈ చర్యను రద్దు చేయడం సాధ్యం కాదు.",
+  "boardUrlReplaceConfirmDescription": "{host} నుండి దిగుమతి చేస్తే ఈ బోర్డు మరియు అందులోని అన్నీ భర్తీ అవుతాయి. ఈ చర్యను రద్దు చేయడం సాధ్యం కాదు.",
   "boardUrlReplace": "భర్తీ చేయి",
   "boardUrlImportFailed": "లింక్ నుండి బోర్డును దిగుమతి చేయలేకపోయాం"
 }

--- a/messages/te.json
+++ b/messages/te.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "ఏదో తప్పు జరిగింది",
   "errorGoHome": "హోమ్‌కు వెళ్లు",
   "errorBoardNotFound": "బోర్డు కనుగొనబడలేదు",
-  "errorBoardSetNotFound": "బోర్డు కనుగొనబడలేదు"
+  "errorBoardSetNotFound": "బోర్డు కనుగొనబడలేదు",
+  "boardUrlReplaceConfirmTitle": "\"{name}\"ను భర్తీ చేయాలా?",
+  "boardUrlReplaceConfirmDescription": "ఈ లింక్ నుండి దిగుమతి చేస్తే ఈ బోర్డు మరియు అందులోని అన్నీ భర్తీ అవుతాయి. ఈ చర్యను రద్దు చేయడం సాధ్యం కాదు.",
+  "boardUrlReplace": "భర్తీ చేయి",
+  "boardUrlImportFailed": "లింక్ నుండి బోర్డును దిగుమతి చేయలేకపోయాం"
 }

--- a/messages/th.json
+++ b/messages/th.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "ไม่พบบอร์ด",
   "errorBoardSetNotFound": "ไม่พบบอร์ด",
   "boardUrlReplaceConfirmTitle": "แทนที่ \"{name}\" ไหม",
-  "boardUrlReplaceConfirmDescription": "การนำเข้าจากลิงก์นี้จะแทนที่บอร์ดนี้และทุกอย่างในบอร์ด ไม่สามารถเลิกทำการกระทำนี้ได้",
+  "boardUrlReplaceConfirmDescription": "การนำเข้าจาก {host} จะแทนที่บอร์ดนี้และทุกอย่างในบอร์ด ไม่สามารถเลิกทำการกระทำนี้ได้",
   "boardUrlReplace": "แทนที่",
   "boardUrlImportFailed": "นำเข้าบอร์ดจากลิงก์ไม่สำเร็จ"
 }

--- a/messages/th.json
+++ b/messages/th.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "เกิดข้อผิดพลาดบางอย่าง",
   "errorGoHome": "ไปที่หน้าแรก",
   "errorBoardNotFound": "ไม่พบบอร์ด",
-  "errorBoardSetNotFound": "ไม่พบบอร์ด"
+  "errorBoardSetNotFound": "ไม่พบบอร์ด",
+  "boardUrlReplaceConfirmTitle": "แทนที่ \"{name}\" ไหม",
+  "boardUrlReplaceConfirmDescription": "การนำเข้าจากลิงก์นี้จะแทนที่บอร์ดนี้และทุกอย่างในบอร์ด ไม่สามารถเลิกทำการกระทำนี้ได้",
+  "boardUrlReplace": "แทนที่",
+  "boardUrlImportFailed": "นำเข้าบอร์ดจากลิงก์ไม่สำเร็จ"
 }

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "Pano bulunamadı",
   "errorBoardSetNotFound": "Pano bulunamadı",
   "boardUrlReplaceConfirmTitle": "\"{name}\" değiştirilsin mi?",
-  "boardUrlReplaceConfirmDescription": "Bu bağlantıdan içe aktarma bu panoyu ve içindeki her şeyi değiştirir. Bu işlem geri alınamaz.",
+  "boardUrlReplaceConfirmDescription": "{host} adresinden içe aktarma bu panoyu ve içindeki her şeyi değiştirir. Bu işlem geri alınamaz.",
   "boardUrlReplace": "Değiştir",
   "boardUrlImportFailed": "Pano bağlantıdan içe aktarılamadı"
 }

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Bir şeyler ters gitti",
   "errorGoHome": "Ana sayfaya git",
   "errorBoardNotFound": "Pano bulunamadı",
-  "errorBoardSetNotFound": "Pano bulunamadı"
+  "errorBoardSetNotFound": "Pano bulunamadı",
+  "boardUrlReplaceConfirmTitle": "\"{name}\" değiştirilsin mi?",
+  "boardUrlReplaceConfirmDescription": "Bu bağlantıdan içe aktarma bu panoyu ve içindeki her şeyi değiştirir. Bu işlem geri alınamaz.",
+  "boardUrlReplace": "Değiştir",
+  "boardUrlImportFailed": "Pano bağlantıdan içe aktarılamadı"
 }

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "Дошку не знайдено",
   "errorBoardSetNotFound": "Дошку не знайдено",
   "boardUrlReplaceConfirmTitle": "Замінити «{name}»?",
-  "boardUrlReplaceConfirmDescription": "Імпорт за цим посиланням замінить цю дошку та весь її вміст. Цю дію не можна скасувати.",
+  "boardUrlReplaceConfirmDescription": "Імпорт із сайту {host} замінить цю дошку та весь її вміст. Цю дію не можна скасувати.",
   "boardUrlReplace": "Замінити",
   "boardUrlImportFailed": "Не вдалося імпортувати дошку за посиланням"
 }

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Щось пішло не так",
   "errorGoHome": "На головну",
   "errorBoardNotFound": "Дошку не знайдено",
-  "errorBoardSetNotFound": "Дошку не знайдено"
+  "errorBoardSetNotFound": "Дошку не знайдено",
+  "boardUrlReplaceConfirmTitle": "Замінити «{name}»?",
+  "boardUrlReplaceConfirmDescription": "Імпорт за цим посиланням замінить цю дошку та весь її вміст. Цю дію не можна скасувати.",
+  "boardUrlReplace": "Замінити",
+  "boardUrlImportFailed": "Не вдалося імпортувати дошку за посиланням"
 }

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "Đã xảy ra lỗi",
   "errorGoHome": "Về trang chủ",
   "errorBoardNotFound": "Không tìm thấy bảng",
-  "errorBoardSetNotFound": "Không tìm thấy bảng"
+  "errorBoardSetNotFound": "Không tìm thấy bảng",
+  "boardUrlReplaceConfirmTitle": "Thay thế \"{name}\"?",
+  "boardUrlReplaceConfirmDescription": "Nhập từ liên kết này sẽ thay thế bảng này và mọi thứ trong đó. Không thể hoàn tác hành động này.",
+  "boardUrlReplace": "Thay thế",
+  "boardUrlImportFailed": "Không thể nhập bảng từ liên kết"
 }

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "Không tìm thấy bảng",
   "errorBoardSetNotFound": "Không tìm thấy bảng",
   "boardUrlReplaceConfirmTitle": "Thay thế \"{name}\"?",
-  "boardUrlReplaceConfirmDescription": "Nhập từ liên kết này sẽ thay thế bảng này và mọi thứ trong đó. Không thể hoàn tác hành động này.",
+  "boardUrlReplaceConfirmDescription": "Nhập từ {host} sẽ thay thế bảng này và mọi thứ trong đó. Không thể hoàn tác hành động này.",
   "boardUrlReplace": "Thay thế",
   "boardUrlImportFailed": "Không thể nhập bảng từ liên kết"
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -126,5 +126,9 @@
   "errorGenericTitle": "出了点问题",
   "errorGoHome": "返回主页",
   "errorBoardNotFound": "未找到沟通板",
-  "errorBoardSetNotFound": "未找到沟通板"
+  "errorBoardSetNotFound": "未找到沟通板",
+  "boardUrlReplaceConfirmTitle": "替换“{name}”？",
+  "boardUrlReplaceConfirmDescription": "从此链接导入将替换此沟通板及其中的所有内容。此操作无法撤消。",
+  "boardUrlReplace": "替换",
+  "boardUrlImportFailed": "无法从链接导入沟通板"
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -128,7 +128,7 @@
   "errorBoardNotFound": "未找到沟通板",
   "errorBoardSetNotFound": "未找到沟通板",
   "boardUrlReplaceConfirmTitle": "替换“{name}”？",
-  "boardUrlReplaceConfirmDescription": "从此链接导入将替换此沟通板及其中的所有内容。此操作无法撤消。",
+  "boardUrlReplaceConfirmDescription": "从 {host} 导入将替换此沟通板及其中的所有内容。此操作无法撤消。",
   "boardUrlReplace": "替换",
   "boardUrlImportFailed": "无法从链接导入沟通板"
 }

--- a/src/app/routing/app-routes.test.tsx
+++ b/src/app/routing/app-routes.test.tsx
@@ -1,5 +1,9 @@
 import { importBoardFromUrl } from "@features/board";
-import { resetBoardsDB } from "@features/board/testing";
+import {
+  makeOBFBoard,
+  resetBoardsDB,
+  seedBoardSets,
+} from "@features/board/testing";
 import { AppProviders } from "@shared/providers/app-providers";
 import { stubAudio } from "@shared/testing/stub-audio";
 import { stubSpeech } from "@shared/testing/stub-speech";
@@ -12,8 +16,10 @@ import { appRoutes } from "./app-routes";
 const OBZ_FIXTURE_URL =
   "/src/features/board/testing/sample-boards/lots-of-stuff.obz";
 
-async function renderApp() {
-  const router = createMemoryRouter(appRoutes, { initialEntries: ["/"] });
+async function renderApp(initialEntry = "/") {
+  const router = createMemoryRouter(appRoutes, {
+    initialEntries: [initialEntry],
+  });
 
   return render(
     <AppProviders>
@@ -68,4 +74,64 @@ describe("app flow", () => {
       .element(screen.getByRole("grid", { name: "Quick Core 24" }))
       .toBeVisible();
   });
+
+  test("?board= link that collides with an existing set replaces it only after confirmation", async () => {
+    await seedExistingLotsOfStuffSet();
+
+    const screen = await renderApp(
+      `/?board=${encodeURIComponent(OBZ_FIXTURE_URL)}`,
+    );
+
+    // The confirmation dialog stacks above onboarding, so answer it first.
+    await screen.getByRole("button", { name: "Replace" }).click();
+
+    // Let the import snackbars run their course: they cover the onboarding
+    // button, and a hovering pointer from a retried click pauses auto-hide.
+    await expect
+      .element(screen.getByText("Board replaced"))
+      .toBeInTheDocument();
+    await expect
+      .element(screen.getByText("Board replaced"), { timeout: 10_000 })
+      .not.toBeInTheDocument();
+
+    await screen.getByRole("button", { name: "Continue" }).click();
+
+    await expect
+      .element(screen.getByRole("grid", { name: "Lots of Stuff Board" }))
+      .toBeVisible();
+  });
+
+  test("cancelling the ?board= replacement keeps the existing set", async () => {
+    await seedExistingLotsOfStuffSet();
+
+    const screen = await renderApp(
+      `/?board=${encodeURIComponent(OBZ_FIXTURE_URL)}`,
+    );
+
+    // The confirmation dialog stacks above onboarding, so answer it first.
+    await screen.getByRole("button", { name: "Cancel" }).click();
+    await screen.getByRole("button", { name: "Continue" }).click();
+
+    await expect
+      .element(screen.getByRole("grid", { name: "Old Board" }))
+      .toBeVisible();
+  });
 });
+
+// A set whose setId collides with what the OBZ fixture URL derives, so a
+// ?board= import of the fixture would overwrite it.
+function seedExistingLotsOfStuffSet() {
+  return seedBoardSets([
+    {
+      setId: "lots-of-stuff",
+      rootBoardId: "root-1",
+      boards: [
+        {
+          boardId: "root-1",
+          name: "Old Board",
+          obf: makeOBFBoard({ id: "root-1", name: "Old Board" }),
+        },
+      ],
+    },
+  ]);
+}

--- a/src/app/routing/app-routes.tsx
+++ b/src/app/routing/app-routes.tsx
@@ -15,7 +15,11 @@ export const appRoutes: RouteObject[] = [
         ErrorBoundary: RouteErrorBoundary,
         HydrateFallback: LoadingState,
         children: [
-          { index: true, loader: rootIndexLoader },
+          {
+            index: true,
+            loader: rootIndexLoader,
+            lazy: () => import("@pages/board-url-import-page"),
+          },
           {
             path: BOARD_SET_SEGMENT,
             children: [

--- a/src/app/routing/loaders/root-index-loader.test.ts
+++ b/src/app/routing/loaders/root-index-loader.test.ts
@@ -1,14 +1,14 @@
-import { beforeEach, describe, expect, test } from "vitest";
-import type { LoaderFunctionArgs } from "react-router";
 import { getBoardSets } from "@features/board";
 import { resetBoardsDB, seedBoardSets } from "@features/board/testing";
-import { rootIndexLoader } from "./root-index-loader";
+import type { LoaderFunctionArgs } from "react-router";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { rootIndexLoader, type RootIndexData } from "./root-index-loader";
 
 const FIXTURE_BOARD_URL =
   "/src/features/board/testing/sample-boards/lots-of-stuff.obz";
 const DEFAULT_BOARD_PATH = "/quick-core-24.obz";
 
-function callLoader(searchParams = ""): Promise<Response> {
+function callLoader(searchParams = ""): Promise<Response | RootIndexData> {
   const args = {
     request: new Request(`http://localhost/${searchParams}`),
     params: {},
@@ -17,13 +17,26 @@ function callLoader(searchParams = ""): Promise<Response> {
   return rootIndexLoader(args);
 }
 
+async function callLoaderForRedirect(searchParams = ""): Promise<Response> {
+  const result = await callLoader(searchParams);
+  if (!(result instanceof Response)) {
+    throw new Error("Expected the loader to return a redirect Response");
+  }
+
+  return result;
+}
+
 describe("rootIndexLoader", () => {
   beforeEach(async () => {
     await resetBoardsDB();
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   test("imports the URL from ?board and redirects to its board route", async () => {
-    const response = await callLoader(
+    const response = await callLoaderForRedirect(
       `?board=${encodeURIComponent(FIXTURE_BOARD_URL)}`,
     );
 
@@ -35,13 +48,56 @@ describe("rootIndexLoader", () => {
     expect(sets).toHaveLength(1);
   });
 
+  test("returns a pending-import intent instead of overwriting an existing set", async () => {
+    await seedBoardSets([
+      { setId: "lots-of-stuff", rootBoardId: "root-1", name: "My Vocabulary" },
+    ]);
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const result = await callLoader(
+      `?board=${encodeURIComponent(FIXTURE_BOARD_URL)}`,
+    );
+
+    expect(result).toEqual({
+      pendingImport: {
+        boardUrl: FIXTURE_BOARD_URL,
+        boardSetName: "My Vocabulary",
+      },
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("throws a localized 400 instead of fetching a non-http(s) board URL", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await expect(
+      callLoader(
+        `?board=${encodeURIComponent("data:application/zip;base64,UEsDBA==")}`,
+      ),
+    ).rejects.toMatchObject({ init: { status: 400 } });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("throws a localized 400 when the board URL cannot be imported", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 404 }),
+    );
+
+    await expect(
+      callLoader(
+        `?board=${encodeURIComponent("https://example.com/gone.obz")}`,
+      ),
+    ).rejects.toMatchObject({ init: { status: 400 } });
+  });
+
   test("redirects to the root board of the most recently updated set when no param is given", async () => {
     await seedBoardSets([
       { setId: "set-1", rootBoardId: "root-1" },
       { setId: "set-2", rootBoardId: "root-2" },
     ]);
 
-    const response = await callLoader();
+    const response = await callLoaderForRedirect();
 
     expect(response.status).toBe(302);
     expect(response.headers.get("Location")).toBe("/sets/set-2/boards/root-2");
@@ -53,7 +109,7 @@ describe("rootIndexLoader", () => {
       throw new Error(`Default board fixture missing at ${DEFAULT_BOARD_PATH}`);
     }
 
-    const response = await callLoader();
+    const response = await callLoaderForRedirect();
 
     expect(response.status).toBe(302);
     expect(response.headers.get("Location")).toMatch(

--- a/src/app/routing/loaders/root-index-loader.ts
+++ b/src/app/routing/loaders/root-index-loader.ts
@@ -1,31 +1,55 @@
 import {
   boardSetPath,
+  deriveSetIdFromUrl,
+  getBoardSet,
   getBoardSets,
   importBoardFromUrl,
 } from "@features/board";
-import { redirect, type LoaderFunctionArgs } from "react-router";
+import { m } from "@paraglide/messages.js";
+import { data, redirect, type LoaderFunctionArgs } from "react-router";
 
 const DEFAULT_BOARD_URL = `${import.meta.env.BASE_URL}quick-core-24.obz`;
 
-async function getOrImportBoardSet(
-  boardUrl: string | null,
-): Promise<{ setId: string; rootBoardId: string }> {
-  if (boardUrl) {
-    return importBoardFromUrl(boardUrl);
-  }
+export interface RootIndexData {
+  pendingImport: {
+    boardUrl: string;
+    boardSetName: string;
+  };
+}
 
-  const [boardSet] = await getBoardSets();
-  if (boardSet) {
-    return boardSet;
-  }
+// The ?board= param is attacker-controlled: a crafted link must never
+// silently replace a user's vocabulary. An import that would overwrite an
+// existing set is returned as an intent for BoardUrlImportPage to confirm,
+// and a rejected URL or failed import surfaces as a localized error state.
+async function importFromBoardUrl(
+  boardUrl: string,
+): Promise<Response | RootIndexData> {
+  try {
+    const existingSet = await getBoardSet(deriveSetIdFromUrl(boardUrl));
 
-  return importBoardFromUrl(DEFAULT_BOARD_URL);
+    if (existingSet) {
+      return { pendingImport: { boardUrl, boardSetName: existingSet.name } };
+    }
+
+    return redirect(boardSetPath(await importBoardFromUrl(boardUrl)));
+  } catch {
+    throw data(m.boardUrlImportFailed(), { status: 400 });
+  }
 }
 
 export async function rootIndexLoader({
   request,
-}: LoaderFunctionArgs): Promise<Response> {
+}: LoaderFunctionArgs): Promise<Response | RootIndexData> {
   const boardUrl = new URL(request.url).searchParams.get("board");
 
-  return redirect(boardSetPath(await getOrImportBoardSet(boardUrl)));
+  if (boardUrl) {
+    return importFromBoardUrl(boardUrl);
+  }
+
+  const [boardSet] = await getBoardSets();
+  if (boardSet) {
+    return redirect(boardSetPath(boardSet));
+  }
+
+  return redirect(boardSetPath(await importBoardFromUrl(DEFAULT_BOARD_URL)));
 }

--- a/src/app/routing/loaders/root-index-loader.ts
+++ b/src/app/routing/loaders/root-index-loader.ts
@@ -21,20 +21,32 @@ export interface RootIndexData {
 // silently replace a user's vocabulary. An import that would overwrite an
 // existing set is returned as an intent for BoardUrlImportPage to confirm,
 // and a rejected URL or failed import surfaces as a localized error state.
+// Storage errors propagate to the generic error boundary instead — they are
+// not the link's fault and must not be reported as a bad link.
 async function importFromBoardUrl(
   boardUrl: string,
 ): Promise<Response | RootIndexData> {
+  let setId: string;
   try {
-    const existingSet = await getBoardSet(deriveSetIdFromUrl(boardUrl));
+    setId = deriveSetIdFromUrl(boardUrl);
+  } catch {
+    throw importFailed();
+  }
 
-    if (existingSet) {
-      return { pendingImport: { boardUrl, boardSetName: existingSet.name } };
-    }
+  const existingSet = await getBoardSet(setId);
+  if (existingSet) {
+    return { pendingImport: { boardUrl, boardSetName: existingSet.name } };
+  }
 
+  try {
     return redirect(boardSetPath(await importBoardFromUrl(boardUrl)));
   } catch {
-    throw data(m.boardUrlImportFailed(), { status: 400 });
+    throw importFailed();
   }
+}
+
+function importFailed() {
+  return data(m.boardUrlImportFailed(), { status: 400 });
 }
 
 export async function rootIndexLoader({

--- a/src/features/board/import/board-import.ts
+++ b/src/features/board/import/board-import.ts
@@ -171,7 +171,7 @@ function buildBoardSetInput(
   };
 }
 
-function deriveSetId(fileName: string): string {
+export function deriveSetId(fileName: string): string {
   const stem = fileName.replace(/\.(obz|obf|zip|json)$/i, "").toLowerCase();
 
   return stem.slice(0, 255) || "imported-board";

--- a/src/features/board/import/import-from-url.test.ts
+++ b/src/features/board/import/import-from-url.test.ts
@@ -50,4 +50,39 @@ describe("importBoardFromUrl", () => {
       importBoardFromUrl("https://example.com/missing.obz"),
     ).rejects.toThrow("Failed to fetch board: HTTP 404");
   });
+
+  test("rejects a non-http(s) URL before fetching", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await expect(
+      importBoardFromUrl("data:application/zip;base64,UEsDBA=="),
+    ).rejects.toMatchObject({
+      name: "BoardUrlError",
+      code: "unsupported-scheme",
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test("cancels a download that exceeds the size cap instead of buffering it", async () => {
+    let cancelled = false;
+    const endlessBody = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(new Uint8Array(32 * 1024 * 1024));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(endlessBody));
+
+    await expect(
+      importBoardFromUrl("https://example.com/huge.obz"),
+    ).rejects.toMatchObject({
+      name: "BoardUrlError",
+      code: "download-too-large",
+    });
+
+    expect(cancelled).toBe(true);
+  });
 });

--- a/src/features/board/import/import-from-url.test.ts
+++ b/src/features/board/import/import-from-url.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { loadFixtureFile, resetBoardsDB } from "../testing";
-import { importBoardFromUrl } from "./import-from-url";
+import {
+  importBoardFromUrl,
+  MAX_BOARD_DOWNLOAD_BYTES,
+} from "./import-from-url";
 
 const SAMPLE_BOARDS_DIR = "/src/features/board/testing/sample-boards";
 const OBZ_FIXTURE = "lots-of-stuff.obz";
@@ -68,7 +71,7 @@ describe("importBoardFromUrl", () => {
     let cancelled = false;
     const endlessBody = new ReadableStream<Uint8Array>({
       pull(controller) {
-        controller.enqueue(new Uint8Array(32 * 1024 * 1024));
+        controller.enqueue(new Uint8Array(MAX_BOARD_DOWNLOAD_BYTES / 4));
       },
       cancel() {
         cancelled = true;

--- a/src/features/board/import/import-from-url.ts
+++ b/src/features/board/import/import-from-url.ts
@@ -1,21 +1,101 @@
-import { importBoardSets, type ImportResult } from "./board-import";
+import {
+  deriveSetId,
+  importBoardSets,
+  type ImportResult,
+} from "./board-import";
 
-export async function importBoardFromUrl(url: string): Promise<ImportResult> {
-  const response = await fetch(url);
+/**
+ * Hard cap on a board download, enforced while the response streams so an
+ * oversized transfer is cancelled mid-flight instead of buffered whole.
+ * Generous versus real boards (observed up to ~70MB) but bounded — the
+ * network-side counterpart of `BOARD_IMPORT_LIMITS`.
+ */
+export const MAX_BOARD_DOWNLOAD_BYTES = 150 * 1024 * 1024;
 
-  if (!response.ok) {
-    throw new Error(`Failed to fetch board: HTTP ${response.status}`);
+export type BoardUrlErrorCode = "unsupported-scheme" | "download-too-large";
+
+/** Thrown when a board URL is rejected before or during download. */
+export class BoardUrlError extends Error {
+  readonly code: BoardUrlErrorCode;
+
+  constructor(code: BoardUrlErrorCode, message: string) {
+    super(message);
+    this.name = "BoardUrlError";
+    this.code = code;
+  }
+}
+
+// The ?board= param is attacker-controlled, so only http(s) may reach fetch —
+// schemes like data: would smuggle a payload past any host-based reasoning.
+function parseBoardUrl(url: string): URL {
+  const resolved = new URL(url, window.location.origin);
+
+  if (resolved.protocol !== "http:" && resolved.protocol !== "https:") {
+    throw new BoardUrlError(
+      "unsupported-scheme",
+      `Unsupported board URL scheme: ${resolved.protocol}`,
+    );
   }
 
-  const blob = await response.blob();
-  const pathname = new URL(url, window.location.origin).pathname;
-  const filename = pathname.split("/").filter(Boolean).at(-1) ?? "board.obz";
+  return resolved;
+}
 
-  const file = new File([blob], filename, {
+function deriveFilename(url: URL): string {
+  return url.pathname.split("/").filter(Boolean).at(-1) ?? "board.obz";
+}
+
+/** The setId a board URL would import into, without downloading anything. */
+export function deriveSetIdFromUrl(url: string): string {
+  return deriveSetId(deriveFilename(parseBoardUrl(url)));
+}
+
+export async function importBoardFromUrl(url: string): Promise<ImportResult> {
+  const boardUrl = parseBoardUrl(url);
+  const blob = await downloadBoard(boardUrl);
+
+  const file = new File([blob], deriveFilename(boardUrl), {
     type: blob.type || "application/octet-stream",
   });
 
   const [result] = await importBoardSets(file);
 
   return result;
+}
+
+async function downloadBoard(url: URL): Promise<Blob> {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch board: HTTP ${response.status}`);
+  }
+
+  const reader = response.body?.getReader();
+  if (!reader) {
+    return response.blob();
+  }
+
+  const chunks: BlobPart[] = [];
+  let receivedBytes = 0;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    receivedBytes += value.byteLength;
+    if (receivedBytes > MAX_BOARD_DOWNLOAD_BYTES) {
+      await reader.cancel();
+      throw new BoardUrlError(
+        "download-too-large",
+        `Board download exceeded ${MAX_BOARD_DOWNLOAD_BYTES} bytes`,
+      );
+    }
+
+    chunks.push(value);
+  }
+
+  return new Blob(chunks, {
+    type: response.headers.get("content-type") ?? "",
+  });
 }

--- a/src/features/board/import/import-from-url.ts
+++ b/src/features/board/import/import-from-url.ts
@@ -69,6 +69,8 @@ async function downloadBoard(url: URL): Promise<Blob> {
     throw new Error(`Failed to fetch board: HTTP ${response.status}`);
   }
 
+  // Not a cap bypass: browsers only leave body null for null-body statuses
+  // (e.g. 204), which carry no payload for the size cap to bound.
   const reader = response.body?.getReader();
   if (!reader) {
     return response.blob();

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -6,7 +6,10 @@ export { deleteBoardSet, getBoardSets } from "./board-sets/board-sets-store";
 export { useBoardSets } from "./board-sets/use-board-sets";
 export { BoardViewer } from "./board-viewer";
 export { BoardFileDropOverlay } from "./import/board-file-drop-overlay";
-export { importBoardFromUrl } from "./import/import-from-url";
+export {
+  deriveSetIdFromUrl,
+  importBoardFromUrl,
+} from "./import/import-from-url";
 export { useBoardFileDrop } from "./import/use-board-file-drop";
 export { useFileHandlerLaunch } from "./import/use-file-handler-launch";
 export { useImportBoardFiles } from "./import/use-import-board-files";

--- a/src/pages/board-url-import-page.tsx
+++ b/src/pages/board-url-import-page.tsx
@@ -1,0 +1,76 @@
+import type { RootIndexData } from "@app/routing/loaders/root-index-loader";
+import { boardSetPath, importBoardFromUrl } from "@features/board";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogTitle from "@mui/material/DialogTitle";
+import { m } from "@paraglide/messages.js";
+import { useSnackbar } from "@shared/snackbar/use-snackbar";
+import { useState } from "react";
+import { useLoaderData, useNavigate } from "react-router";
+
+// Rendered only when rootIndexLoader returns a pending import instead of
+// redirecting: the ?board= link targets an existing set, and replacing a
+// user's vocabulary requires their explicit confirmation.
+export const Component = function BoardUrlImportPage() {
+  const { pendingImport } = useLoaderData<RootIndexData>();
+  const { showSnackbar } = useSnackbar();
+  const navigate = useNavigate();
+  const [importing, setImporting] = useState(false);
+
+  async function confirmImport() {
+    setImporting(true);
+    showSnackbar({ message: m.libraryImportingBoards({ count: 1 }) });
+
+    try {
+      const result = await importBoardFromUrl(pendingImport.boardUrl);
+
+      showSnackbar({
+        message: m.libraryReplacedBoards({ count: 1 }),
+        severity: "success",
+      });
+      await navigate(boardSetPath(result), { replace: true });
+    } catch {
+      showSnackbar({ message: m.boardUrlImportFailed(), severity: "error" });
+      await navigate("/", { replace: true });
+    }
+  }
+
+  function cancelImport() {
+    void navigate("/", { replace: true });
+  }
+
+  return (
+    <Dialog
+      open
+      onClose={importing ? undefined : cancelImport}
+      aria-labelledby="board-url-import-title"
+      aria-describedby="board-url-import-description"
+    >
+      <DialogTitle id="board-url-import-title">
+        {m.boardUrlReplaceConfirmTitle({ name: pendingImport.boardSetName })}
+      </DialogTitle>
+
+      <DialogContent>
+        <DialogContentText id="board-url-import-description">
+          {m.boardUrlReplaceConfirmDescription()}
+        </DialogContentText>
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={cancelImport} disabled={importing}>
+          {m.libraryCancel()}
+        </Button>
+        <Button
+          onClick={() => void confirmImport()}
+          color="error"
+          disabled={importing}
+        >
+          {m.boardUrlReplace()}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/src/pages/board-url-import-page.tsx
+++ b/src/pages/board-url-import-page.tsx
@@ -20,6 +20,10 @@ export const Component = function BoardUrlImportPage() {
   const navigate = useNavigate();
   const [importing, setImporting] = useState(false);
 
+  // Consent needs to name the source; a relative URL resolves to this origin.
+  const boardHost = new URL(pendingImport.boardUrl, window.location.origin)
+    .host;
+
   async function confirmImport() {
     setImporting(true);
     showSnackbar({ message: m.libraryImportingBoards({ count: 1 }) });
@@ -55,7 +59,7 @@ export const Component = function BoardUrlImportPage() {
 
       <DialogContent>
         <DialogContentText id="board-url-import-description">
-          {m.boardUrlReplaceConfirmDescription()}
+          {m.boardUrlReplaceConfirmDescription({ host: boardHost })}
         </DialogContentText>
       </DialogContent>
 


### PR DESCRIPTION
## Summary
- A crafted `?board=` link could silently overwrite a nonverbal user's vocabulary: the loader fetched any scheme unconditionally, buffered the full response, and `replaceBoardSet` overwrote any existing set sharing the derived `setId`.
- `importBoardFromUrl` now rejects non-http(s) schemes (e.g. `data:`) before ever calling `fetch`, and streams the download, aborting mid-transfer past a 150MB cap instead of buffering the whole response.
- `rootIndexLoader` now checks whether the derived `setId` already exists; if so it returns a pending-import intent instead of importing. A new confirmation dialog (`board-url-import-page.tsx`) names the host the board would be downloaded from and requires explicit user consent before `replaceBoardSet` runs.
- A rejected URL or failed fetch/parse surfaces as a localized error via the existing `RouteErrorBoundary`; storage failures propagate to the generic error boundary instead of being mislabeled as a bad link.
- New user-facing strings translated across all 35 locales.

## Out of scope (residual risk)
A `?board=` link whose derived `setId` does **not** collide with an existing set still imports without confirmation: it adds a new set, redirects into it, and — being the most recently updated set — becomes where `/` lands on subsequent visits. This PR guards *replacement* of existing content only; unconfirmed drive-by *addition* is a known, accepted limitation of the link-sharing flow.

## Test plan
- [x] `npm test` — 501 tests / 73 files pass (real Chromium via Vitest browser mode)
- [x] `npx tsc -b` — clean
- [x] `npx eslint` on changed files — clean
- [x] `npm run build` — clean
- [x] Unit: rejected scheme never calls `fetch`
- [x] Unit: oversize download is cancelled mid-stream (not buffered); test chunk size derives from `MAX_BOARD_DOWNLOAD_BYTES`
- [x] Loader: existing setId returns a pending-import intent with zero network calls
- [x] Loader: fresh setId still imports and redirects unchanged
- [x] E2e (real browser): confirming the dialog replaces the board set; cancelling preserves the existing one

🤖 Generated with [Claude Code](https://claude.com/claude-code)
