### PR TITLE
Trim redundant and fix stale code comments

### DIFF
--- a/src/features/board/import/board-import.ts
+++ b/src/features/board/import/board-import.ts
@@ -31,8 +31,8 @@ export interface ImportResult {
  * makes `loadBoard` throw an `OBFError` with code `"archive-too-large"`.
  */
 export const BOARD_IMPORT_LIMITS: UnzipLimits = {
-  maxTotalOriginalSize: 500 * 1024 * 1024, // 500MB across the whole archive
-  maxEntrySize: 100 * 1024 * 1024, // 100MB for any single entry
+  maxTotalOriginalSize: 500 * 1024 * 1024,
+  maxEntrySize: 100 * 1024 * 1024,
   maxEntries: 5000,
 };
 

--- a/src/features/board/message/playback/use-message-playback.test.ts
+++ b/src/features/board/message/playback/use-message-playback.test.ts
@@ -233,7 +233,7 @@ describe("useMessagePlayback", () => {
     await rerender();
 
     result.current.stop();
-    resolveFirstSpeak?.(); // let the awaited first utterance resolve
+    resolveFirstSpeak?.();
     await playPromise;
     await rerender();
 
@@ -266,7 +266,7 @@ describe("useMessagePlayback", () => {
     await rerender();
 
     result.current.stop();
-    fireBoundary?.(2); // late event for the canceled utterance
+    fireBoundary?.(2);
     await rerender();
     expect(result.current.activePartId).toBeNull();
 

--- a/src/features/board/testing/db.ts
+++ b/src/features/board/testing/db.ts
@@ -39,7 +39,6 @@ async function clearBoardsDB(): Promise<void> {
   await tx.done;
 }
 
-/** Standard per-suite IDB reset: clear all board stores and refresh the in-memory board-sets cache. */
 export async function resetBoardsDB(): Promise<void> {
   await clearBoardsDB();
   await refreshBoardSets();

--- a/src/features/board/testing/fixtures.ts
+++ b/src/features/board/testing/fixtures.ts
@@ -7,10 +7,6 @@ export const TEST_IMAGE_SRC =
 
 const SAMPLE_BOARDS_DIR = "/src/features/board/testing/sample-boards";
 
-/**
- * Loads a board file from sample-boards/ off the test server as a File,
- * ready to feed into import flows.
- */
 export async function loadFixtureFile(name: string): Promise<File> {
   const response = await fetch(`${SAMPLE_BOARDS_DIR}/${name}`);
 

--- a/src/shared/speech/speak.cancellation.test.ts
+++ b/src/shared/speech/speak.cancellation.test.ts
@@ -8,9 +8,6 @@ import {
 } from "vitest";
 import { speak } from "./speak";
 
-// Kept separate from the no-API suite: that suite must import speak only
-// after stubbing speechSynthesis away, which a static import in a shared file
-// would defeat.
 describe("speak() under cancellation", () => {
   let speakSpy: MockInstance<SpeechSynthesis["speak"]>;
   let cancelSpy: MockInstance<SpeechSynthesis["cancel"]>;

--- a/src/shared/speech/use-voice-language-sync.ts
+++ b/src/shared/speech/use-voice-language-sync.ts
@@ -16,8 +16,7 @@ export interface UseVoiceLanguageSyncOptions {
 
 /**
  * The user's own region for a language, drawn from OS/browser preferences
- * (e.g. a Canadian's "fr-CA" → "CA"). Undefined when none of the preferred
- * locales name a region for this language.
+ * (e.g. a Canadian's "fr-CA" → "CA").
  */
 function getUserRegionForLanguage(language: string): string | undefined {
   for (const tag of navigator.languages) {

--- a/src/shared/theme/rtl.ts
+++ b/src/shared/theme/rtl.ts
@@ -1,23 +1,12 @@
 import type { Theme } from "@mui/material/styles";
 
-/**
- * sx helper that mirrors an element on the X axis when the theme direction is
- * RTL. Intended for directional icons (arrows, backspace, play, etc.).
- *
- * Usage:
- *   <ArrowBackOutlinedIcon sx={flipForRtl} />
- *   <PlayArrowIcon sx={[flipForRtl, { width: 48, height: 48 }]} />
- */
+/** Mirrors on the X axis in RTL — for directional icons (arrows, backspace, play). */
 export const flipForRtl = (theme: Theme) =>
   theme.direction === "rtl" ? { transform: "scaleX(-1)" } : {};
 
 /**
- * sx helper that mirrors an element on the X axis when the theme direction is
- * LTR. Intended for icons that are inherently asymmetric but happen to read
- * correctly unflipped in RTL (e.g. a sidebar icon depicting a left-hand rail).
- *
- * Usage:
- *   <ViewSidebarOutlinedIcon sx={flipForLtr} />
+ * Mirrors on the X axis in LTR — for asymmetric icons that already read
+ * correctly in RTL (e.g. a sidebar icon depicting a left-hand rail).
  */
 export const flipForLtr = (theme: Theme) =>
   theme.direction === "ltr" ? { transform: "scaleX(-1)" } : {};

--- a/src/shared/utils/locale.ts
+++ b/src/shared/utils/locale.ts
@@ -19,10 +19,6 @@ export function normalizeLocale(locale: string): string {
   }
 }
 
-/**
- * Extracts the primary language subtag from a BCP-47 locale code
- * (e.g. "en-US" → "en"). Always lowercase.
- */
 export function getLanguageCode(locale: string): string {
   return locale.split(/[_-]/)[0].toLowerCase();
 }
@@ -52,7 +48,6 @@ export function getLikelyRegion(language: string): string | undefined {
 }
 
 /**
- * Returns the writing direction for a BCP-47 locale code.
  * Falls back to "ltr" for structurally invalid input; unknown
  * but well-formed codes default to "ltr" via Intl.
  */
@@ -65,8 +60,8 @@ export function getTextDirection(locale: string): "ltr" | "rtl" {
 }
 
 /**
- * Returns the language name of a locale code in English
- * (e.g. "he-IL" → "Hebrew").
+ * English display name of a locale, dialect-aware
+ * (e.g. "en-US" → "American English", "he-IL" → "Hebrew (Israel)").
  * Falls back to the original code if the locale is not recognized.
  */
 export function getEnglishLanguageName(locale: string): string {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,7 +24,6 @@ const themeColorHtmlPlugin: Plugin = {
       .replaceAll("__CONTENT_DARK__", CONTENT_DARK),
 };
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [
     themeColorHtmlPlugin,
@@ -129,7 +128,6 @@ export default defineConfig({
     browser: {
       enabled: true,
       provider: playwright(),
-      // https://vitest.dev/guide/browser/playwright
       instances: [{ browser: "chromium" }],
     },
     coverage: {


### PR DESCRIPTION
## Summary
- Removed 8 comments that only restated adjacent code/names (docs links, redundant JSDoc, inline decodes of already-named calls)
- Fixed 2 stale comments: a disproven rationale for why `speak.cancellation.test.ts` imports separately, and a wrong `getEnglishLanguageName` example (`"he-IL"` actually returns `"Hebrew (Israel)"`, not `"Hebrew"`, under `languageDisplay: "dialect"`)
- Tightened 5 JSDoc blocks (`rtl.ts`, `locale.ts`, `use-voice-language-sync.ts`) to keep only the non-obvious "why", dropping padding that restated the type signature or included unnecessary usage examples

All other comments in the codebase were reviewed in context and kept — they document library quirks, deliberate empty catches, or cross-file coupling that the code itself can't express.

## Test plan
- [x] `tsc -b` passes
- [x] ESLint clean on changed files
- [x] Prettier clean on changed files
- [x] Pre-commit hooks (lint-staged) passed