### PR TITLE
Add catch-all route and root error boundary

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "يعمل بالكامل على جهازك دون أي تتبّع للبيانات أو اعتماد على السحابة.",
   "onboardingContinue": "متابعة",
   "errorGenericTitle": "حدث خطأ ما",
+  "errorPageNotFound": "الصفحة غير موجودة",
   "errorGoHome": "الانتقال إلى الرئيسية",
   "errorBoardNotFound": "اللوحة غير موجودة",
   "errorBoardSetNotFound": "اللوحة غير موجودة",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Работи изцяло на вашето устройство, без проследяване на данни и без зависимост от облака.",
   "onboardingContinue": "Продължаване",
   "errorGenericTitle": "Нещо се обърка",
+  "errorPageNotFound": "Страницата не е намерена",
   "errorGoHome": "Към началото",
   "errorBoardNotFound": "Дъската не е намерена",
   "errorBoardSetNotFound": "Дъската не е намерена",

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "সম্পূর্ণরূপে আপনার ডিভাইসে চলে, কোনো ডেটা ট্র্যাকিং ছাড়াই এবং ক্লাউডের ওপর নির্ভরতা ছাড়াই।",
   "onboardingContinue": "চালিয়ে যান",
   "errorGenericTitle": "কিছু একটা ভুল হয়েছে",
+  "errorPageNotFound": "পৃষ্ঠাটি পাওয়া যায়নি",
   "errorGoHome": "হোমে যান",
   "errorBoardNotFound": "বোর্ড পাওয়া যায়নি",
   "errorBoardSetNotFound": "বোর্ড পাওয়া যায়নি",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Běží zcela ve vašem zařízení, bez sledování dat a bez závislosti na cloudu.",
   "onboardingContinue": "Pokračovat",
   "errorGenericTitle": "Něco se pokazilo",
+  "errorPageNotFound": "Stránka nebyla nalezena",
   "errorGoHome": "Přejít domů",
   "errorBoardNotFound": "Tabulka nebyla nalezena",
   "errorBoardSetNotFound": "Tabulka nebyla nalezena",

--- a/messages/da.json
+++ b/messages/da.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Kører helt på din enhed, uden datasporing og uden afhængighed af skyen.",
   "onboardingContinue": "Fortsæt",
   "errorGenericTitle": "Noget gik galt",
+  "errorPageNotFound": "Siden blev ikke fundet",
   "errorGoHome": "Gå til start",
   "errorBoardNotFound": "Tavlen blev ikke fundet",
   "errorBoardSetNotFound": "Tavlen blev ikke fundet",

--- a/messages/de.json
+++ b/messages/de.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Läuft vollständig auf deinem Gerät – ohne Datenverfolgung und ohne Cloud-Abhängigkeiten.",
   "onboardingContinue": "Weiter",
   "errorGenericTitle": "Etwas ist schiefgelaufen",
+  "errorPageNotFound": "Seite nicht gefunden",
   "errorGoHome": "Zur Startseite",
   "errorBoardNotFound": "Tafel nicht gefunden",
   "errorBoardSetNotFound": "Tafel nicht gefunden",

--- a/messages/el.json
+++ b/messages/el.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Εκτελείται εξ ολοκλήρου στη συσκευή σας, χωρίς παρακολούθηση δεδομένων και χωρίς εξάρτηση από το cloud.",
   "onboardingContinue": "Συνέχεια",
   "errorGenericTitle": "Κάτι πήγε στραβά",
+  "errorPageNotFound": "Η σελίδα δεν βρέθηκε",
   "errorGoHome": "Μετάβαση στην αρχική",
   "errorBoardNotFound": "Ο πίνακας δεν βρέθηκε",
   "errorBoardSetNotFound": "Ο πίνακας δεν βρέθηκε",

--- a/messages/en.json
+++ b/messages/en.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Runs entirely on your device with zero data tracking and no cloud dependencies.",
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
+  "errorPageNotFound": "Page not found",
   "errorGoHome": "Go home",
   "errorBoardNotFound": "Board not found",
   "errorBoardSetNotFound": "Board not found",

--- a/messages/es.json
+++ b/messages/es.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Se ejecuta por completo en tu dispositivo, sin rastreo de datos ni dependencia de la nube.",
   "onboardingContinue": "Continuar",
   "errorGenericTitle": "Algo salió mal",
+  "errorPageNotFound": "Página no encontrada",
   "errorGoHome": "Ir al inicio",
   "errorBoardNotFound": "Tablero no encontrado",
   "errorBoardSetNotFound": "Tablero no encontrado",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Toimii kokonaan laitteellasi ilman tietojen seurantaa ja ilman pilviriippuvuutta.",
   "onboardingContinue": "Jatka",
   "errorGenericTitle": "Jokin meni pieleen",
+  "errorPageNotFound": "Sivua ei löytynyt",
   "errorGoHome": "Siirry etusivulle",
   "errorBoardNotFound": "Taulua ei löytynyt",
   "errorBoardSetNotFound": "Taulua ei löytynyt",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Fonctionne entièrement sur votre appareil, sans suivi des données ni dépendance au cloud.",
   "onboardingContinue": "Continuer",
   "errorGenericTitle": "Une erreur s'est produite",
+  "errorPageNotFound": "Page introuvable",
   "errorGoHome": "Aller à l'accueil",
   "errorBoardNotFound": "Tableau introuvable",
   "errorBoardSetNotFound": "Tableau introuvable",

--- a/messages/he.json
+++ b/messages/he.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "פועל לחלוטין על המכשיר שלך, ללא מעקב אחר נתונים וללא תלות בענן.",
   "onboardingContinue": "המשך",
   "errorGenericTitle": "משהו השתבש",
+  "errorPageNotFound": "הדף לא נמצא",
   "errorGoHome": "חזרה לעמוד הבית",
   "errorBoardNotFound": "הלוח לא נמצא",
   "errorBoardSetNotFound": "הלוח לא נמצא",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "पूरी तरह आपके डिवाइस पर चलता है, बिना किसी डेटा ट्रैकिंग और बिना क्लाउड पर निर्भरता के।",
   "onboardingContinue": "जारी रखें",
   "errorGenericTitle": "कुछ गलत हो गया",
+  "errorPageNotFound": "पृष्ठ नहीं मिला",
   "errorGoHome": "होम पर जाएँ",
   "errorBoardNotFound": "बोर्ड नहीं मिला",
   "errorBoardSetNotFound": "बोर्ड नहीं मिला",

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Radi u potpunosti na vašem uređaju, bez praćenja podataka i bez ovisnosti o oblaku.",
   "onboardingContinue": "Nastavi",
   "errorGenericTitle": "Nešto je pošlo po zlu",
+  "errorPageNotFound": "Stranica nije pronađena",
   "errorGoHome": "Idi na početnu",
   "errorBoardNotFound": "Ploča nije pronađena",
   "errorBoardSetNotFound": "Ploča nije pronađena",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Teljes egészében az eszközödön fut, adatkövetés nélkül és felhőfüggőség nélkül.",
   "onboardingContinue": "Folytatás",
   "errorGenericTitle": "Hiba történt",
+  "errorPageNotFound": "Az oldal nem található",
   "errorGoHome": "Ugrás a kezdőlapra",
   "errorBoardNotFound": "A tábla nem található",
   "errorBoardSetNotFound": "A tábla nem található",

--- a/messages/id.json
+++ b/messages/id.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Berjalan sepenuhnya di perangkat Anda, tanpa pelacakan data dan tanpa ketergantungan cloud.",
   "onboardingContinue": "Lanjutkan",
   "errorGenericTitle": "Terjadi kesalahan",
+  "errorPageNotFound": "Halaman tidak ditemukan",
   "errorGoHome": "Ke beranda",
   "errorBoardNotFound": "Papan tidak ditemukan",
   "errorBoardSetNotFound": "Papan tidak ditemukan",

--- a/messages/it.json
+++ b/messages/it.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Funziona interamente sul tuo dispositivo, senza tracciamento dei dati né dipendenza dal cloud.",
   "onboardingContinue": "Continua",
   "errorGenericTitle": "Qualcosa è andato storto",
+  "errorPageNotFound": "Pagina non trovata",
   "errorGoHome": "Vai alla home",
   "errorBoardNotFound": "Tabella non trovata",
   "errorBoardSetNotFound": "Tabella non trovata",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "すべてお使いのデバイス上で動作し、データの追跡やクラウドへの依存は一切ありません。",
   "onboardingContinue": "続ける",
   "errorGenericTitle": "問題が発生しました",
+  "errorPageNotFound": "ページが見つかりません",
   "errorGoHome": "ホームに戻る",
   "errorBoardNotFound": "ボードが見つかりません",
   "errorBoardSetNotFound": "ボードが見つかりません",

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "ಸಂಪೂರ್ಣವಾಗಿ ನಿಮ್ಮ ಸಾಧನದಲ್ಲಿ ಕಾರ್ಯನಿರ್ವಹಿಸುತ್ತದೆ, ಯಾವುದೇ ಡೇಟಾ ಟ್ರ್ಯಾಕಿಂಗ್ ಇಲ್ಲದೆ ಮತ್ತು ಕ್ಲೌಡ್ ಅವಲಂಬನೆ ಇಲ್ಲದೆ.",
   "onboardingContinue": "ಮುಂದುವರಿಸಿ",
   "errorGenericTitle": "ಏನೋ ತಪ್ಪಾಗಿದೆ",
+  "errorPageNotFound": "ಪುಟ ಕಂಡುಬಂದಿಲ್ಲ",
   "errorGoHome": "ಮುಖಪುಟಕ್ಕೆ ಹೋಗಿ",
   "errorBoardNotFound": "ಬೋರ್ಡ್ ಕಂಡುಬಂದಿಲ್ಲ",
   "errorBoardSetNotFound": "ಬೋರ್ಡ್ ಕಂಡುಬಂದಿಲ್ಲ",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "전적으로 기기에서 실행되며, 데이터 추적이 전혀 없고 클라우드에 의존하지 않습니다.",
   "onboardingContinue": "계속",
   "errorGenericTitle": "문제가 발생했습니다",
+  "errorPageNotFound": "페이지를 찾을 수 없음",
   "errorGoHome": "홈으로",
   "errorBoardNotFound": "보드를 찾을 수 없음",
   "errorBoardSetNotFound": "보드를 찾을 수 없음",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Draait volledig op je apparaat, zonder gegevens te volgen en zonder afhankelijkheid van de cloud.",
   "onboardingContinue": "Doorgaan",
   "errorGenericTitle": "Er is iets misgegaan",
+  "errorPageNotFound": "Pagina niet gevonden",
   "errorGoHome": "Naar start",
   "errorBoardNotFound": "Bord niet gevonden",
   "errorBoardSetNotFound": "Bord niet gevonden",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Działa w całości na Twoim urządzeniu, bez śledzenia danych i bez zależności od chmury.",
   "onboardingContinue": "Kontynuuj",
   "errorGenericTitle": "Coś poszło nie tak",
+  "errorPageNotFound": "Nie znaleziono strony",
   "errorGoHome": "Przejdź do strony głównej",
   "errorBoardNotFound": "Nie znaleziono tablicy",
   "errorBoardSetNotFound": "Nie znaleziono tablicy",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Funciona inteiramente no seu dispositivo, sem rastreamento de dados nem dependência da nuvem.",
   "onboardingContinue": "Continuar",
   "errorGenericTitle": "Algo deu errado",
+  "errorPageNotFound": "Página não encontrada",
   "errorGoHome": "Ir para o início",
   "errorBoardNotFound": "Prancha não encontrada",
   "errorBoardSetNotFound": "Prancha não encontrada",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Rulează în întregime pe dispozitivul tău, fără urmărirea datelor și fără dependență de cloud.",
   "onboardingContinue": "Continuă",
   "errorGenericTitle": "Ceva nu a mers bine",
+  "errorPageNotFound": "Pagina nu a fost găsită",
   "errorGoHome": "Mergi la pagina principală",
   "errorBoardNotFound": "Tabla nu a fost găsită",
   "errorBoardSetNotFound": "Tabla nu a fost găsită",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Работает полностью на вашем устройстве, без отслеживания данных и без зависимости от облака.",
   "onboardingContinue": "Продолжить",
   "errorGenericTitle": "Что-то пошло не так",
+  "errorPageNotFound": "Страница не найдена",
   "errorGoHome": "На главную",
   "errorBoardNotFound": "Доска не найдена",
   "errorBoardSetNotFound": "Доска не найдена",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Beží úplne vo vašom zariadení, bez sledovania údajov a bez závislosti od cloudu.",
   "onboardingContinue": "Pokračovať",
   "errorGenericTitle": "Niečo sa pokazilo",
+  "errorPageNotFound": "Stránka sa nenašla",
   "errorGoHome": "Prejsť domov",
   "errorBoardNotFound": "Tabuľka sa nenašla",
   "errorBoardSetNotFound": "Tabuľka sa nenašla",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Deluje v celoti v vaši napravi, brez sledenja podatkom in brez odvisnosti od oblaka.",
   "onboardingContinue": "Nadaljuj",
   "errorGenericTitle": "Nekaj je šlo narobe",
+  "errorPageNotFound": "Strani ni mogoče najti",
   "errorGoHome": "Pojdi domov",
   "errorBoardNotFound": "Table ni mogoče najti",
   "errorBoardSetNotFound": "Table ni mogoče najti",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Körs helt på din enhet, utan dataspårning och utan molnberoende.",
   "onboardingContinue": "Fortsätt",
   "errorGenericTitle": "Något gick fel",
+  "errorPageNotFound": "Sidan hittades inte",
   "errorGoHome": "Till startsidan",
   "errorBoardNotFound": "Tavlan hittades inte",
   "errorBoardSetNotFound": "Tavlan hittades inte",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "முழுவதுமாக உங்கள் சாதனத்தில் இயங்குகிறது, எந்த தரவுக் கண்காணிப்பும் இல்லாமல், கிளவுட் சார்பும் இல்லாமல்.",
   "onboardingContinue": "தொடரவும்",
   "errorGenericTitle": "ஏதோ தவறு நடந்தது",
+  "errorPageNotFound": "பக்கம் கிடைக்கவில்லை",
   "errorGoHome": "முகப்புக்குச் செல்",
   "errorBoardNotFound": "பலகை கிடைக்கவில்லை",
   "errorBoardSetNotFound": "பலகை கிடைக்கவில்லை",

--- a/messages/te.json
+++ b/messages/te.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "పూర్తిగా మీ పరికరంలోనే పనిచేస్తుంది, ఎలాంటి డేటా ట్రాకింగ్ లేకుండా, క్లౌడ్ ఆధారపడటం లేకుండా.",
   "onboardingContinue": "కొనసాగించు",
   "errorGenericTitle": "ఏదో తప్పు జరిగింది",
+  "errorPageNotFound": "పేజీ కనుగొనబడలేదు",
   "errorGoHome": "హోమ్‌కు వెళ్లు",
   "errorBoardNotFound": "బోర్డు కనుగొనబడలేదు",
   "errorBoardSetNotFound": "బోర్డు కనుగొనబడలేదు",

--- a/messages/th.json
+++ b/messages/th.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "ทำงานบนอุปกรณ์ของคุณทั้งหมด ไม่มีการติดตามข้อมูลและไม่ต้องพึ่งพาคลาวด์",
   "onboardingContinue": "ดำเนินการต่อ",
   "errorGenericTitle": "เกิดข้อผิดพลาดบางอย่าง",
+  "errorPageNotFound": "ไม่พบหน้านี้",
   "errorGoHome": "ไปที่หน้าแรก",
   "errorBoardNotFound": "ไม่พบบอร์ด",
   "errorBoardSetNotFound": "ไม่พบบอร์ด",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Tamamen cihazınızda çalışır; veri takibi olmadan ve buluta bağımlılık olmadan.",
   "onboardingContinue": "Devam et",
   "errorGenericTitle": "Bir şeyler ters gitti",
+  "errorPageNotFound": "Sayfa bulunamadı",
   "errorGoHome": "Ana sayfaya git",
   "errorBoardNotFound": "Pano bulunamadı",
   "errorBoardSetNotFound": "Pano bulunamadı",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Працює повністю на вашому пристрої, без відстеження даних і без залежності від хмари.",
   "onboardingContinue": "Продовжити",
   "errorGenericTitle": "Щось пішло не так",
+  "errorPageNotFound": "Сторінку не знайдено",
   "errorGoHome": "На головну",
   "errorBoardNotFound": "Дошку не знайдено",
   "errorBoardSetNotFound": "Дошку не знайдено",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "Chạy hoàn toàn trên thiết bị của bạn, không theo dõi dữ liệu và không phụ thuộc vào đám mây.",
   "onboardingContinue": "Tiếp tục",
   "errorGenericTitle": "Đã xảy ra lỗi",
+  "errorPageNotFound": "Không tìm thấy trang",
   "errorGoHome": "Về trang chủ",
   "errorBoardNotFound": "Không tìm thấy bảng",
   "errorBoardSetNotFound": "Không tìm thấy bảng",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -124,6 +124,7 @@
   "onboardingPrivacyDescription": "完全在你的设备上运行，零数据追踪，也不依赖云端。",
   "onboardingContinue": "继续",
   "errorGenericTitle": "出了点问题",
+  "errorPageNotFound": "页面未找到",
   "errorGoHome": "返回主页",
   "errorBoardNotFound": "未找到沟通板",
   "errorBoardSetNotFound": "未找到沟通板",

--- a/src/app/routing/app-routes.test.tsx
+++ b/src/app/routing/app-routes.test.tsx
@@ -116,6 +116,18 @@ describe("app flow", () => {
       .element(screen.getByRole("grid", { name: "Old Board" }))
       .toBeVisible();
   });
+
+  test("an unmatched URL renders the localized not-found page inside the shell", async () => {
+    const screen = await renderApp("/nonexistent");
+
+    // The shell still mounts on a miss, so dismiss onboarding first.
+    await screen.getByRole("button", { name: "Continue" }).click();
+
+    await expect.element(screen.getByText("Page not found")).toBeVisible();
+    await expect
+      .element(screen.getByRole("link", { name: "Go home" }))
+      .toHaveAttribute("href", "/");
+  });
 });
 
 // A set whose setId collides with what the OBZ fixture URL derives, so a

--- a/src/app/routing/app-routes.tsx
+++ b/src/app/routing/app-routes.tsx
@@ -2,6 +2,7 @@ import { AppShell } from "@app/layouts/app-shell";
 import { boardLoader } from "@app/routing/loaders/board-loader";
 import { boardSetIndexLoader } from "@app/routing/loaders/board-set-index-loader";
 import { rootIndexLoader } from "@app/routing/loaders/root-index-loader";
+import { NotFound } from "@app/routing/not-found";
 import { RouteErrorBoundary } from "@app/routing/route-error-boundary";
 import { BOARD_SEGMENT, BOARD_SET_SEGMENT } from "@features/board";
 import { LoadingState } from "@shared/components/loading-state";
@@ -10,6 +11,7 @@ import type { RouteObject } from "react-router";
 export const appRoutes: RouteObject[] = [
   {
     Component: AppShell,
+    ErrorBoundary: RouteErrorBoundary,
     children: [
       {
         ErrorBoundary: RouteErrorBoundary,
@@ -31,6 +33,7 @@ export const appRoutes: RouteObject[] = [
               },
             ],
           },
+          { path: "*", Component: NotFound },
         ],
       },
     ],

--- a/src/app/routing/not-found.tsx
+++ b/src/app/routing/not-found.tsx
@@ -1,0 +1,20 @@
+import Button from "@mui/material/Button";
+import { m } from "@paraglide/messages.js";
+import { ErrorState } from "@shared/components/error-state";
+import { Link } from "react-router";
+
+// Catch-all target for URLs that match no route (typo'd links, stale
+// bookmarks). Rendered inside the app shell so the header and a way home stay
+// available, rather than falling through to react-router's unstyled default.
+export function NotFound() {
+  return (
+    <ErrorState
+      title={m.errorPageNotFound()}
+      action={
+        <Button component={Link} to="/" variant="contained">
+          {m.errorGoHome()}
+        </Button>
+      }
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Add `ErrorBoundary: RouteErrorBoundary` on the root `AppShell` route so a shell render error no longer falls through to react-router's unstyled default screen (the nested boundary is kept, so board errors still render inside the shell)
- Add a `*` catch-all route rendering a new localized `NotFound` page (title + "Go home" link) for unmatched paths
- Translate the new `errorPageNotFound` message key into all 35 locales

## Test plan
- [x] `an unmatched URL renders the localized not-found page inside the shell` test added in `app-routes.test.tsx`, verifies `/nonexistent` shows "Page not found" and a working "Go home" link to `/`
- [x] Full `app-routes.test.tsx` suite passes (5/5)
- [x] `messages/*.json` validated as valid JSON, `errorPageNotFound` present in all 35 locale files
- [x] Paraglide recompiled successfully from updated messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)