### PR TITLE
Add tile color saturation setting

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -98,6 +98,7 @@
   "speechPreview": "استماع",
   "speechVoicePreview": "مرحبًا، هذا هو صوتي!",
   "playbackHighlight": "تمييز الكلمات أثناء التحدث",
+  "tileSaturation": "شدة الألوان",
   "aiCustomInstructions": "تعليمات مخصصة",
   "aiCustomInstructionsPlaceholder": "مثل: تحدث بنبرة ساخرة",
   "aiCustomInstructionsHelper": "صِغ الاقتراحات بأسلوبك الخاص.",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -98,6 +98,7 @@
   "speechPreview": "Прослушване",
   "speechVoicePreview": "Здравей, това е моят глас!",
   "playbackHighlight": "Осветяване на думите по време на говорене",
+  "tileSaturation": "Интензивност на цвета",
   "aiCustomInstructions": "Персонализирани инструкции",
   "aiCustomInstructionsPlaceholder": "напр. говори със саркастичен тон",
   "aiCustomInstructionsHelper": "Оформете предложенията с ваши думи.",

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -98,6 +98,7 @@
   "speechPreview": "শুনুন",
   "speechVoicePreview": "হ্যালো, এটা আমার কণ্ঠস্বর!",
   "playbackHighlight": "কথা বলার সময় শব্দগুলি হাইলাইট করুন",
+  "tileSaturation": "রঙের তীব্রতা",
   "aiCustomInstructions": "কাস্টম নির্দেশনা",
   "aiCustomInstructionsPlaceholder": "যেমন, ব্যঙ্গাত্মক সুরে কথা বলুন",
   "aiCustomInstructionsHelper": "নিজের ভাষায় পরামর্শগুলো গঠন করুন।",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -98,6 +98,7 @@
   "speechPreview": "Poslechnout",
   "speechVoicePreview": "Ahoj, tohle je můj hlas!",
   "playbackHighlight": "Zvýraznit slova během mluvení",
+  "tileSaturation": "Intenzita barev",
   "aiCustomInstructions": "Vlastní pokyny",
   "aiCustomInstructionsPlaceholder": "např. mluv sarkastickým tónem",
   "aiCustomInstructionsHelper": "Formulujte návrhy vlastními slovy.",

--- a/messages/da.json
+++ b/messages/da.json
@@ -98,6 +98,7 @@
   "speechPreview": "Lyt",
   "speechVoicePreview": "Hej, det er min stemme!",
   "playbackHighlight": "Fremhæv ord under tale",
+  "tileSaturation": "Farveintensitet",
   "aiCustomInstructions": "Tilpassede instruktioner",
   "aiCustomInstructionsPlaceholder": "f.eks. tal i en sarkastisk tone",
   "aiCustomInstructionsHelper": "Form forslagene med dine egne ord.",

--- a/messages/de.json
+++ b/messages/de.json
@@ -98,6 +98,7 @@
   "speechPreview": "Anhören",
   "speechVoicePreview": "Hallo, das ist meine Stimme!",
   "playbackHighlight": "Wörter beim Sprechen hervorheben",
+  "tileSaturation": "Farbintensität",
   "aiCustomInstructions": "Benutzerdefinierte Anweisungen",
   "aiCustomInstructionsPlaceholder": "z. B. in sarkastischem Ton sprechen",
   "aiCustomInstructionsHelper": "Gestalte die Vorschläge mit deinen eigenen Worten.",

--- a/messages/el.json
+++ b/messages/el.json
@@ -98,6 +98,7 @@
   "speechPreview": "Ακρόαση",
   "speechVoicePreview": "Γεια, αυτή είναι η φωνή μου!",
   "playbackHighlight": "Επισήμανση λέξεων κατά την ομιλία",
+  "tileSaturation": "Ένταση χρώματος",
   "aiCustomInstructions": "Προσαρμοσμένες οδηγίες",
   "aiCustomInstructionsPlaceholder": "π.χ. μίλα με σαρκαστικό τόνο",
   "aiCustomInstructionsHelper": "Διαμορφώστε τις προτάσεις με τα δικά σας λόγια.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -98,6 +98,7 @@
   "speechPreview": "Preview",
   "speechVoicePreview": "Hi, this is my voice!",
   "playbackHighlight": "Highlight words while speaking",
+  "tileSaturation": "Color intensity",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g. speak in a sarcastic tone",
   "aiCustomInstructionsHelper": "Shape suggestions in your own words.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -98,6 +98,7 @@
   "speechPreview": "Escuchar",
   "speechVoicePreview": "¡Hola, esta es mi voz!",
   "playbackHighlight": "Resaltar palabras mientras se habla",
+  "tileSaturation": "Intensidad del color",
   "aiCustomInstructions": "Instrucciones personalizadas",
   "aiCustomInstructionsPlaceholder": "p. ej., habla con un tono sarcástico",
   "aiCustomInstructionsHelper": "Da forma a las sugerencias con tus propias palabras.",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -98,6 +98,7 @@
   "speechPreview": "Kuuntele",
   "speechVoicePreview": "Hei, tämä on minun ääneni!",
   "playbackHighlight": "Korosta sanat puheen aikana",
+  "tileSaturation": "Värien voimakkuus",
   "aiCustomInstructions": "Mukautetut ohjeet",
   "aiCustomInstructionsPlaceholder": "esim. puhu sarkastisella sävyllä",
   "aiCustomInstructionsHelper": "Muotoile ehdotukset omin sanoin.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -98,6 +98,7 @@
   "speechPreview": "Écouter",
   "speechVoicePreview": "Bonjour, voici ma voix !",
   "playbackHighlight": "Surligner les mots pendant la lecture à voix haute",
+  "tileSaturation": "Intensité des couleurs",
   "aiCustomInstructions": "Instructions personnalisées",
   "aiCustomInstructionsPlaceholder": "p. ex. parler sur un ton sarcastique",
   "aiCustomInstructionsHelper": "Façonnez les suggestions avec vos propres mots.",

--- a/messages/he.json
+++ b/messages/he.json
@@ -98,6 +98,7 @@
   "speechPreview": "השמעה",
   "speechVoicePreview": "שלום, זה הקול שלי!",
   "playbackHighlight": "הדגשת מילים בעת הדיבור",
+  "tileSaturation": "עוצמת הצבע",
   "aiCustomInstructions": "הוראות מותאמות אישית",
   "aiCustomInstructionsPlaceholder": "למשל: דבר בטון סרקסטי",
   "aiCustomInstructionsHelper": "עצבו את ההצעות במילים שלכם.",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -98,6 +98,7 @@
   "speechPreview": "सुनें",
   "speechVoicePreview": "नमस्ते, यह मेरी आवाज़ है!",
   "playbackHighlight": "बोलते समय शब्दों को हाइलाइट करें",
+  "tileSaturation": "रंग की तीव्रता",
   "aiCustomInstructions": "कस्टम निर्देश",
   "aiCustomInstructionsPlaceholder": "जैसे, व्यंग्यात्मक लहजे में बोलें",
   "aiCustomInstructionsHelper": "सुझावों को अपने शब्दों में ढालें।",

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -98,6 +98,7 @@
   "speechPreview": "Poslušaj",
   "speechVoicePreview": "Bok, ovo je moj glas!",
   "playbackHighlight": "Istakni riječi tijekom govora",
+  "tileSaturation": "Intenzitet boje",
   "aiCustomInstructions": "Prilagođene upute",
   "aiCustomInstructionsPlaceholder": "npr. govori sarkastičnim tonom",
   "aiCustomInstructionsHelper": "Oblikujte prijedloge svojim riječima.",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -98,6 +98,7 @@
   "speechPreview": "Meghallgatás",
   "speechVoicePreview": "Szia, ez az én hangom!",
   "playbackHighlight": "Szavak kiemelése beszéd közben",
+  "tileSaturation": "Színintenzitás",
   "aiCustomInstructions": "Egyéni utasítások",
   "aiCustomInstructionsPlaceholder": "pl. beszélj szarkasztikus hangnemben",
   "aiCustomInstructionsHelper": "Alakítsd a javaslatokat a saját szavaiddal.",

--- a/messages/id.json
+++ b/messages/id.json
@@ -98,6 +98,7 @@
   "speechPreview": "Dengarkan",
   "speechVoicePreview": "Hai, ini suara saya!",
   "playbackHighlight": "Sorot kata saat berbicara",
+  "tileSaturation": "Intensitas warna",
   "aiCustomInstructions": "Instruksi khusus",
   "aiCustomInstructionsPlaceholder": "mis. berbicara dengan nada sarkastis",
   "aiCustomInstructionsHelper": "Bentuk saran dengan kata-katamu sendiri.",

--- a/messages/it.json
+++ b/messages/it.json
@@ -98,6 +98,7 @@
   "speechPreview": "Ascolta",
   "speechVoicePreview": "Ciao, questa è la mia voce!",
   "playbackHighlight": "Evidenzia le parole durante il parlato",
+  "tileSaturation": "Intensità del colore",
   "aiCustomInstructions": "Istruzioni personalizzate",
   "aiCustomInstructionsPlaceholder": "ad es. parla con tono sarcastico",
   "aiCustomInstructionsHelper": "Modella i suggerimenti con le tue parole.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -98,6 +98,7 @@
   "speechPreview": "試聴",
   "speechVoicePreview": "こんにちは、これが私の声です！",
   "playbackHighlight": "発話中に単語をハイライト表示",
+  "tileSaturation": "色の濃さ",
   "aiCustomInstructions": "カスタム指示",
   "aiCustomInstructionsPlaceholder": "例：皮肉っぽい口調で話す",
   "aiCustomInstructionsHelper": "自分の言葉で提案を形づくりましょう。",

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -98,6 +98,7 @@
   "speechPreview": "ಕೇಳಿ",
   "speechVoicePreview": "ನಮಸ್ಕಾರ, ಇದು ನನ್ನ ಧ್ವನಿ!",
   "playbackHighlight": "ಮಾತನಾಡುವಾಗ ಪದಗಳನ್ನು ಹೈಲೈಟ್ ಮಾಡಿ",
+  "tileSaturation": "ಬಣ್ಣದ ತೀವ್ರತೆ",
   "aiCustomInstructions": "ಕಸ್ಟಮ್ ಸೂಚನೆಗಳು",
   "aiCustomInstructionsPlaceholder": "ಉದಾ., ವ್ಯಂಗ್ಯ ಧ್ವನಿಯಲ್ಲಿ ಮಾತನಾಡಿ",
   "aiCustomInstructionsHelper": "ನಿಮ್ಮ ಸ್ವಂತ ಮಾತುಗಳಲ್ಲಿ ಸಲಹೆಗಳನ್ನು ರೂಪಿಸಿ.",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -98,6 +98,7 @@
   "speechPreview": "미리 듣기",
   "speechVoicePreview": "안녕하세요, 제 목소리예요!",
   "playbackHighlight": "말할 때 단어 강조 표시",
+  "tileSaturation": "색상 강도",
   "aiCustomInstructions": "맞춤 지침",
   "aiCustomInstructionsPlaceholder": "예: 냉소적인 어조로 말하기",
   "aiCustomInstructionsHelper": "자신만의 언어로 제안을 다듬어 보세요.",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -98,6 +98,7 @@
   "speechPreview": "Beluisteren",
   "speechVoicePreview": "Hoi, dit is mijn stem!",
   "playbackHighlight": "Woorden markeren tijdens het spreken",
+  "tileSaturation": "Kleurintensiteit",
   "aiCustomInstructions": "Aangepaste instructies",
   "aiCustomInstructionsPlaceholder": "bijv. spreek op een sarcastische toon",
   "aiCustomInstructionsHelper": "Geef de suggesties vorm in je eigen woorden.",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -98,6 +98,7 @@
   "speechPreview": "Posłuchaj",
   "speechVoicePreview": "Cześć, to mój głos!",
   "playbackHighlight": "Podświetlaj słowa podczas mówienia",
+  "tileSaturation": "Intensywność kolorów",
   "aiCustomInstructions": "Instrukcje niestandardowe",
   "aiCustomInstructionsPlaceholder": "np. mów sarkastycznym tonem",
   "aiCustomInstructionsHelper": "Kształtuj sugestie własnymi słowami.",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -98,6 +98,7 @@
   "speechPreview": "Ouvir",
   "speechVoicePreview": "Olá, esta é a minha voz!",
   "playbackHighlight": "Destacar palavras durante a fala",
+  "tileSaturation": "Intensidade da cor",
   "aiCustomInstructions": "Instruções personalizadas",
   "aiCustomInstructionsPlaceholder": "ex.: fale com um tom sarcástico",
   "aiCustomInstructionsHelper": "Molde as sugestões com suas próprias palavras.",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -98,6 +98,7 @@
   "speechPreview": "Ascultă",
   "speechVoicePreview": "Bună, aceasta este vocea mea!",
   "playbackHighlight": "Evidențiază cuvintele în timpul vorbirii",
+  "tileSaturation": "Intensitatea culorii",
   "aiCustomInstructions": "Instrucțiuni personalizate",
   "aiCustomInstructionsPlaceholder": "ex. vorbește pe un ton sarcastic",
   "aiCustomInstructionsHelper": "Modelează sugestiile cu propriile tale cuvinte.",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -98,6 +98,7 @@
   "speechPreview": "Прослушать",
   "speechVoicePreview": "Привет, это мой голос!",
   "playbackHighlight": "Подсвечивать слова во время произношения",
+  "tileSaturation": "Насыщенность цвета",
   "aiCustomInstructions": "Пользовательские инструкции",
   "aiCustomInstructionsPlaceholder": "напр. говори саркастичным тоном",
   "aiCustomInstructionsHelper": "Формулируйте предложения своими словами.",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -98,6 +98,7 @@
   "speechPreview": "Vypočuť",
   "speechVoicePreview": "Ahoj, toto je môj hlas!",
   "playbackHighlight": "Zvýrazniť slová počas hovorenia",
+  "tileSaturation": "Intenzita farieb",
   "aiCustomInstructions": "Vlastné pokyny",
   "aiCustomInstructionsPlaceholder": "napr. hovor sarkastickým tónom",
   "aiCustomInstructionsHelper": "Formulujte návrhy vlastnými slovami.",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -98,6 +98,7 @@
   "speechPreview": "Poslušaj",
   "speechVoicePreview": "Živjo, to je moj glas!",
   "playbackHighlight": "Označi besede med govorjenjem",
+  "tileSaturation": "Intenzivnost barve",
   "aiCustomInstructions": "Navodila po meri",
   "aiCustomInstructionsPlaceholder": "npr. govori sarkastičnim tonom",
   "aiCustomInstructionsHelper": "Oblikujte predloge s svojimi besedami.",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -98,6 +98,7 @@
   "speechPreview": "Lyssna",
   "speechVoicePreview": "Hej, det här är min röst!",
   "playbackHighlight": "Markera ord medan de talas",
+  "tileSaturation": "Färgintensitet",
   "aiCustomInstructions": "Anpassade instruktioner",
   "aiCustomInstructionsPlaceholder": "t.ex. tala med sarkastisk ton",
   "aiCustomInstructionsHelper": "Forma förslagen med dina egna ord.",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -98,6 +98,7 @@
   "speechPreview": "கேள்",
   "speechVoicePreview": "வணக்கம், இது என் குரல்!",
   "playbackHighlight": "பேசும்போது சொற்களை தனிப்படுத்து",
+  "tileSaturation": "வண்ணத் தீவிரம்",
   "aiCustomInstructions": "தனிப்பயன் வழிமுறைகள்",
   "aiCustomInstructionsPlaceholder": "எ.கா., கிண்டலான தொனியில் பேசு",
   "aiCustomInstructionsHelper": "உங்கள் சொந்த வார்த்தைகளில் பரிந்துரைகளை வடிவமைக்கவும்.",

--- a/messages/te.json
+++ b/messages/te.json
@@ -98,6 +98,7 @@
   "speechPreview": "విను",
   "speechVoicePreview": "హాయ్, ఇది నా వాయిస్!",
   "playbackHighlight": "మాట్లాడేటప్పుడు పదాలను హైలైట్ చేయి",
+  "tileSaturation": "రంగు తీవ్రత",
   "aiCustomInstructions": "అనుకూల సూచనలు",
   "aiCustomInstructionsPlaceholder": "ఉదా., వ్యంగ్యమైన స్వరంతో మాట్లాడు",
   "aiCustomInstructionsHelper": "మీ సొంత మాటల్లో సూచనలను రూపొందించండి.",

--- a/messages/th.json
+++ b/messages/th.json
@@ -98,6 +98,7 @@
   "speechPreview": "ฟัง",
   "speechVoicePreview": "สวัสดี นี่คือเสียงของฉัน!",
   "playbackHighlight": "ไฮไลต์คำขณะพูด",
+  "tileSaturation": "ความเข้มของสี",
   "aiCustomInstructions": "คำสั่งที่กำหนดเอง",
   "aiCustomInstructionsPlaceholder": "เช่น พูดด้วยน้ำเสียงประชดประชัน",
   "aiCustomInstructionsHelper": "ปรับคำแนะนำให้เป็นสำนวนของคุณเอง",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -98,6 +98,7 @@
   "speechPreview": "Dinle",
   "speechVoicePreview": "Merhaba, bu benim sesim!",
   "playbackHighlight": "Konuşurken kelimeleri vurgula",
+  "tileSaturation": "Renk yoğunluğu",
   "aiCustomInstructions": "Özel talimatlar",
   "aiCustomInstructionsPlaceholder": "ör. alaycı bir tonda konuş",
   "aiCustomInstructionsHelper": "Önerileri kendi kelimelerinizle şekillendirin.",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -98,6 +98,7 @@
   "speechPreview": "Прослухати",
   "speechVoicePreview": "Привіт, це мій голос!",
   "playbackHighlight": "Підсвічувати слова під час озвучення",
+  "tileSaturation": "Насиченість кольору",
   "aiCustomInstructions": "Власні інструкції",
   "aiCustomInstructionsPlaceholder": "напр. говори саркастичним тоном",
   "aiCustomInstructionsHelper": "Формулюйте пропозиції власними словами.",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -98,6 +98,7 @@
   "speechPreview": "Nghe thử",
   "speechVoicePreview": "Xin chào, đây là giọng nói của tôi!",
   "playbackHighlight": "Đánh dấu từ khi nói",
+  "tileSaturation": "Cường độ màu",
   "aiCustomInstructions": "Hướng dẫn tùy chỉnh",
   "aiCustomInstructionsPlaceholder": "ví dụ: nói với giọng điệu châm biếm",
   "aiCustomInstructionsHelper": "Định hình gợi ý theo cách nói của riêng bạn.",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -98,6 +98,7 @@
   "speechPreview": "试听",
   "speechVoicePreview": "你好，这是我的声音！",
   "playbackHighlight": "说话时高亮显示单词",
+  "tileSaturation": "颜色强度",
   "aiCustomInstructions": "自定义指令",
   "aiCustomInstructionsPlaceholder": "例如：以讽刺的语气说话",
   "aiCustomInstructionsHelper": "用你自己的话塑造建议。",

--- a/src/app/settings/appearance-settings.tsx
+++ b/src/app/settings/appearance-settings.tsx
@@ -25,6 +25,7 @@ export function AppearanceSettings() {
         aria-labelledby="theme-toggle"
         name="theme-toggle"
         value={mode}
+        row={true}
         onChange={(event) =>
           setMode(event.target.value as "system" | "light" | "dark")
         }

--- a/src/app/settings/board-settings.test.tsx
+++ b/src/app/settings/board-settings.test.tsx
@@ -1,10 +1,15 @@
 import { AppProviders } from "@shared/providers/app-providers";
 import { expectNoA11yViolations } from "@shared/testing/axe";
-import { describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { userEvent } from "vitest/browser";
 import { render } from "vitest-browser-react";
 import { BoardSettings } from "./board-settings";
 
 describe("BoardSettings", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   test("toggles the highlight-while-speaking switch with no a11y violations", async () => {
     const screen = await render(
       <AppProviders>
@@ -20,6 +25,40 @@ describe("BoardSettings", () => {
     await highlightSwitch.click();
     await expect.element(highlightSwitch).toBeChecked();
 
+    const saturationSlider = screen.getByRole("slider", {
+      name: "Color intensity",
+    });
+
+    await expect.element(saturationSlider).toBeVisible();
+    expect(saturationSlider.element().getAttribute("aria-valuenow")).toBe("1");
+
     await expectNoA11yViolations(screen.container);
+  });
+
+  test("lowering the color-intensity slider persists the saturation setting", async () => {
+    const screen = await render(
+      <AppProviders>
+        <BoardSettings />
+      </AppProviders>,
+    );
+
+    const saturationSlider = screen.getByRole("slider", {
+      name: "Color intensity",
+    });
+
+    saturationSlider.element().focus();
+    await userEvent.keyboard("{ArrowLeft}");
+
+    const valueNow = Number(
+      saturationSlider.element().getAttribute("aria-valuenow"),
+    );
+    expect(valueNow).toBeLessThan(1);
+
+    await vi.waitFor(() => {
+      const stored = localStorage.getItem("tile-color-config");
+      expect(stored).not.toBeNull();
+      const config = JSON.parse(stored ?? "{}") as { saturation: number };
+      expect(config.saturation).toBe(valueNow);
+    });
   });
 });

--- a/src/app/settings/board-settings.tsx
+++ b/src/app/settings/board-settings.tsx
@@ -1,23 +1,50 @@
 import FormControlLabel from "@mui/material/FormControlLabel";
+import Slider from "@mui/material/Slider";
+import Stack from "@mui/material/Stack";
 import Switch from "@mui/material/Switch";
+import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
 import {
   setHighlightActivePart,
   useHighlightConfig,
 } from "@shared/highlight/highlight-store";
+import {
+  setTileSaturation,
+  TILE_SATURATION,
+  useTileColorConfig,
+} from "@shared/tile-color/tile-color-store";
 
 export function BoardSettings() {
   const { highlightActivePart } = useHighlightConfig();
+  const { saturation } = useTileColorConfig();
 
   return (
-    <FormControlLabel
-      label={m.playbackHighlight()}
-      control={
-        <Switch
-          checked={highlightActivePart}
-          onChange={(event) => setHighlightActivePart(event.target.checked)}
+    <Stack spacing={3}>
+      <FormControlLabel
+        label={m.playbackHighlight()}
+        control={
+          <Switch
+            checked={highlightActivePart}
+            onChange={(event) => setHighlightActivePart(event.target.checked)}
+          />
+        }
+      />
+
+      <Stack spacing={0.5}>
+        <Typography variant="body2" sx={{ color: "text.secondary" }}>
+          {m.tileSaturation()}
+        </Typography>
+        <Slider
+          aria-label={m.tileSaturation()}
+          valueLabelDisplay="auto"
+          valueLabelFormat={(value) => `${Math.round(value * 100)}%`}
+          value={saturation}
+          min={TILE_SATURATION.min}
+          max={TILE_SATURATION.max}
+          step={0.05}
+          onChange={(_event, newValue) => setTileSaturation(newValue)}
         />
-      }
-    />
+      </Stack>
+    </Stack>
   );
 }

--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -6,6 +6,7 @@ import { m } from "@paraglide/messages.js";
 import { useHighlightConfig } from "@shared/highlight/highlight-store";
 import { useLanguage } from "@shared/language/use-language";
 import { safeAreaInset } from "@shared/theme/safe-area";
+import { useTileColorConfig } from "@shared/tile-color/tile-color-store";
 import { createButtonActivation } from "./activation/button-activation";
 import { getNavigationTargetId } from "./button-readers";
 import { Grid, type GridItemProps } from "./grid/grid";
@@ -42,6 +43,7 @@ export function BoardViewer({ board }: BoardViewerProps) {
   const { direction } = useLanguage();
   const isSmallScreen = useMediaQuery((theme) => theme.breakpoints.down("sm"));
   const { highlightActivePart } = useHighlightConfig();
+  const { saturation } = useTileColorConfig();
   const message = useMessage();
   const playback = useMessagePlayback();
   const suggestions = useSuggestions(message.text);
@@ -69,7 +71,11 @@ export function BoardViewer({ board }: BoardViewerProps) {
   );
 
   return (
-    <Stack {...keyboard.rootProps} direction="column" sx={rootSx}>
+    <Stack
+      {...keyboard.rootProps}
+      direction="column"
+      sx={[rootSx, { "--tile-saturation": String(saturation) }]}
+    >
       <MessageBar
         parts={message.parts}
         activePartId={highlightActivePart ? playback.activePartId : null}

--- a/src/features/board/tile/tile.test.tsx
+++ b/src/features/board/tile/tile.test.tsx
@@ -1,7 +1,20 @@
+import type { CSSProperties } from "react";
 import { describe, expect, test, vi } from "vitest";
 import { render } from "vitest-browser-react";
 import { TEST_IMAGE_SRC } from "../testing";
 import { Tile } from "./tile";
+
+// Colors are rendered through oklch(from ...), so the browser serializes computed
+// values as oklch(...)/color(...) rather than rgb(...). Ask the browser for the
+// canonical serialization of the expected color instead of hardcoding a format.
+function resolveColor(cssColor: string): string {
+  const probe = document.createElement("div");
+  document.body.append(probe);
+  probe.style.color = cssColor;
+  const resolved = getComputedStyle(probe).color;
+  probe.remove();
+  return resolved;
+}
 
 describe("Tile", () => {
   test("renders label without image when imageSrc is not provided", async () => {
@@ -51,7 +64,9 @@ describe("Tile", () => {
     const button = screen.getByRole("button", { name: "Colored" });
     const styles = getComputedStyle(button.element());
 
-    expect(["rgb(0, 0, 0)", "oklab(0 0 0)"]).toContain(styles.backgroundColor);
+    expect(styles.backgroundColor).toBe(
+      resolveColor("oklch(from #000000 l c h)"),
+    );
     expect(styles.color).toBe("rgb(255, 255, 255)");
   });
 
@@ -63,7 +78,7 @@ describe("Tile", () => {
     const button = screen.getByRole("button", { name: "Bordered" });
     const styles = getComputedStyle(button.element());
 
-    expect(styles.borderColor).toBe("rgb(0, 255, 0)");
+    expect(styles.borderColor).toBe(resolveColor("oklch(from #00ff00 l c h)"));
   });
 
   test("defaults borderColor to backgroundColor when borderColor is omitted", async () => {
@@ -74,7 +89,23 @@ describe("Tile", () => {
     const button = screen.getByRole("button", { name: "Match" });
     const styles = getComputedStyle(button.element());
 
-    expect(styles.borderColor).toBe("rgb(255, 0, 0)");
+    expect(styles.borderColor).toBe(resolveColor("oklch(from #ff0000 l c h)"));
+  });
+
+  test("desaturates the background when --tile-saturation is set", async () => {
+    const screen = await render(
+      <div style={{ "--tile-saturation": 0 } as CSSProperties}>
+        <Tile label="Muted" backgroundColor="#ff0000" onClick={vi.fn()} />
+      </div>,
+    );
+
+    const button = screen.getByRole("button", { name: "Muted" });
+    const styles = getComputedStyle(button.element());
+
+    // chroma × 0 → achromatic gray at the original lightness
+    expect(styles.backgroundColor).toBe(
+      resolveColor("oklch(from #ff0000 l 0 h)"),
+    );
   });
 
   test("calls onClick when clicked", async () => {

--- a/src/features/board/tile/tile.tsx
+++ b/src/features/board/tile/tile.tsx
@@ -13,6 +13,13 @@ export interface TileProps {
   onClick: () => void;
 }
 
+// Scale an author-supplied color's OKLCH chroma by the board's saturation
+// setting so bright third-party boards can be toned down without shifting hue
+// or perceived lightness. The var fallback keeps colors intact outside BoardViewer.
+function desaturate(color: string): string {
+  return `oklch(from ${color} l calc(c * var(--tile-saturation, 1)) h)`;
+}
+
 export function Tile({
   label,
   imageSrc,
@@ -23,6 +30,8 @@ export function Tile({
   tabIndex,
   onClick,
 }: TileProps) {
+  const resolvedBorderColor = borderColor ?? backgroundColor;
+
   return (
     <Button
       tabIndex={tabIndex}
@@ -36,15 +45,15 @@ export function Tile({
         alignItems: "stretch",
         justifyContent: "stretch",
         p: 1,
-        border: `4px solid ${borderColor ?? backgroundColor ?? "transparent"}`,
+        border: `4px solid ${resolvedBorderColor ? desaturate(resolvedBorderColor) : "transparent"}`,
         borderRadius: 4,
         overflow: "hidden",
         position: "relative",
         textTransform: "none",
         color: backgroundColor
-          ? `contrast-color(${backgroundColor})`
+          ? `contrast-color(${desaturate(backgroundColor)})`
           : "inherit",
-        backgroundColor,
+        backgroundColor: backgroundColor && desaturate(backgroundColor),
         transition: theme.transitions.create("filter", {
           duration: theme.transitions.duration.short,
         }),
@@ -68,7 +77,7 @@ export function Tile({
             insetInlineEnd: -2,
             width: 0,
             height: 0,
-            borderInlineEnd: `32px solid ${borderColor ?? "#000"}`,
+            borderInlineEnd: `32px solid ${borderColor ? desaturate(borderColor) : "#000"}`,
             borderBottom: "32px solid transparent",
           },
         }),

--- a/src/shared/tile-color/tile-color-store.test.ts
+++ b/src/shared/tile-color/tile-color-store.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { renderHook } from "vitest-browser-react";
+import {
+  parseTileColorConfig,
+  setTileSaturation,
+  useTileColorConfig,
+} from "./tile-color-store";
+
+describe("tile-color-store", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe("parseTileColorConfig", () => {
+    test("defaults saturation to 1 when absent", () => {
+      expect(parseTileColorConfig(undefined).saturation).toBe(1);
+    });
+
+    test("ignores a non-number stored value", () => {
+      expect(parseTileColorConfig({ saturation: "high" }).saturation).toBe(1);
+    });
+
+    test("ignores a non-finite stored value", () => {
+      expect(parseTileColorConfig({ saturation: NaN }).saturation).toBe(1);
+    });
+
+    test("clamps a value below the minimum", () => {
+      expect(parseTileColorConfig({ saturation: -0.5 }).saturation).toBe(0);
+    });
+
+    test("clamps a value above the maximum", () => {
+      expect(parseTileColorConfig({ saturation: 5 }).saturation).toBe(1);
+    });
+
+    test("keeps an in-range stored value", () => {
+      expect(parseTileColorConfig({ saturation: 0.4 }).saturation).toBe(0.4);
+    });
+  });
+
+  test("setTileSaturation updates the snapshot and persists it", async () => {
+    const { result, rerender } = await renderHook(() => useTileColorConfig());
+
+    setTileSaturation(0.4);
+    await rerender();
+
+    expect(result.current.saturation).toBe(0.4);
+    await vi.waitFor(() =>
+      expect(localStorage.getItem("tile-color-config")).toBe(
+        JSON.stringify({ saturation: 0.4 }),
+      ),
+    );
+  });
+});

--- a/src/shared/tile-color/tile-color-store.ts
+++ b/src/shared/tile-color/tile-color-store.ts
@@ -1,0 +1,37 @@
+import { createPersistedStore } from "@shared/utils/persisted-store";
+import { useSyncExternalStore } from "react";
+
+export interface TileColorConfig {
+  saturation: number;
+}
+
+export const TILE_SATURATION = { min: 0, max: 1, fallback: 1 };
+
+export function parseTileColorConfig(raw: unknown): TileColorConfig {
+  const parsed = (raw ?? {}) as Record<string, unknown>;
+  const { min, max, fallback } = TILE_SATURATION;
+
+  return {
+    saturation:
+      typeof parsed.saturation === "number" &&
+      Number.isFinite(parsed.saturation)
+        ? Math.min(Math.max(parsed.saturation, min), max)
+        : fallback,
+  };
+}
+
+const tileColorStore = createPersistedStore<TileColorConfig>(
+  "tile-color-config",
+  parseTileColorConfig,
+);
+
+export function setTileSaturation(saturation: number): void {
+  tileColorStore.setState({ ...tileColorStore.getSnapshot(), saturation });
+}
+
+export function useTileColorConfig(): TileColorConfig {
+  return useSyncExternalStore(
+    tileColorStore.subscribe,
+    tileColorStore.getSnapshot,
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a persisted "Color intensity" slider to Settings → Board that scales the OKLCH chroma of tile background/border colors, so bright third-party OBF/OBZ boards can be toned down without affecting pictogram images.
- Driven by a single `--tile-saturation` CSS variable set on the board root; `Tile` wraps each author color in `oklch(from <color> l calc(c * var) h)` with a fallback of `1`.
- New persisted store at `src/shared/tile-color/tile-color-store.ts` (mirrors the existing highlight/speech stores).
- Adds the `tileSaturation` message key to `en.json` and all 34 sibling locales.

## Test plan
- [x] `npm run lint`
- [x] `npm test` (511 passed)
- [x] `npm run build`
- [ ] Manual: `npm run dev`, open a board with colored tiles, Settings → Board → drag "Color intensity" down, confirm live preview and persistence across reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)