### PR TITLE
Add tile border visibility toggle setting

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "مرحبًا، هذا هو صوتي!",
   "playbackHighlight": "تمييز الكلمات أثناء التحدث",
   "tileSaturation": "شدة الألوان",
+  "tileBorders": "إظهار حدود الرموز",
   "aiCustomInstructions": "تعليمات مخصصة",
   "aiCustomInstructionsPlaceholder": "مثل: تحدث بنبرة ساخرة",
   "aiCustomInstructionsHelper": "صِغ الاقتراحات بأسلوبك الخاص.",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "Здравей, това е моят глас!",
   "playbackHighlight": "Осветяване на думите по време на говорене",
   "tileSaturation": "Интензивност на цвета",
+  "tileBorders": "Показване на рамки на плочките",
   "aiCustomInstructions": "Персонализирани инструкции",
   "aiCustomInstructionsPlaceholder": "напр. говори със саркастичен тон",
   "aiCustomInstructionsHelper": "Оформете предложенията с ваши думи.",

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "হ্যালো, এটা আমার কণ্ঠস্বর!",
   "playbackHighlight": "কথা বলার সময় শব্দগুলি হাইলাইট করুন",
   "tileSaturation": "রঙের তীব্রতা",
+  "tileBorders": "টাইলের সীমানা দেখান",
   "aiCustomInstructions": "কাস্টম নির্দেশনা",
   "aiCustomInstructionsPlaceholder": "যেমন, ব্যঙ্গাত্মক সুরে কথা বলুন",
   "aiCustomInstructionsHelper": "নিজের ভাষায় পরামর্শগুলো গঠন করুন।",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "Ahoj, tohle je můj hlas!",
   "playbackHighlight": "Zvýraznit slova během mluvení",
   "tileSaturation": "Intenzita barev",
+  "tileBorders": "Zobrazit ohraničení dlaždic",
   "aiCustomInstructions": "Vlastní pokyny",
   "aiCustomInstructionsPlaceholder": "např. mluv sarkastickým tónem",
   "aiCustomInstructionsHelper": "Formulujte návrhy vlastními slovy.",

--- a/messages/da.json
+++ b/messages/da.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "Hej, det er min stemme!",
   "playbackHighlight": "Fremhæv ord under tale",
   "tileSaturation": "Farveintensitet",
+  "tileBorders": "Vis kant på felter",
   "aiCustomInstructions": "Tilpassede instruktioner",
   "aiCustomInstructionsPlaceholder": "f.eks. tal i en sarkastisk tone",
   "aiCustomInstructionsHelper": "Form forslagene med dine egne ord.",

--- a/messages/de.json
+++ b/messages/de.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "Hallo, das ist meine Stimme!",
   "playbackHighlight": "Wörter beim Sprechen hervorheben",
   "tileSaturation": "Farbintensität",
+  "tileBorders": "Kachel-Rahmen anzeigen",
   "aiCustomInstructions": "Benutzerdefinierte Anweisungen",
   "aiCustomInstructionsPlaceholder": "z. B. in sarkastischem Ton sprechen",
   "aiCustomInstructionsHelper": "Gestalte die Vorschläge mit deinen eigenen Worten.",

--- a/messages/el.json
+++ b/messages/el.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "Γεια, αυτή είναι η φωνή μου!",
   "playbackHighlight": "Επισήμανση λέξεων κατά την ομιλία",
   "tileSaturation": "Ένταση χρώματος",
+  "tileBorders": "Εμφάνιση περιγράμματος πλακιδίων",
   "aiCustomInstructions": "Προσαρμοσμένες οδηγίες",
   "aiCustomInstructionsPlaceholder": "π.χ. μίλα με σαρκαστικό τόνο",
   "aiCustomInstructionsHelper": "Διαμορφώστε τις προτάσεις με τα δικά σας λόγια.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "Hi, this is my voice!",
   "playbackHighlight": "Highlight words while speaking",
   "tileSaturation": "Color intensity",
+  "tileBorders": "Show tile borders",
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g. speak in a sarcastic tone",
   "aiCustomInstructionsHelper": "Shape suggestions in your own words.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "¡Hola, esta es mi voz!",
   "playbackHighlight": "Resaltar palabras mientras se habla",
   "tileSaturation": "Intensidad del color",
+  "tileBorders": "Mostrar bordes de las casillas",
   "aiCustomInstructions": "Instrucciones personalizadas",
   "aiCustomInstructionsPlaceholder": "p. ej., habla con un tono sarcástico",
   "aiCustomInstructionsHelper": "Da forma a las sugerencias con tus propias palabras.",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "Hei, tämä on minun ääneni!",
   "playbackHighlight": "Korosta sanat puheen aikana",
   "tileSaturation": "Värien voimakkuus",
+  "tileBorders": "Näytä ruutujen reunat",
   "aiCustomInstructions": "Mukautetut ohjeet",
   "aiCustomInstructionsPlaceholder": "esim. puhu sarkastisella sävyllä",
   "aiCustomInstructionsHelper": "Muotoile ehdotukset omin sanoin.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "Bonjour, voici ma voix !",
   "playbackHighlight": "Surligner les mots pendant la lecture à voix haute",
   "tileSaturation": "Intensité des couleurs",
+  "tileBorders": "Afficher les bordures des cases",
   "aiCustomInstructions": "Instructions personnalisées",
   "aiCustomInstructionsPlaceholder": "p. ex. parler sur un ton sarcastique",
   "aiCustomInstructionsHelper": "Façonnez les suggestions avec vos propres mots.",

--- a/messages/he.json
+++ b/messages/he.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "שלום, זה הקול שלי!",
   "playbackHighlight": "הדגשת מילים בעת הדיבור",
   "tileSaturation": "עוצמת הצבע",
+  "tileBorders": "הצגת מסגרות למשבצות",
   "aiCustomInstructions": "הוראות מותאמות אישית",
   "aiCustomInstructionsPlaceholder": "למשל: דבר בטון סרקסטי",
   "aiCustomInstructionsHelper": "עצבו את ההצעות במילים שלכם.",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "नमस्ते, यह मेरी आवाज़ है!",
   "playbackHighlight": "बोलते समय शब्दों को हाइलाइट करें",
   "tileSaturation": "रंग की तीव्रता",
+  "tileBorders": "टाइल की सीमाएँ दिखाएं",
   "aiCustomInstructions": "कस्टम निर्देश",
   "aiCustomInstructionsPlaceholder": "जैसे, व्यंग्यात्मक लहजे में बोलें",
   "aiCustomInstructionsHelper": "सुझावों को अपने शब्दों में ढालें।",

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "Bok, ovo je moj glas!",
   "playbackHighlight": "Istakni riječi tijekom govora",
   "tileSaturation": "Intenzitet boje",
+  "tileBorders": "Prikaži obrube pločica",
   "aiCustomInstructions": "Prilagođene upute",
   "aiCustomInstructionsPlaceholder": "npr. govori sarkastičnim tonom",
   "aiCustomInstructionsHelper": "Oblikujte prijedloge svojim riječima.",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "Szia, ez az én hangom!",
   "playbackHighlight": "Szavak kiemelése beszéd közben",
   "tileSaturation": "Színintenzitás",
+  "tileBorders": "Csempék szegélyének megjelenítése",
   "aiCustomInstructions": "Egyéni utasítások",
   "aiCustomInstructionsPlaceholder": "pl. beszélj szarkasztikus hangnemben",
   "aiCustomInstructionsHelper": "Alakítsd a javaslatokat a saját szavaiddal.",

--- a/messages/id.json
+++ b/messages/id.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "Hai, ini suara saya!",
   "playbackHighlight": "Sorot kata saat berbicara",
   "tileSaturation": "Intensitas warna",
+  "tileBorders": "Tampilkan batas petak",
   "aiCustomInstructions": "Instruksi khusus",
   "aiCustomInstructionsPlaceholder": "mis. berbicara dengan nada sarkastis",
   "aiCustomInstructionsHelper": "Bentuk saran dengan kata-katamu sendiri.",

--- a/messages/it.json
+++ b/messages/it.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "Ciao, questa è la mia voce!",
   "playbackHighlight": "Evidenzia le parole durante il parlato",
   "tileSaturation": "Intensità del colore",
+  "tileBorders": "Mostra i bordi delle caselle",
   "aiCustomInstructions": "Istruzioni personalizzate",
   "aiCustomInstructionsPlaceholder": "ad es. parla con tono sarcastico",
   "aiCustomInstructionsHelper": "Modella i suggerimenti con le tue parole.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "こんにちは、これが私の声です！",
   "playbackHighlight": "発話中に単語をハイライト表示",
   "tileSaturation": "色の濃さ",
+  "tileBorders": "タイルの枠線を表示",
   "aiCustomInstructions": "カスタム指示",
   "aiCustomInstructionsPlaceholder": "例：皮肉っぽい口調で話す",
   "aiCustomInstructionsHelper": "自分の言葉で提案を形づくりましょう。",

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "ನಮಸ್ಕಾರ, ಇದು ನನ್ನ ಧ್ವನಿ!",
   "playbackHighlight": "ಮಾತನಾಡುವಾಗ ಪದಗಳನ್ನು ಹೈಲೈಟ್ ಮಾಡಿ",
   "tileSaturation": "ಬಣ್ಣದ ತೀವ್ರತೆ",
+  "tileBorders": "ಟೈಲ್ ಗಡಿಗಳನ್ನು ತೋರಿಸಿ",
   "aiCustomInstructions": "ಕಸ್ಟಮ್ ಸೂಚನೆಗಳು",
   "aiCustomInstructionsPlaceholder": "ಉದಾ., ವ್ಯಂಗ್ಯ ಧ್ವನಿಯಲ್ಲಿ ಮಾತನಾಡಿ",
   "aiCustomInstructionsHelper": "ನಿಮ್ಮ ಸ್ವಂತ ಮಾತುಗಳಲ್ಲಿ ಸಲಹೆಗಳನ್ನು ರೂಪಿಸಿ.",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "안녕하세요, 제 목소리예요!",
   "playbackHighlight": "말할 때 단어 강조 표시",
   "tileSaturation": "색상 강도",
+  "tileBorders": "타일 테두리 표시",
   "aiCustomInstructions": "맞춤 지침",
   "aiCustomInstructionsPlaceholder": "예: 냉소적인 어조로 말하기",
   "aiCustomInstructionsHelper": "자신만의 언어로 제안을 다듬어 보세요.",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "Hoi, dit is mijn stem!",
   "playbackHighlight": "Woorden markeren tijdens het spreken",
   "tileSaturation": "Kleurintensiteit",
+  "tileBorders": "Tegelranden weergeven",
   "aiCustomInstructions": "Aangepaste instructies",
   "aiCustomInstructionsPlaceholder": "bijv. spreek op een sarcastische toon",
   "aiCustomInstructionsHelper": "Geef de suggesties vorm in je eigen woorden.",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "Cześć, to mój głos!",
   "playbackHighlight": "Podświetlaj słowa podczas mówienia",
   "tileSaturation": "Intensywność kolorów",
+  "tileBorders": "Pokaż obramowania kafelków",
   "aiCustomInstructions": "Instrukcje niestandardowe",
   "aiCustomInstructionsPlaceholder": "np. mów sarkastycznym tonem",
   "aiCustomInstructionsHelper": "Kształtuj sugestie własnymi słowami.",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "Olá, esta é a minha voz!",
   "playbackHighlight": "Destacar palavras durante a fala",
   "tileSaturation": "Intensidade da cor",
+  "tileBorders": "Mostrar contornos dos blocos",
   "aiCustomInstructions": "Instruções personalizadas",
   "aiCustomInstructionsPlaceholder": "ex.: fale com um tom sarcástico",
   "aiCustomInstructionsHelper": "Molde as sugestões com suas próprias palavras.",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "Bună, aceasta este vocea mea!",
   "playbackHighlight": "Evidențiază cuvintele în timpul vorbirii",
   "tileSaturation": "Intensitatea culorii",
+  "tileBorders": "Afișează marginile casetelor",
   "aiCustomInstructions": "Instrucțiuni personalizate",
   "aiCustomInstructionsPlaceholder": "ex. vorbește pe un ton sarcastic",
   "aiCustomInstructionsHelper": "Modelează sugestiile cu propriile tale cuvinte.",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "Привет, это мой голос!",
   "playbackHighlight": "Подсвечивать слова во время произношения",
   "tileSaturation": "Насыщенность цвета",
+  "tileBorders": "Показывать границы плиток",
   "aiCustomInstructions": "Пользовательские инструкции",
   "aiCustomInstructionsPlaceholder": "напр. говори саркастичным тоном",
   "aiCustomInstructionsHelper": "Формулируйте предложения своими словами.",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "Ahoj, toto je môj hlas!",
   "playbackHighlight": "Zvýrazniť slová počas hovorenia",
   "tileSaturation": "Intenzita farieb",
+  "tileBorders": "Zobraziť okraje dlaždíc",
   "aiCustomInstructions": "Vlastné pokyny",
   "aiCustomInstructionsPlaceholder": "napr. hovor sarkastickým tónom",
   "aiCustomInstructionsHelper": "Formulujte návrhy vlastnými slovami.",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "Živjo, to je moj glas!",
   "playbackHighlight": "Označi besede med govorjenjem",
   "tileSaturation": "Intenzivnost barve",
+  "tileBorders": "Prikaži obrobe ploščic",
   "aiCustomInstructions": "Navodila po meri",
   "aiCustomInstructionsPlaceholder": "npr. govori sarkastičnim tonom",
   "aiCustomInstructionsHelper": "Oblikujte predloge s svojimi besedami.",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "Hej, det här är min röst!",
   "playbackHighlight": "Markera ord medan de talas",
   "tileSaturation": "Färgintensitet",
+  "tileBorders": "Visa kantlinjer på rutor",
   "aiCustomInstructions": "Anpassade instruktioner",
   "aiCustomInstructionsPlaceholder": "t.ex. tala med sarkastisk ton",
   "aiCustomInstructionsHelper": "Forma förslagen med dina egna ord.",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "வணக்கம், இது என் குரல்!",
   "playbackHighlight": "பேசும்போது சொற்களை தனிப்படுத்து",
   "tileSaturation": "வண்ணத் தீவிரம்",
+  "tileBorders": "டைல் எல்லைகளைக் காட்டு",
   "aiCustomInstructions": "தனிப்பயன் வழிமுறைகள்",
   "aiCustomInstructionsPlaceholder": "எ.கா., கிண்டலான தொனியில் பேசு",
   "aiCustomInstructionsHelper": "உங்கள் சொந்த வார்த்தைகளில் பரிந்துரைகளை வடிவமைக்கவும்.",

--- a/messages/te.json
+++ b/messages/te.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "హాయ్, ఇది నా వాయిస్!",
   "playbackHighlight": "మాట్లాడేటప్పుడు పదాలను హైలైట్ చేయి",
   "tileSaturation": "రంగు తీవ్రత",
+  "tileBorders": "టైల్ సరిహద్దులను చూపించు",
   "aiCustomInstructions": "అనుకూల సూచనలు",
   "aiCustomInstructionsPlaceholder": "ఉదా., వ్యంగ్యమైన స్వరంతో మాట్లాడు",
   "aiCustomInstructionsHelper": "మీ సొంత మాటల్లో సూచనలను రూపొందించండి.",

--- a/messages/th.json
+++ b/messages/th.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "สวัสดี นี่คือเสียงของฉัน!",
   "playbackHighlight": "ไฮไลต์คำขณะพูด",
   "tileSaturation": "ความเข้มของสี",
+  "tileBorders": "แสดงขอบไทล์",
   "aiCustomInstructions": "คำสั่งที่กำหนดเอง",
   "aiCustomInstructionsPlaceholder": "เช่น พูดด้วยน้ำเสียงประชดประชัน",
   "aiCustomInstructionsHelper": "ปรับคำแนะนำให้เป็นสำนวนของคุณเอง",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "Merhaba, bu benim sesim!",
   "playbackHighlight": "Konuşurken kelimeleri vurgula",
   "tileSaturation": "Renk yoğunluğu",
+  "tileBorders": "Kare kenarlıklarını göster",
   "aiCustomInstructions": "Özel talimatlar",
   "aiCustomInstructionsPlaceholder": "ör. alaycı bir tonda konuş",
   "aiCustomInstructionsHelper": "Önerileri kendi kelimelerinizle şekillendirin.",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "Привіт, це мій голос!",
   "playbackHighlight": "Підсвічувати слова під час озвучення",
   "tileSaturation": "Насиченість кольору",
+  "tileBorders": "Показувати межі плиток",
   "aiCustomInstructions": "Власні інструкції",
   "aiCustomInstructionsPlaceholder": "напр. говори саркастичним тоном",
   "aiCustomInstructionsHelper": "Формулюйте пропозиції власними словами.",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "Xin chào, đây là giọng nói của tôi!",
   "playbackHighlight": "Đánh dấu từ khi nói",
   "tileSaturation": "Cường độ màu",
+  "tileBorders": "Hiển thị viền ô",
   "aiCustomInstructions": "Hướng dẫn tùy chỉnh",
   "aiCustomInstructionsPlaceholder": "ví dụ: nói với giọng điệu châm biếm",
   "aiCustomInstructionsHelper": "Định hình gợi ý theo cách nói của riêng bạn.",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -99,6 +99,7 @@
   "speechVoicePreview": "你好，这是我的声音！",
   "playbackHighlight": "说话时高亮显示单词",
   "tileSaturation": "颜色强度",
+  "tileBorders": "显示图块边框",
   "aiCustomInstructions": "自定义指令",
   "aiCustomInstructionsPlaceholder": "例如：以讽刺的语气说话",
   "aiCustomInstructionsHelper": "用你自己的话塑造建议。",

--- a/src/app/settings/board-settings.test.tsx
+++ b/src/app/settings/board-settings.test.tsx
@@ -32,7 +32,38 @@ describe("BoardSettings", () => {
     await expect.element(saturationSlider).toBeVisible();
     expect(saturationSlider.element().getAttribute("aria-valuenow")).toBe("1");
 
+    const bordersSwitch = screen.getByRole("switch", {
+      name: "Show tile borders",
+    });
+
+    await expect.element(bordersSwitch).toBeChecked();
+
     await expectNoA11yViolations(screen.container);
+  });
+
+  test("toggling the tile-borders switch persists the borderVisible setting", async () => {
+    const screen = await render(
+      <AppProviders>
+        <BoardSettings />
+      </AppProviders>,
+    );
+
+    const bordersSwitch = screen.getByRole("switch", {
+      name: "Show tile borders",
+    });
+
+    await expect.element(bordersSwitch).toBeChecked();
+    await bordersSwitch.click();
+    await expect.element(bordersSwitch).not.toBeChecked();
+
+    await vi.waitFor(() => {
+      const stored = localStorage.getItem("tile-color-config");
+      expect(stored).not.toBeNull();
+      const config = JSON.parse(stored ?? "{}") as {
+        borderVisible: boolean;
+      };
+      expect(config.borderVisible).toBe(false);
+    });
   });
 
   test("lowering the color-intensity slider persists the saturation setting", async () => {

--- a/src/app/settings/board-settings.tsx
+++ b/src/app/settings/board-settings.tsx
@@ -9,6 +9,7 @@ import {
   useHighlightConfig,
 } from "@shared/highlight/highlight-store";
 import {
+  setTileBorderVisible,
   setTileSaturation,
   TILE_SATURATION,
   useTileColorConfig,
@@ -16,7 +17,7 @@ import {
 
 export function BoardSettings() {
   const { highlightActivePart } = useHighlightConfig();
-  const { saturation } = useTileColorConfig();
+  const { saturation, borderVisible } = useTileColorConfig();
 
   return (
     <Stack spacing={3}>
@@ -26,6 +27,16 @@ export function BoardSettings() {
           <Switch
             checked={highlightActivePart}
             onChange={(event) => setHighlightActivePart(event.target.checked)}
+          />
+        }
+      />
+
+      <FormControlLabel
+        label={m.tileBorders()}
+        control={
+          <Switch
+            checked={borderVisible}
+            onChange={(event) => setTileBorderVisible(event.target.checked)}
           />
         }
       />

--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -43,7 +43,7 @@ export function BoardViewer({ board }: BoardViewerProps) {
   const { direction } = useLanguage();
   const isSmallScreen = useMediaQuery((theme) => theme.breakpoints.down("sm"));
   const { highlightActivePart } = useHighlightConfig();
-  const { saturation } = useTileColorConfig();
+  const { saturation, borderVisible } = useTileColorConfig();
   const message = useMessage();
   const playback = useMessagePlayback();
   const suggestions = useSuggestions(message.text);
@@ -65,6 +65,7 @@ export function BoardViewer({ board }: BoardViewerProps) {
       backgroundColor={button.backgroundColor}
       borderColor={button.borderColor}
       variant={getNavigationTargetId(button) ? "folder" : undefined}
+      borderHidden={!borderVisible}
       onClick={() => activateButton(button)}
       {...props}
     />

--- a/src/features/board/tile/tile.test.tsx
+++ b/src/features/board/tile/tile.test.tsx
@@ -108,6 +108,44 @@ describe("Tile", () => {
     );
   });
 
+  test("borderHidden renders a transparent border but keeps its width", async () => {
+    const screen = await render(
+      <Tile
+        label="Borderless"
+        backgroundColor="#ff0000"
+        borderColor="#00ff00"
+        borderHidden
+        onClick={vi.fn()}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Borderless" });
+    const styles = getComputedStyle(button.element());
+
+    expect(styles.borderColor).toBe("rgba(0, 0, 0, 0)");
+    expect(styles.borderTopWidth).toBe("4px");
+    expect(styles.backgroundColor).toBe(
+      resolveColor("oklch(from #ff0000 l c h)"),
+    );
+  });
+
+  test("borderHidden keeps the folder corner visible", async () => {
+    const screen = await render(
+      <Tile
+        label="Folder"
+        variant="folder"
+        borderColor="#000000"
+        borderHidden
+        onClick={vi.fn()}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Folder" });
+    const afterStyles = getComputedStyle(button.element(), "::after");
+
+    expect(afterStyles.display).toBe("block");
+  });
+
   test("calls onClick when clicked", async () => {
     const onClick = vi.fn();
 

--- a/src/features/board/tile/tile.tsx
+++ b/src/features/board/tile/tile.tsx
@@ -9,6 +9,7 @@ export interface TileProps {
   borderColor?: string;
   disabled?: boolean;
   variant?: "folder";
+  borderHidden?: boolean;
   tabIndex?: number;
   onClick: () => void;
 }
@@ -27,6 +28,7 @@ export function Tile({
   borderColor,
   disabled,
   variant,
+  borderHidden,
   tabIndex,
   onClick,
 }: TileProps) {
@@ -45,7 +47,11 @@ export function Tile({
         alignItems: "stretch",
         justifyContent: "stretch",
         p: 1,
-        border: `4px solid ${resolvedBorderColor ? desaturate(resolvedBorderColor) : "transparent"}`,
+        border: `4px solid ${
+          !borderHidden && resolvedBorderColor
+            ? desaturate(resolvedBorderColor)
+            : "transparent"
+        }`,
         borderRadius: 4,
         overflow: "hidden",
         position: "relative",

--- a/src/shared/tile-color/tile-color-store.test.ts
+++ b/src/shared/tile-color/tile-color-store.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { renderHook } from "vitest-browser-react";
 import {
   parseTileColorConfig,
+  setTileBorderVisible,
   setTileSaturation,
   useTileColorConfig,
 } from "./tile-color-store";
@@ -35,6 +36,29 @@ describe("tile-color-store", () => {
     test("keeps an in-range stored value", () => {
       expect(parseTileColorConfig({ saturation: 0.4 }).saturation).toBe(0.4);
     });
+
+    test("defaults borderVisible to true when absent", () => {
+      expect(parseTileColorConfig(undefined).borderVisible).toBe(true);
+    });
+
+    test("ignores a non-boolean stored borderVisible value", () => {
+      expect(parseTileColorConfig({ borderVisible: "no" }).borderVisible).toBe(
+        true,
+      );
+      expect(parseTileColorConfig({ borderVisible: 0 }).borderVisible).toBe(
+        true,
+      );
+    });
+
+    test("keeps a stored borderVisible value of false", () => {
+      expect(parseTileColorConfig({ borderVisible: false }).borderVisible).toBe(
+        false,
+      );
+    });
+
+    test("keeps other fields when only borderVisible is stored", () => {
+      expect(parseTileColorConfig({ borderVisible: false }).saturation).toBe(1);
+    });
   });
 
   test("setTileSaturation updates the snapshot and persists it", async () => {
@@ -46,7 +70,21 @@ describe("tile-color-store", () => {
     expect(result.current.saturation).toBe(0.4);
     await vi.waitFor(() =>
       expect(localStorage.getItem("tile-color-config")).toBe(
-        JSON.stringify({ saturation: 0.4 }),
+        JSON.stringify({ saturation: 0.4, borderVisible: true }),
+      ),
+    );
+  });
+
+  test("setTileBorderVisible updates the snapshot and persists it", async () => {
+    const { result, rerender } = await renderHook(() => useTileColorConfig());
+
+    setTileBorderVisible(false);
+    await rerender();
+
+    expect(result.current.borderVisible).toBe(false);
+    await vi.waitFor(() =>
+      expect(localStorage.getItem("tile-color-config")).toBe(
+        JSON.stringify({ saturation: 1, borderVisible: false }),
       ),
     );
   });

--- a/src/shared/tile-color/tile-color-store.ts
+++ b/src/shared/tile-color/tile-color-store.ts
@@ -3,6 +3,7 @@ import { useSyncExternalStore } from "react";
 
 export interface TileColorConfig {
   saturation: number;
+  borderVisible: boolean;
 }
 
 export const TILE_SATURATION = { min: 0, max: 1, fallback: 1 };
@@ -17,6 +18,8 @@ export function parseTileColorConfig(raw: unknown): TileColorConfig {
       Number.isFinite(parsed.saturation)
         ? Math.min(Math.max(parsed.saturation, min), max)
         : fallback,
+    borderVisible:
+      typeof parsed.borderVisible === "boolean" ? parsed.borderVisible : true,
   };
 }
 
@@ -27,6 +30,13 @@ const tileColorStore = createPersistedStore<TileColorConfig>(
 
 export function setTileSaturation(saturation: number): void {
   tileColorStore.setState({ ...tileColorStore.getSnapshot(), saturation });
+}
+
+export function setTileBorderVisible(borderVisible: boolean): void {
+  tileColorStore.setState({
+    ...tileColorStore.getSnapshot(),
+    borderVisible,
+  });
 }
 
 export function useTileColorConfig(): TileColorConfig {


### PR DESCRIPTION
## Summary
- Add a switch in board settings to hide tile borders entirely
- Persist the new `borderVisible` flag in the tile color store alongside saturation

## Test plan
- [x] Unit tests for `tile-color-store`, `tile`, and `board-settings`