### PR TITLE
style: widen mobile gutters and add global MUI button padding

### DIFF
--- a/src/app/layouts/app-header.tsx
+++ b/src/app/layouts/app-header.tsx
@@ -32,8 +32,8 @@ export function AppHeader({
           gridTemplateColumns: "1fr minmax(0, auto) 1fr",
           alignItems: "center",
           gap: theme.spacing(2),
-          pl: safeAreaGutter(theme.spacing(2), "left"),
-          pr: safeAreaGutter(theme.spacing(2), "right"),
+          pl: safeAreaGutter(theme.spacing(3), "left"),
+          pr: safeAreaGutter(theme.spacing(3), "right"),
           [theme.breakpoints.up("sm")]: {
             pl: safeAreaGutter(theme.spacing(3), "left"),
             pr: safeAreaGutter(theme.spacing(3), "right"),

--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -125,6 +125,7 @@ export function BoardViewer({ board }: BoardViewerProps) {
           sx={{
             justifyContent: "space-between",
             gap: 2,
+            px: { xs: 3 },
             pb: safeAreaInset("bottom"),
           }}
         >

--- a/src/shared/theme/theme-provider.tsx
+++ b/src/shared/theme/theme-provider.tsx
@@ -110,7 +110,9 @@ function getThemeOptions(reducedMotion: boolean) {
       MuiButton: {
         styleOverrides: {
           root: {
-            borderRadius: 24,
+            borderRadius: 25,
+            paddingTop: 13,
+            paddingBottom: 13,
           },
         },
       },


### PR DESCRIPTION
## Summary
- Widen the mobile safe-area gutter for the app header (spacing(2) → spacing(3)) so it matches the sm+ breakpoint
- Add horizontal padding to the board viewer's bottom bar on mobile
- Increase MUI button border radius slightly and add vertical padding globally for a larger tap target

## Test plan
- [ ] Visually check app header and board viewer on a narrow/mobile viewport
- [ ] Confirm buttons across the app still look correct with the new padding/radius