### PR TITLE
style: increase border radius across inputs, buttons, and surfaces

### DIFF
--- a/src/features/board/import/board-file-drop-overlay.tsx
+++ b/src/features/board/import/board-file-drop-overlay.tsx
@@ -32,7 +32,7 @@ export function BoardFileDropOverlay({ open }: BoardFileDropOverlayProps) {
             gap: 2,
             px: 6,
             py: 5,
-            borderRadius: 2,
+            borderRadius: 4,
             border: `2px dashed ${theme.palette.primary.main}`,
           })}
         >

--- a/src/features/board/message/message-bar.tsx
+++ b/src/features/board/message/message-bar.tsx
@@ -52,7 +52,7 @@ export function MessageBar({
           {
             flexGrow: 1,
             gap: 2,
-            borderRadius: 16,
+            borderRadius: 32,
             overflow: "hidden",
             bgcolor: "grey.200",
           },

--- a/src/features/board/navigation/board-switcher.tsx
+++ b/src/features/board/navigation/board-switcher.tsx
@@ -42,6 +42,10 @@ export function BoardSwitcher() {
           onFocus={() => setInputValue("")}
           slotProps={{
             ...params.slotProps,
+            input: {
+              ...params.slotProps?.input,
+              sx: { height: 50, borderRadius: 7 },
+            },
             htmlInput: {
               ...params.slotProps?.htmlInput,
               "aria-label": m.board(),

--- a/src/shared/theme/theme-provider.tsx
+++ b/src/shared/theme/theme-provider.tsx
@@ -110,7 +110,7 @@ function getThemeOptions(reducedMotion: boolean) {
       MuiButton: {
         styleOverrides: {
           root: {
-            borderRadius: 25,
+            borderRadius: 32,
             paddingTop: 13,
             paddingBottom: 13,
           },
@@ -134,14 +134,14 @@ function getThemeOptions(reducedMotion: boolean) {
       MuiOutlinedInput: {
         styleOverrides: {
           root: {
-            borderRadius: 24,
+            borderRadius: 32,
           },
         },
       },
       MuiListItemButton: {
         styleOverrides: {
           root: {
-            borderRadius: 24,
+            borderRadius: 32,
           },
         },
       },


### PR DESCRIPTION
## Summary
- Bump border-radius across the app for a rounder, more consistent look
- Inputs (`MuiOutlinedInput`), buttons (`MuiButton`), and list item buttons now use `borderRadius: 32` in the theme
- Message bar and file-drop overlay radii bumped to match
- Board switcher input gets an explicit height (50) and rounded corners

🤖 Generated with [Claude Code](https://claude.com/claude-code)