### PR TITLE
fix: sanitize imported board colors against CSS injection

### DIFF
--- a/src/features/board/obf/obf-to-board.test.ts
+++ b/src/features/board/obf/obf-to-board.test.ts
@@ -176,6 +176,32 @@ describe("obfToBoard", () => {
       });
     });
 
+    test("drops a CSS-unsafe button color", () => {
+      const obfBoard: OBFBoard = {
+        format: "open-board-0.1",
+        id: "board-unsafe-color",
+        buttons: [
+          {
+            id: "btn-1",
+            label: "hi",
+            background_color:
+              "x); } a { background-image: url(https://evil.example) }",
+            border_color: "rgb(0, 0, 0)",
+          },
+        ],
+        grid: {
+          rows: 1,
+          columns: 1,
+          order: [["btn-1"]],
+        },
+      };
+
+      const board = obfToBoard(obfBoard);
+
+      expect(board.buttons[0]?.backgroundColor).toBeUndefined();
+      expect(board.buttons[0]?.borderColor).toBe("rgb(0, 0, 0)");
+    });
+
     test("maps load_board to camelCased loadBoard", () => {
       const obfBoard: OBFBoard = {
         format: "open-board-0.1",

--- a/src/features/board/obf/obf-to-board.ts
+++ b/src/features/board/obf/obf-to-board.ts
@@ -1,3 +1,4 @@
+import { sanitizeColor } from "@shared/utils/css-color";
 import { normalizeLocale } from "@shared/utils/locale";
 import type {
   OBFBoard,
@@ -70,8 +71,8 @@ function transformButton(
     id: obfButton.id,
     label: obfButton.label,
     vocalization: obfButton.vocalization,
-    backgroundColor: obfButton.background_color,
-    borderColor: obfButton.border_color,
+    backgroundColor: sanitizeColor(obfButton.background_color),
+    borderColor: sanitizeColor(obfButton.border_color),
     imageSrc: obfButton.image_id
       ? imageSourceById.get(obfButton.image_id)
       : undefined,

--- a/src/shared/utils/css-color.test.ts
+++ b/src/shared/utils/css-color.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeColor } from "./css-color";
+
+describe("sanitizeColor", () => {
+  it.each([
+    "#ff0000",
+    "rgb(0 0 0)",
+    "rgba(0, 0, 0, 0.5)",
+    "red",
+    "oklch(0.7 0.1 200)",
+    "transparent",
+  ])("passes through valid color %s", (color) => {
+    expect(sanitizeColor(color)).toBe(color);
+  });
+
+  it("rejects a CSS breakout payload", () => {
+    expect(
+      sanitizeColor("x); } a { background-image: url(https://evil.example) }"),
+    ).toBeUndefined();
+  });
+
+  it.each(["", "not-a-color", "red; background: url(x)"])(
+    "rejects invalid value %s",
+    (color) => {
+      expect(sanitizeColor(color)).toBeUndefined();
+    },
+  );
+
+  it("returns undefined for undefined input", () => {
+    expect(sanitizeColor(undefined)).toBeUndefined();
+  });
+});

--- a/src/shared/utils/css-color.ts
+++ b/src/shared/utils/css-color.ts
@@ -1,0 +1,13 @@
+/**
+ * Returns the color only if the browser parses it as a valid CSS <color>,
+ * otherwise undefined. Guards against untrusted values that get interpolated
+ * into CSS declarations: validating with the browser's own parser rejects
+ * breakout payloads like "x); } a { background-image: url(...) }".
+ */
+export function sanitizeColor(color: string | undefined): string | undefined {
+  if (color === undefined) {
+    return undefined;
+  }
+
+  return CSS.supports("color", color) ? color : undefined;
+}


### PR DESCRIPTION
## Summary

Author-supplied `background_color` / `border_color` from imported OBF boards are interpolated into CSS declarations (via Tile's `desaturate`), so a crafted value like `x); } a { background-image: url(https://evil.example) }` could break out of the declaration and inject a global rule that fires an external request.

This validates each color with the browser's own CSS parser (`CSS.supports`) at the point where OBF becomes the app's domain model, dropping anything that isn't a valid `<color>`. No Tile change needed — it already handles a valid color or `undefined`.

## Changes
- `src/shared/utils/css-color.ts` — new `sanitizeColor()` guard.
- `src/features/board/obf/obf-to-board.ts` — run button colors through `sanitizeColor` in `transformButton`.
- Tests for the sanitizer and an OBF-boundary case asserting an unsafe color is dropped.

## Verification
`npm test -- css-color obf-to-board` (30 passed), `npm run lint`, `npm run build` all pass. Tests run in real Chromium where `CSS.supports` exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)