### PR TITLE
style: move nav buttons into board action row

### DIFF
--- a/src/app/layouts/app-header.tsx
+++ b/src/app/layouts/app-header.tsx
@@ -1,4 +1,4 @@
-import { BoardSwitcher, NavButtons } from "@features/board";
+import { BoardSwitcher } from "@features/board";
 import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
 import ViewSidebarOutlinedIcon from "@mui/icons-material/ViewSidebarOutlined";
 import AppBar from "@mui/material/AppBar";
@@ -6,7 +6,6 @@ import Box from "@mui/material/Box";
 import IconButton from "@mui/material/IconButton";
 import Toolbar from "@mui/material/Toolbar";
 import Tooltip from "@mui/material/Tooltip";
-import useMediaQuery from "@mui/material/useMediaQuery";
 import { m } from "@paraglide/messages.js";
 import { flipForLtr } from "@shared/theme/rtl";
 import { safeAreaGutter } from "@shared/theme/safe-area";
@@ -22,8 +21,6 @@ export function AppHeader({
   onLibraryClick,
   onSettingsClick,
 }: AppHeaderProps) {
-  const isSmallScreen = useMediaQuery((theme) => theme.breakpoints.down("sm"));
-
   return (
     <AppBar position="static">
       <Toolbar
@@ -61,8 +58,6 @@ export function AppHeader({
               </IconButton>
             </Tooltip>
           )}
-
-          {!isSmallScreen && <NavButtons />}
         </Box>
 
         <Box sx={{ minWidth: 0 }}>

--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -91,6 +91,8 @@ export function BoardViewer({ board }: BoardViewerProps) {
         spacing={2}
         sx={{ justifyContent: "flex-end", px: { xs: 2, sm: 3 } }}
       >
+        {!isSmallScreen && <NavButtons />}
+
         {suggestions.isSupported && (
           <SuggestionBar
             status={suggestions.status}

--- a/src/features/board/message/backspace-button.tsx
+++ b/src/features/board/message/backspace-button.tsx
@@ -33,7 +33,7 @@ export function BackspaceButton({
       color="inherit"
       disabled={disabled}
       variant="contained"
-      sx={{ width: 104, borderRadius: 4 }}
+      sx={{ width: 104 }}
     >
       <BackspaceOutlinedIcon sx={flipForRtl} />
     </Button>

--- a/src/features/board/navigation/nav-buttons.tsx
+++ b/src/features/board/navigation/nav-buttons.tsx
@@ -1,8 +1,7 @@
 import ArrowBackOutlinedIcon from "@mui/icons-material/ArrowBackOutlined";
 import HomeOutlinedIcon from "@mui/icons-material/HomeOutlined";
 import Box from "@mui/material/Box";
-import IconButton from "@mui/material/IconButton";
-import Tooltip from "@mui/material/Tooltip";
+import Button from "@mui/material/Button";
 import { m } from "@paraglide/messages.js";
 import { flipForRtl } from "@shared/theme/rtl";
 import { useBoardNavigation } from "./use-board-navigation";
@@ -16,33 +15,29 @@ export function NavButtons() {
 
   return (
     <Box sx={{ display: "flex", gap: 1 }}>
-      <Tooltip title={m.navBack()}>
-        <span>
-          <IconButton
-            aria-label={m.navBack()}
-            size="large"
-            color="inherit"
-            disabled={!canGoBack}
-            onClick={goBack}
-          >
-            <ArrowBackOutlinedIcon sx={flipForRtl} />
-          </IconButton>
-        </span>
-      </Tooltip>
+      <Button
+        aria-label={m.navBack()}
+        size="large"
+        color="inherit"
+        disabled={!canGoBack}
+        variant="contained"
+        sx={{ width: 104 }}
+        onClick={goBack}
+      >
+        <ArrowBackOutlinedIcon sx={flipForRtl} />
+      </Button>
 
-      <Tooltip title={m.navHome()}>
-        <span>
-          <IconButton
-            aria-label={m.navHome()}
-            size="large"
-            color="inherit"
-            disabled={!canGoHome}
-            onClick={goHome}
-          >
-            <HomeOutlinedIcon />
-          </IconButton>
-        </span>
-      </Tooltip>
+      <Button
+        aria-label={m.navHome()}
+        size="large"
+        color="inherit"
+        disabled={!canGoHome}
+        variant="contained"
+        sx={{ width: 104 }}
+        onClick={goHome}
+      >
+        <HomeOutlinedIcon />
+      </Button>
     </Box>
   );
 }

--- a/src/features/board/suggestions/suggestion-bar.tsx
+++ b/src/features/board/suggestions/suggestion-bar.tsx
@@ -31,6 +31,8 @@ export function SuggestionBar({
         overflow: "hidden",
       }}
     >
+      {(status === null || isPending) && <PendingDot show={isPending} />}
+
       <SuggestionStatus status={status} onEnable={onEnable} />
 
       <Box
@@ -51,8 +53,6 @@ export function SuggestionBar({
           />
         ))}
       </Box>
-
-      {(status === null || isPending) && <PendingDot show={isPending} />}
     </Stack>
   );
 }


### PR DESCRIPTION
## Summary
- Relocate the back/home nav buttons from the app header into the board viewer's action row (still hidden on small screens)
- Restyle nav buttons from `IconButton`+`Tooltip` to contained `Button`s matching the backspace button (fixed width 104)
- Move the suggestion pending dot to the start of the suggestion bar
- Drop the now-unused `borderRadius: 4` override on the backspace button

## Test plan
- [ ] Nav buttons appear in the board action row on non-small screens and navigate back/home correctly
- [ ] Suggestion bar renders the pending dot in its new position

🤖 Generated with [Claude Code](https://claude.com/claude-code)