### PR TITLE
style: narrow nav and backspace buttons to 96px

### DIFF
--- a/src/features/board/message/backspace-button.tsx
+++ b/src/features/board/message/backspace-button.tsx
@@ -33,7 +33,7 @@ export function BackspaceButton({
       color="inherit"
       disabled={disabled}
       variant="contained"
-      sx={{ width: 104 }}
+      sx={{ width: 96 }}
     >
       <BackspaceOutlinedIcon sx={flipForRtl} />
     </Button>

--- a/src/features/board/navigation/nav-buttons.tsx
+++ b/src/features/board/navigation/nav-buttons.tsx
@@ -21,7 +21,7 @@ export function NavButtons() {
         color="inherit"
         disabled={!canGoBack}
         variant="contained"
-        sx={{ width: 104 }}
+        sx={{ width: 96 }}
         onClick={goBack}
       >
         <ArrowBackOutlinedIcon sx={flipForRtl} />
@@ -33,7 +33,7 @@ export function NavButtons() {
         color="inherit"
         disabled={!canGoHome}
         variant="contained"
-        sx={{ width: 104 }}
+        sx={{ width: 96 }}
         onClick={goHome}
       >
         <HomeOutlinedIcon />


### PR DESCRIPTION
## Summary
- Narrow the nav (back/home) and backspace buttons from a fixed width of 104px to 96px

🤖 Generated with [Claude Code](https://claude.com/claude-code)