### PR TITLE
fix: flatten action scanning targets

### DIFF
--- a/src/features/board/board-scanning-ids.ts
+++ b/src/features/board/board-scanning-ids.ts
@@ -1,4 +1,3 @@
-export const ACTIONS_SCAN_ID = "board-actions";
 export const BACK_SCAN_ID = "board-navigation-back";
 export const BACKSPACE_SCAN_ID = "board-message-backspace";
 export const HOME_SCAN_ID = "board-navigation-home";

--- a/src/features/board/board-scanning.tsx
+++ b/src/features/board/board-scanning.tsx
@@ -3,7 +3,6 @@ import { m } from "@paraglide/messages.js";
 import { useScanGroup, useScanTarget } from "@shayc/switch-scanning/react";
 import { getNavigationTargetId } from "./button-readers";
 import {
-  ACTIONS_SCAN_ID,
   getTileScanId,
   getRowScanId,
   getSuggestionScanId,
@@ -87,7 +86,6 @@ export function ScannableSuggestion({
 }: ScannableSuggestionProps) {
   const scanTarget = useScanTarget({
     id: getSuggestionScanId(boardId, phrase),
-    parentId: ACTIONS_SCAN_ID,
     label: phrase,
   });
 

--- a/src/features/board/board-viewer.test.tsx
+++ b/src/features/board/board-viewer.test.tsx
@@ -143,7 +143,7 @@ describe("BoardViewer", () => {
     });
   });
 
-  test("scans navigation and backspace inside the actions group", async () => {
+  test("scans navigation and backspace as top-level targets", async () => {
     await seedBoardSets([{ setId: "set-1", rootBoardId: "root-board" }]);
     setSwitchScanningEnabled(true);
     setSwitchScanningMethod("step");
@@ -162,21 +162,18 @@ describe("BoardViewer", () => {
     await screen.getByRole("button", { name: "hello" }).click();
     await expect.element(backspace).toBeEnabled();
 
-    const actionsGroup = getScanGroup(back.element());
+    expect(back.element().closest("[data-scan-group]")).toBeNull();
+    expect(home.element().closest("[data-scan-group]")).toBeNull();
+    expect(backspace.element().closest("[data-scan-group]")).toBeNull();
 
     await userEvent.keyboard("{Space}");
     await expect.element(play).toHaveAttribute("data-scan-highlighted");
 
     await userEvent.keyboard("{Space}");
-    if (!actionsGroup.hasAttribute("data-scan-highlighted")) {
-      // On small screens the actions toolbar follows the grid visually.
+    if (!back.element().hasAttribute("data-scan-highlighted")) {
+      // On small screens the tile grid precedes the actions toolbar.
       await userEvent.keyboard("{Space}");
     }
-    await vi.waitFor(() => {
-      expect(actionsGroup.hasAttribute("data-scan-highlighted")).toBe(true);
-    });
-
-    await userEvent.keyboard("{Enter}");
     await expect.element(back).toHaveAttribute("data-scan-highlighted");
 
     await userEvent.keyboard("{Space}");
@@ -186,7 +183,7 @@ describe("BoardViewer", () => {
     await expect.element(backspace).toHaveAttribute("data-scan-highlighted");
   });
 
-  test("scans generated suggestions inside the actions group", async () => {
+  test("scans generated suggestions as top-level targets", async () => {
     stubProofreader(() => makeProofreadResult("Corrected hello"));
     stubBuiltInAIUnsupported("Rewriter");
     setSwitchScanningEnabled(true);
@@ -201,17 +198,11 @@ describe("BoardViewer", () => {
     });
     await expect.element(suggestion).toBeVisible();
 
-    const actionsGroup = getScanGroup(suggestion.element());
+    expect(suggestion.element().closest("[data-scan-group]")).toBeNull();
 
     await userEvent.keyboard("{Space}");
     await userEvent.keyboard("{Space}");
-    await vi.waitFor(() => {
-      expect(actionsGroup.hasAttribute("data-scan-highlighted")).toBe(true);
-    });
-
-    await userEvent.keyboard("{Enter}");
     await expect.element(suggestion).toHaveAttribute("data-scan-highlighted");
-    expect(actionsGroup.hasAttribute("data-scan-within")).toBe(true);
   });
 
   test("shows the active row and tile clearly in light and dark themes", async () => {
@@ -291,14 +282,9 @@ describe("BoardViewer", () => {
 
     await expect.element(enableSuggestions).toBeVisible();
 
-    const actionsGroup = getScanGroup(enableSuggestions.element());
+    expect(enableSuggestions.element().closest("[data-scan-group]")).toBeNull();
 
     await userEvent.keyboard("{Space}");
-    await vi.waitFor(() => {
-      expect(actionsGroup.hasAttribute("data-scan-highlighted")).toBe(true);
-    });
-
-    await userEvent.keyboard("{Enter}");
     await expect
       .element(enableSuggestions)
       .toHaveAttribute("data-scan-highlighted");
@@ -329,13 +315,4 @@ describe("BoardViewer", () => {
 function setThemeMode(mode: "light" | "dark"): void {
   document.documentElement.classList.remove("light", "dark");
   document.documentElement.classList.add(mode);
-}
-
-function getScanGroup(element: Element): HTMLElement {
-  const group = element.closest<HTMLElement>("[data-scan-group]");
-  if (!group) {
-    throw new Error("Expected control to be inside a scan group");
-  }
-
-  return group;
 }

--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -73,22 +73,17 @@ function BoardViewerContent({ board }: BoardViewerProps) {
   const keyboard = useBoardKeyboard({ message, playback });
   const hasMessage = message.parts.length > 0;
   const scanning = useBoardScanning({
-    boardId: board.id,
     hasMessage,
     isPlaying: playback.isPlaying,
     navigation: {
-      isInBoardSet: navigation.setId !== undefined,
       canGoBack: navigation.canGoBack,
       canGoHome: navigation.canGoHome,
       isHome: navigation.isHome,
     },
     suggestions: {
-      isSupported: suggestions.isSupported,
       needsActivation: suggestions.status?.kind === "needs-activation",
-      phrases: suggestions.phrases,
     },
   });
-  const isActionsGroupOnTop = !isSmallScreen || suggestions.isSupported;
 
   const renderTile = (button: BoardButton, props: GridItemProps) => (
     <ScannableTile
@@ -138,7 +133,6 @@ function BoardViewerContent({ board }: BoardViewerProps) {
       />
 
       <Stack
-        {...(isActionsGroupOnTop ? scanning.actionsGroup : {})}
         direction="row"
         spacing={2}
         sx={{ justifyContent: "flex-end", px: { xs: 2, sm: 3 } }}
@@ -188,7 +182,6 @@ function BoardViewerContent({ board }: BoardViewerProps) {
 
       {isSmallScreen && (
         <Toolbar
-          {...(!isActionsGroupOnTop ? scanning.actionsGroup : {})}
           sx={{
             justifyContent: "space-between",
             gap: 2,

--- a/src/features/board/use-board-scanning.ts
+++ b/src/features/board/use-board-scanning.ts
@@ -1,34 +1,26 @@
 import { m } from "@paraglide/messages.js";
 import {
-  type ScanGroupProps,
   type ScanTargetProps,
-  useScanGroup,
   useScanTarget,
 } from "@shayc/switch-scanning/react";
 import {
-  ACTIONS_SCAN_ID,
   BACK_SCAN_ID,
   BACKSPACE_SCAN_ID,
-  getSuggestionScanId,
   HOME_SCAN_ID,
   PLAY_SCAN_ID,
   SUGGESTIONS_ENABLE_SCAN_ID,
 } from "./board-scanning-ids";
 
 export interface UseBoardScanningOptions {
-  boardId: string;
   hasMessage: boolean;
   isPlaying: boolean;
   navigation: {
-    isInBoardSet: boolean;
     canGoBack: boolean;
     canGoHome: boolean;
     isHome: boolean;
   };
   suggestions: {
-    isSupported: boolean;
     needsActivation: boolean;
-    phrases: readonly string[];
   };
 }
 
@@ -38,11 +30,9 @@ export interface UseBoardScanningReturn {
   homeTarget: ScanTargetProps;
   suggestionsEnableTarget: ScanTargetProps;
   backspaceTarget: ScanTargetProps;
-  actionsGroup: ScanGroupProps;
 }
 
 export function useBoardScanning({
-  boardId,
   hasMessage,
   isPlaying,
   navigation,
@@ -56,50 +46,26 @@ export function useBoardScanning({
 
   const backTarget = useScanTarget({
     id: BACK_SCAN_ID,
-    parentId: ACTIONS_SCAN_ID,
     label: m.navBack(),
     disabled: !navigation.canGoBack,
   });
 
   const homeTarget = useScanTarget({
     id: HOME_SCAN_ID,
-    parentId: ACTIONS_SCAN_ID,
     label: m.navHome(),
     disabled: !navigation.canGoHome || navigation.isHome,
   });
 
   const suggestionsEnableTarget = useScanTarget({
     id: SUGGESTIONS_ENABLE_SCAN_ID,
-    parentId: ACTIONS_SCAN_ID,
     label: m.suggestionsEnable(),
     disabled: !suggestions.needsActivation,
   });
 
   const backspaceTarget = useScanTarget({
     id: BACKSPACE_SCAN_ID,
-    parentId: ACTIONS_SCAN_ID,
     label: m.messageBackspace(),
     disabled: !hasMessage,
-  });
-
-  const suggestionScanIds = suggestions.isSupported
-    ? suggestions.phrases.map((phrase) =>
-      getSuggestionScanId(boardId, phrase),
-    )
-    : [];
-
-  const actionSequence = [
-    ...(navigation.isInBoardSet ? [BACK_SCAN_ID, HOME_SCAN_ID] : []),
-    ...(suggestions.needsActivation ? [SUGGESTIONS_ENABLE_SCAN_ID] : []),
-    ...suggestionScanIds,
-    BACKSPACE_SCAN_ID,
-  ];
-
-  const actionsGroup = useScanGroup({
-    id: ACTIONS_SCAN_ID,
-    label: m.switchScanningActions(),
-    exitLabel: m.switchScanningActionsExit(),
-    sequence: actionSequence,
   });
 
   return {
@@ -108,6 +74,5 @@ export function useBoardScanning({
     homeTarget,
     suggestionsEnableTarget,
     backspaceTarget,
-    actionsGroup,
   };
 }


### PR DESCRIPTION
## What changed

- remove the shared row-style scan group around navigation, suggestions, and backspace
- register those controls as direct top-level scan targets in their existing visual order
- retain row scanning for communication-board tile rows
- update BoardViewer scanning tests for direct action-target traversal

## Why

The navigation and suggestion bars required an extra group-selection step before their individual controls could be scanned. That row-scanning behavior added unnecessary interaction cost outside the tile grid.

## Impact

Switch users can move directly through navigation, suggestions, suggestion activation, and backspace. Tile-grid row scanning remains unchanged.

## Validation

- `npm run lint`
- `npm test` — 570 passed, 7 skipped
- `npm run build`
