### PR TITLE
Fix board control alignment

### DIFF
--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -135,27 +135,29 @@ function BoardViewerContent({ board }: BoardViewerProps) {
       <Stack
         direction="row"
         spacing={2}
-        sx={{ justifyContent: "flex-end", px: { xs: 2, sm: 3 } }}
+        sx={{ justifyContent: "space-between", px: { xs: 2, sm: 3 } }}
       >
-        {!isSmallScreen && (
-          <NavButtons
-            slotProps={{
-              backButton: scanning.backTarget,
-              homeButton: scanning.homeTarget,
-            }}
-          />
-        )}
+        <div>
+          {!isSmallScreen && (
+            <NavButtons
+              slotProps={{
+                backButton: scanning.backTarget,
+                homeButton: scanning.homeTarget,
+              }}
+            />
+          )}
 
-        {suggestions.isSupported && (
-          <SuggestionBar
-            status={suggestions.status}
-            phrases={suggestions.phrases}
-            slotProps={{ enableButton: scanning.suggestionsEnableTarget }}
-            renderPhrase={renderSuggestion}
-            onEnable={suggestions.enable}
-            onPhraseClick={message.setFromText}
-          />
-        )}
+          {suggestions.isSupported && (
+            <SuggestionBar
+              status={suggestions.status}
+              phrases={suggestions.phrases}
+              slotProps={{ enableButton: scanning.suggestionsEnableTarget }}
+              renderPhrase={renderSuggestion}
+              onEnable={suggestions.enable}
+              onPhraseClick={message.setFromText}
+            />
+          )}
+        </div>
 
         {!isSmallScreen && (
           <BackspaceButton


### PR DESCRIPTION
## What changed

- Grouped desktop navigation controls with AI suggestions on the left.
- Kept the backspace control aligned to the right.

## Why

The board controls need clear separation so navigation and suggestion actions remain grouped while the destructive backspace action stays distinct.

## Impact

Desktop board controls now use the intended left/right layout. Small-screen behavior is unchanged.

## Validation

- npm run lint
- npm test (83 files; 572 passed, 7 skipped)
- npm run build