### PR TITLE
Increase tile focus outline

### DIFF
--- a/src/features/board/tile/tile.tsx
+++ b/src/features/board/tile/tile.tsx
@@ -93,7 +93,7 @@ export function Tile({
           },
           [`&.${buttonClasses.focusVisible}`]: {
             boxShadow: (theme.vars ?? theme).shadows[6],
-            outline: `3px solid ${
+            outline: `4px solid ${
               theme.vars
                 ? `rgba(${theme.vars.palette.text.primaryChannel} / 0.8)`
                 : alpha(theme.palette.text.primary, 0.8)


### PR DESCRIPTION
## What changed

- Increased the keyboard-focus outline on board tiles from 3px to 4px.

## Why

A stronger outline improves focus visibility for keyboard and switch-access users.

## Impact

Focused tiles are easier to identify without changing layout or pointer interaction.

## Validation

- npm run lint
- npm test (83 files; 572 passed, 7 skipped)
- npm run build