### PR TITLE
chore: bump version to 1.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aac-board-ai",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aac-board-ai",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aac-board-ai",
   "private": true,
-  "version": "1.14.0",
+  "version": "1.15.0",
   "license": "MIT",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## What changed

- Bumped the application version from 1.14.0 to 1.15.0 in package.json and package-lock.json.

## Why

The changes merged since v1.14.0 include major accessibility and user-facing features that warrant a new minor release.

## Impact

Prepares the current main branch for the v1.15.0 tag and GitHub release.

## Validation

- npm run lint
- npm test (83 files; 572 passed, 7 skipped)
- npm run build