### PR TITLE
Refine board controls and suggestions

### DIFF
--- a/src/features/board/board-viewer.test.tsx
+++ b/src/features/board/board-viewer.test.tsx
@@ -301,7 +301,7 @@ describe("BoardViewer", () => {
 
       const lightRowStyles = getComputedStyle(firstRow.element());
       expect(lightRowStyles.outlineStyle).toBe("solid");
-      expect(lightRowStyles.outlineWidth).toBe("5px");
+      expect(lightRowStyles.outlineWidth).toBe("4px");
       expect(lightRowStyles.boxShadow).not.toBe("none");
 
       await userEvent.keyboard("{Enter}");
@@ -309,7 +309,7 @@ describe("BoardViewer", () => {
       const lightTileStyles = getComputedStyle(hello.element());
       const lightOutlineColor = lightTileStyles.outlineColor;
       expect(lightTileStyles.outlineStyle).toBe("solid");
-      expect(lightTileStyles.outlineWidth).toBe("5px");
+      expect(lightTileStyles.outlineWidth).toBe("4px");
       expect(lightTileStyles.boxShadow).not.toBe("none");
       expect(getComputedStyle(firstRow.element()).outlineStyle).toBe("dashed");
 
@@ -323,7 +323,7 @@ describe("BoardViewer", () => {
 
       const darkTileStyles = getComputedStyle(hello.element());
       expect(darkTileStyles.outlineStyle).toBe("solid");
-      expect(darkTileStyles.outlineWidth).toBe("5px");
+      expect(darkTileStyles.outlineWidth).toBe("4px");
       expect(darkTileStyles.boxShadow).not.toBe("none");
       expect(getComputedStyle(firstRow.element()).outlineStyle).toBe("dashed");
     } finally {

--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -142,7 +142,7 @@ function BoardViewerContent({ board }: BoardViewerProps) {
         spacing={2}
         sx={{ justifyContent: "space-between", px: { xs: 2, sm: 3 } }}
       >
-        <Stack direction="row" spacing={2} sx={{ overflow: "hidden" }}>
+        <Stack direction="row" spacing={2} sx={{ flex: 1, minWidth: 0 }}>
           {!isSmallScreen && (
             <NavButtons
               onHomeClick={navigation.isHome ? scrollGridToOrigin : undefined}

--- a/src/features/board/suggestions/pending-dot.tsx
+++ b/src/features/board/suggestions/pending-dot.tsx
@@ -12,6 +12,7 @@ export function PendingDot({ show }: PendingDotProps) {
       <Box
         sx={{
           width: 8,
+          flexShrink: 0,
           aspectRatio: "1",
           borderRadius: "50%",
           backgroundColor: orange[500],

--- a/src/features/board/suggestions/use-suggestions.test.ts
+++ b/src/features/board/suggestions/use-suggestions.test.ts
@@ -37,11 +37,13 @@ function renderSuggestions(text: string, board: Board = FOOD_BOARD) {
   });
 }
 
-function stubRewritesByTone(rewrites: Record<RewriterTone, string>) {
+function stubRewritesByTone(
+  rewrites: Pick<Record<RewriterTone, string>, "as-is" | "more-casual">,
+) {
   const rewriter = stubRewriter();
 
   rewriter.create.mockImplementation((options) => {
-    const tone = options?.tone as RewriterTone;
+    const tone = options?.tone as keyof typeof rewrites;
 
     return Promise.resolve({
       destroy: () => undefined,
@@ -94,12 +96,11 @@ describe("useSuggestions", () => {
     });
   });
 
-  test("orders suggestions as proofread, direct, friendly, then professional", async () => {
+  test("orders suggestions as proofread, direct, then friendly", async () => {
     stubProofreader(() => makeProofreadResult("Proofread message."));
     stubRewritesByTone({
       "as-is": "Direct message.",
       "more-casual": "Friendly message.",
-      "more-formal": "Professional message.",
     });
 
     const { result } = await renderSuggestions("message");
@@ -109,7 +110,6 @@ describe("useSuggestions", () => {
         "Proofread message.",
         "Direct message.",
         "Friendly message.",
-        "Professional message.",
       ]);
     });
   });
@@ -170,7 +170,7 @@ describe("useSuggestions", () => {
     const { result } = await renderSuggestions("unchanged");
 
     await vi.waitFor(() => {
-      expect(rejecters).toHaveLength(3);
+      expect(rejecters).toHaveLength(2);
       expect(result.current.status).toEqual({ kind: "pending" });
     });
     rejecters.forEach((reject) => reject(new Error("rewrite down")));
@@ -191,7 +191,7 @@ describe("useSuggestions", () => {
     const { result } = await renderSuggestions("want eat");
 
     await vi.waitFor(() => {
-      expect(rejecters).toHaveLength(3);
+      expect(rejecters).toHaveLength(2);
       expect(result.current.status).toEqual({ kind: "pending" });
     });
     rejecters.forEach((reject) =>
@@ -224,13 +224,13 @@ describe("useSuggestions", () => {
 
     await vi.waitFor(() => {
       expect(result.current.status).toEqual({ kind: "needs-activation" });
-      expect(rewriter.availability).toHaveBeenCalledTimes(3);
+      expect(rewriter.availability).toHaveBeenCalledTimes(2);
     });
 
     result.current.enable();
 
     await vi.waitFor(() => {
-      expect(rewriter.availability).toHaveBeenCalledTimes(6);
+      expect(rewriter.availability).toHaveBeenCalledTimes(4);
     });
   });
 
@@ -264,7 +264,7 @@ describe("useSuggestions", () => {
     await renderSuggestions("ahoy");
 
     await vi.waitFor(() => {
-      expect(create).toHaveBeenCalledTimes(3);
+      expect(create).toHaveBeenCalledTimes(2);
     });
 
     expect(create.mock.calls.map(([options]) => options)).toEqual([
@@ -280,12 +280,6 @@ describe("useSuggestions", () => {
         length: "shorter",
         format: "plain-text",
       }),
-      expect.objectContaining({
-        tone: "more-formal",
-        sharedContext: "Talk like a pirate",
-        length: "shorter",
-        format: "plain-text",
-      }),
     ]);
   });
 
@@ -296,7 +290,7 @@ describe("useSuggestions", () => {
     await renderSuggestions("hello");
 
     await vi.waitFor(() => {
-      expect(createRewriter).toHaveBeenCalledTimes(3);
+      expect(createRewriter).toHaveBeenCalledTimes(2);
       expect(createProofreader.mock.calls.at(0)?.at(0)).toMatchObject({
         expectedInputLanguages: ["en"],
       });
@@ -319,7 +313,7 @@ describe("useSuggestions", () => {
     await renderSuggestions("שלום");
 
     await vi.waitFor(() => {
-      expect(create).toHaveBeenCalledTimes(3);
+      expect(create).toHaveBeenCalledTimes(2);
     });
 
     for (const [options] of create.mock.calls) {
@@ -342,17 +336,12 @@ describe("useSuggestions", () => {
       expect(result.current.status).toEqual({ kind: "pending" });
     });
 
-    await vi.waitFor(() => expect(pending).toHaveLength(3));
+    await vi.waitFor(() => expect(pending).toHaveLength(2));
     pending[0]("direct hi");
     pending[1]("friendly hi");
-    pending[2]("professional hi");
 
     await vi.waitFor(() => {
-      expect(result.current.phrases).toEqual([
-        "direct hi",
-        "friendly hi",
-        "professional hi",
-      ]);
+      expect(result.current.phrases).toEqual(["direct hi", "friendly hi"]);
       expect(result.current.status).toBeNull();
     });
   });

--- a/src/features/board/suggestions/use-suggestions.ts
+++ b/src/features/board/suggestions/use-suggestions.ts
@@ -46,23 +46,22 @@ export function useSuggestions(
   const { language } = useLanguage();
 
   const proofreader = useProofreader(proofreaderLanguageOptions(language));
+
   const rewriterOptions = {
     sharedContext: debouncedSharedContext,
     length: "shorter" as const,
     format: "plain-text" as const,
     ...rewriterLanguageOptions(language),
   };
+
   const directRewriter = useRewriter({
     ...rewriterOptions,
     tone: "as-is",
   });
+
   const friendlyRewriter = useRewriter({
     ...rewriterOptions,
     tone: "more-casual",
-  });
-  const professionalRewriter = useRewriter({
-    ...rewriterOptions,
-    tone: "more-formal",
   });
 
   const prediction = useWordPrediction(text, board);
@@ -90,15 +89,9 @@ export function useSuggestions(
     run: (signal) => friendlyRewriter.rewrite(text, { signal }),
   });
 
-  const professionalRewrite = useLatestAsync({
-    enabled: hasText && professionalRewriter.status === "ready",
-    deps: [text, debouncedSharedContext, language],
-    run: (signal) => professionalRewriter.rewrite(text, { signal }),
-  });
   const rewriterSuggestions = [
     { engine: directRewriter, request: directRewrite },
     { engine: friendlyRewriter, request: friendlyRewrite },
-    { engine: professionalRewriter, request: professionalRewrite },
   ];
 
   // Other hook instances can start these downloads; global progress keeps the
@@ -113,9 +106,9 @@ export function useSuggestions(
     corrected.value,
     directRewrite.value,
     friendlyRewrite.value,
-    professionalRewrite.value,
     prediction.phrase,
   ]);
+
   const isPending =
     corrected.isPending ||
     rewriterSuggestions.some(({ request }) => request.isPending) ||

--- a/src/shared/switch-scanning/switch-scanning-presentation.ts
+++ b/src/shared/switch-scanning/switch-scanning-presentation.ts
@@ -5,10 +5,10 @@ const highlightedTargetSelector =
   "&[data-switch-scanning-scope] [data-scan-highlighted]";
 
 export const switchScanningSx = (theme: Theme) => ({
-  "--scan-outline-width": "5px",
-  "--scan-outline-offset": "3px",
+  "--scan-outline-width": "4px",
+  "--scan-outline-offset": "2px",
   "--scan-within-width": "3px",
-  "--scan-within-offset": "1px",
+  "--scan-within-offset": "2px",
   [highlightedTargetSelector]: {
     outline:
       "var(--scan-outline-width) solid var(--scan-outline-color, CanvasText)",


### PR DESCRIPTION
## What changed

- let the board control row flex correctly without clipping suggestions
- keep the pending indicator from shrinking
- tighten switch-scanning outline dimensions
- remove the Professional rewrite variant, leaving Direct and Friendly
- update affected browser-test expectations

## Why

These presentation adjustments keep board controls and suggestions fitting cleanly while matching the intended rewrite variants and switch-scanning appearance.

## Validation

- `npm run lint`
- `npm test` — 555 passed, 7 skipped
- `npm run build`
