### PR TITLE
Clarify switch-scanning timing labels

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "إيقاف",
   "switchScanningAdvanced": "متقدم",
   "switchScanningCyclesBeforePausing": "الدورات قبل التوقف المؤقت",
   "switchScanningFirstItemPause": "التوقف المؤقت عند العنصر الأول",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "Изключено",
   "switchScanningAdvanced": "Разширени",
   "switchScanningCyclesBeforePausing": "Цикли преди пауза",
   "switchScanningFirstItemPause": "Пауза на първия елемент",

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "বন্ধ",
   "switchScanningAdvanced": "উন্নত",
   "switchScanningCyclesBeforePausing": "বিরতির আগে চক্র",
   "switchScanningFirstItemPause": "প্রথম আইটেমে বিরতি",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "Vypnuto",
   "switchScanningAdvanced": "Pokročilé",
   "switchScanningCyclesBeforePausing": "Cykly před pozastavením",
   "switchScanningFirstItemPause": "Pozastavení na první položce",

--- a/messages/da.json
+++ b/messages/da.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "Fra",
   "switchScanningAdvanced": "Avanceret",
   "switchScanningCyclesBeforePausing": "Cyklusser før pause",
   "switchScanningFirstItemPause": "Pause ved første element",

--- a/messages/de.json
+++ b/messages/de.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "Aus",
   "switchScanningAdvanced": "Erweitert",
   "switchScanningCyclesBeforePausing": "Durchläufe bis zur Pause",
   "switchScanningFirstItemPause": "Pause beim ersten Element",

--- a/messages/el.json
+++ b/messages/el.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "Ανενεργό",
   "switchScanningAdvanced": "Για προχωρημένους",
   "switchScanningCyclesBeforePausing": "Κύκλοι πριν από την παύση",
   "switchScanningFirstItemPause": "Παύση στο πρώτο στοιχείο",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
-  "switchScanningAssign": "Press your switch…",
+  "switchScanningAssign": "Press your switch",
+  "switchScanningOff": "Off",
   "switchScanningChange": "Change",
   "switchScanningNextItemSwitch": "Next item switch",
   "switchScanningSelectSwitch": "Select switch",
@@ -115,7 +116,7 @@
   "switchScanningCyclesBeforePausing": "Cycles before pausing",
   "switchScanningFirstItemPause": "First-item pause",
   "switchScanningIgnoreRepeatedPresses": "Ignore repeated presses",
-  "switchScanningMinimumPressDuration": "Minimum press duration",
+  "switchScanningMinimumPressDuration": "Minimum press time",
   "settingsSectionBoard": "Board",
   "settingsSectionSpeech": "Speech",
   "settingsSectionSuggestions": "Suggestions",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "Desactivado",
   "switchScanningAdvanced": "Avanzado",
   "switchScanningCyclesBeforePausing": "Ciclos antes de pausar",
   "switchScanningFirstItemPause": "Pausa en el primer elemento",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "Pois",
   "switchScanningAdvanced": "Lisäasetukset",
   "switchScanningCyclesBeforePausing": "Kierrokset ennen keskeytystä",
   "switchScanningFirstItemPause": "Ensimmäisen kohteen tauko",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "Désactivé",
   "switchScanningAdvanced": "Avancé",
   "switchScanningCyclesBeforePausing": "Cycles avant la pause",
   "switchScanningFirstItemPause": "Pause sur le premier élément",

--- a/messages/he.json
+++ b/messages/he.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "כבוי",
   "switchScanningAdvanced": "מתקדם",
   "switchScanningCyclesBeforePausing": "מחזורים לפני השהיה",
   "switchScanningFirstItemPause": "השהיה בפריט הראשון",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "बंद",
   "switchScanningAdvanced": "उन्नत",
   "switchScanningCyclesBeforePausing": "रुकने से पहले चक्र",
   "switchScanningFirstItemPause": "पहले आइटम पर विराम",

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "Isključeno",
   "switchScanningAdvanced": "Napredno",
   "switchScanningCyclesBeforePausing": "Ciklusi prije pauziranja",
   "switchScanningFirstItemPause": "Pauza na prvoj stavci",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "Ki",
   "switchScanningAdvanced": "Speciális",
   "switchScanningCyclesBeforePausing": "Ciklusok száma szüneteltetés előtt",
   "switchScanningFirstItemPause": "Első elem szünete",

--- a/messages/id.json
+++ b/messages/id.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "Nonaktif",
   "switchScanningAdvanced": "Lanjutan",
   "switchScanningCyclesBeforePausing": "Siklus sebelum dijeda",
   "switchScanningFirstItemPause": "Jeda item pertama",

--- a/messages/it.json
+++ b/messages/it.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "Disattivato",
   "switchScanningAdvanced": "Avanzate",
   "switchScanningCyclesBeforePausing": "Cicli prima della pausa",
   "switchScanningFirstItemPause": "Pausa sul primo elemento",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "オフ",
   "switchScanningAdvanced": "詳細設定",
   "switchScanningCyclesBeforePausing": "一時停止するまでのサイクル数",
   "switchScanningFirstItemPause": "最初の項目で一時停止",

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "ಆಫ್",
   "switchScanningAdvanced": "ಸುಧಾರಿತ",
   "switchScanningCyclesBeforePausing": "ವಿರಾಮದ ಮೊದಲು ಆವರ್ತನಗಳು",
   "switchScanningFirstItemPause": "ಮೊದಲ ಐಟಂ ವಿರಾಮ",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "끔",
   "switchScanningAdvanced": "고급",
   "switchScanningCyclesBeforePausing": "일시 정지 전 반복 횟수",
   "switchScanningFirstItemPause": "첫 번째 항목 일시 정지",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "Uit",
   "switchScanningAdvanced": "Geavanceerd",
   "switchScanningCyclesBeforePausing": "Cycli vóór pauzeren",
   "switchScanningFirstItemPause": "Pauze bij eerste item",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "Wyłączone",
   "switchScanningAdvanced": "Zaawansowane",
   "switchScanningCyclesBeforePausing": "Cykle przed wstrzymaniem",
   "switchScanningFirstItemPause": "Pauza na pierwszym elemencie",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "Desativado",
   "switchScanningAdvanced": "Avançado",
   "switchScanningCyclesBeforePausing": "Ciclos antes da pausa",
   "switchScanningFirstItemPause": "Pausa no primeiro item",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "Oprit",
   "switchScanningAdvanced": "Avansat",
   "switchScanningCyclesBeforePausing": "Cicluri înainte de pauză",
   "switchScanningFirstItemPause": "Pauză la primul element",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "Выкл.",
   "switchScanningAdvanced": "Дополнительно",
   "switchScanningCyclesBeforePausing": "Циклы до паузы",
   "switchScanningFirstItemPause": "Пауза на первом элементе",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "Vypnuté",
   "switchScanningAdvanced": "Rozšírené",
   "switchScanningCyclesBeforePausing": "Cykly pred pozastavením",
   "switchScanningFirstItemPause": "Pozastavenie na prvej položke",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "Izklopljeno",
   "switchScanningAdvanced": "Napredno",
   "switchScanningCyclesBeforePausing": "Cikli pred premorom",
   "switchScanningFirstItemPause": "Premor na prvem elementu",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "Av",
   "switchScanningAdvanced": "Avancerat",
   "switchScanningCyclesBeforePausing": "Cykler före paus",
   "switchScanningFirstItemPause": "Paus på första objektet",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "முடக்கு",
   "switchScanningAdvanced": "மேம்பட்டவை",
   "switchScanningCyclesBeforePausing": "இடைநிறுத்தத்திற்கு முன் சுழற்சிகள்",
   "switchScanningFirstItemPause": "முதல் உருப்படி இடைநிறுத்தம்",

--- a/messages/te.json
+++ b/messages/te.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "ಆఫ్",
   "switchScanningAdvanced": "అధునాతన",
   "switchScanningCyclesBeforePausing": "పాజ్ చేయడానికి ముందు చక్రాలు",
   "switchScanningFirstItemPause": "మొదటి అంశం పాజ్",

--- a/messages/th.json
+++ b/messages/th.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "ปิด",
   "switchScanningAdvanced": "ขั้นสูง",
   "switchScanningCyclesBeforePausing": "จำนวนรอบก่อนหยุดชั่วคราว",
   "switchScanningFirstItemPause": "หยุดที่รายการแรกชั่วคราว",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "Kapalı",
   "switchScanningAdvanced": "Gelişmiş",
   "switchScanningCyclesBeforePausing": "Duraklatmadan önceki döngüler",
   "switchScanningFirstItemPause": "İlk öğede duraklama",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "Вимкнено",
   "switchScanningAdvanced": "Додатково",
   "switchScanningCyclesBeforePausing": "Цикли до паузи",
   "switchScanningFirstItemPause": "Пауза на першому елементі",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "Tắt",
   "switchScanningAdvanced": "Nâng cao",
   "switchScanningCyclesBeforePausing": "Số chu kỳ trước khi tạm dừng",
   "switchScanningFirstItemPause": "Tạm dừng ở mục đầu tiên",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "switchScanningOff": "关闭",
   "switchScanningAdvanced": "高级",
   "switchScanningCyclesBeforePausing": "暂停前的循环次数",
   "switchScanningFirstItemPause": "首项暂停",

--- a/src/app/settings/switch-scanning-settings.test.tsx
+++ b/src/app/settings/switch-scanning-settings.test.tsx
@@ -178,7 +178,7 @@ describe("SwitchScanningSettings", () => {
 
     await moveSwitch.getByRole("button", { name: "Space Change" }).click();
     await expect
-      .element(moveSwitch.getByText("Press your switch…", { exact: true }))
+      .element(moveSwitch.getByText("Press your switch", { exact: true }))
       .toBeVisible();
     document.dispatchEvent(
       new KeyboardEvent("keydown", {
@@ -270,18 +270,28 @@ describe("SwitchScanningSettings", () => {
     const ignoreRepeatedPresses = screen.getByRole("slider", {
       name: "Ignore repeated presses",
     });
-    const minimumPressDuration = screen.getByRole("slider", {
-      name: "Minimum press duration",
+    const minimumPressTime = screen.getByRole("slider", {
+      name: "Minimum press time",
     });
 
     await expect.element(cycles).toBeVisible();
     await expect.element(firstItemPause).toBeVisible();
     await expect.element(ignoreRepeatedPresses).toBeVisible();
-    await expect.element(minimumPressDuration).toBeVisible();
+    await expect.element(minimumPressTime).toBeVisible();
+    expect(screen.getByText("Off", { exact: true }).all()).toHaveLength(3);
+    await expect
+      .element(firstItemPause)
+      .toHaveAttribute("aria-valuetext", "Off");
+    await expect
+      .element(ignoreRepeatedPresses)
+      .toHaveAttribute("aria-valuetext", "Off");
+    await expect
+      .element(minimumPressTime)
+      .toHaveAttribute("aria-valuetext", "Off");
 
     cycles.element().focus();
     await userEvent.keyboard("{ArrowRight}");
-    minimumPressDuration.element().focus();
+    minimumPressTime.element().focus();
     await userEvent.keyboard("{ArrowRight}");
 
     await vi.waitFor(() => {

--- a/src/app/settings/switch-scanning-settings.tsx
+++ b/src/app/settings/switch-scanning-settings.tsx
@@ -73,6 +73,8 @@ export function SwitchScanningSettings() {
     unitDisplay: "long",
     maximumFractionDigits: 1,
   });
+  const formatOptionalSeconds = (value: number) =>
+    value === 0 ? m.switchScanningOff() : seconds.format(value);
 
   const timing =
     method === "dwell"
@@ -164,7 +166,7 @@ export function SwitchScanningSettings() {
             hasTimedScan={hasTimedScan}
             ignoreRepeatMs={ignoreRepeatMs}
             minimumPressDurationMs={minimumPressDurationMs}
-            formatSeconds={(value) => seconds.format(value)}
+            formatSeconds={formatOptionalSeconds}
           />
         </Stack>
       )}


### PR DESCRIPTION
## Summary

- Display a localized **Off** state instead of **0 seconds** for the three optional timing filters.
- Rename **Minimum press duration** to **Minimum press time**.
- Remove the ellipsis from **Press your switch**.
- Cover the visible and accessible slider values in the browser tests.

## Why

Zero seconds describes the stored value but does not communicate that these optional filters are disabled. The updated labels make the switch-scanning settings shorter and clearer for AAC users and caregivers.

## Validation

- `npm run lint`
- `npm test` — 563 passed, 7 skipped
- `npm run build`
