### PR TITLE
Handle reported import failures

### DIFF
--- a/src/features/board/import/use-file-handler-launch.test.tsx
+++ b/src/features/board/import/use-file-handler-launch.test.tsx
@@ -31,6 +31,12 @@ function fileHandle(file: File): FileSystemFileHandle {
   return { getFile: () => Promise.resolve(file) } as FileSystemFileHandle;
 }
 
+function inaccessibleFileHandle(): FileSystemFileHandle {
+  return {
+    getFile: () => Promise.reject(new DOMException("Access denied")),
+  } as FileSystemFileHandle;
+}
+
 function renderLaunchHandler() {
   return render(
     <AppProviders>
@@ -73,5 +79,16 @@ describe("useFileHandlerLaunch", () => {
     await expect
       .element(screen.getByTestId("path"))
       .toHaveTextContent(`/sets/${IMPORTED_SET_ID}/boards/`);
+  });
+
+  test("reports a file that can no longer be opened", async () => {
+    const launch = stubLaunchQueue();
+    const screen = await renderLaunchHandler();
+
+    launch(inaccessibleFileHandle());
+
+    await expect
+      .element(screen.getByRole("alert"))
+      .toHaveTextContent("Couldn't import board");
   });
 });

--- a/src/features/board/import/use-file-handler-launch.ts
+++ b/src/features/board/import/use-file-handler-launch.ts
@@ -1,9 +1,12 @@
+import { m } from "@paraglide/messages.js";
+import { useSnackbar } from "@shared/snackbar/use-snackbar";
 import { useEffect } from "react";
 import { isBoardFile } from "./board-file-formats";
 import { useImportBoardFiles } from "./use-import-board-files";
 
 export function useFileHandlerLaunch(): void {
   const { importAndOpenBoardFiles } = useImportBoardFiles();
+  const { showSnackbar } = useSnackbar();
 
   useEffect(() => {
     const queue = window.launchQueue;
@@ -11,10 +14,22 @@ export function useFileHandlerLaunch(): void {
       return;
     }
 
+    async function importFileHandles(handles: readonly FileSystemFileHandle[]) {
+      try {
+        const opened = await Promise.all(
+          handles.map((handle) => handle.getFile()),
+        );
+        await importAndOpenBoardFiles(opened.filter(isBoardFile));
+      } catch {
+        showSnackbar({
+          message: m.libraryImportFailedBoards({ count: handles.length }),
+          severity: "error",
+        });
+      }
+    }
+
     queue.setConsumer(({ files }) => {
-      void Promise.all(files.map((handle) => handle.getFile())).then((opened) =>
-        importAndOpenBoardFiles(opened.filter(isBoardFile)),
-      );
+      void importFileHandles(files);
     });
-  }, [importAndOpenBoardFiles]);
+  }, [importAndOpenBoardFiles, showSnackbar]);
 }

--- a/src/features/board/import/use-import-board-files.test.tsx
+++ b/src/features/board/import/use-import-board-files.test.tsx
@@ -12,11 +12,7 @@ const OBF_FIXTURE = "lots-of-stuff.obf";
 function ImportTrigger({ files }: { files: File[] }) {
   const { importBoardFiles } = useImportBoardFiles();
 
-  return (
-    <button onClick={() => void importBoardFiles(files).catch(() => undefined)}>
-      import
-    </button>
-  );
+  return <button onClick={() => void importBoardFiles(files)}>import</button>;
 }
 
 function renderImport(files: File[]) {

--- a/src/features/board/import/use-import-board-files.ts
+++ b/src/features/board/import/use-import-board-files.ts
@@ -9,7 +9,7 @@ import { importBoardSets, type ImportResult } from "./board-import";
 
 interface UseImportBoardFilesReturn {
   pickAndImportBoardFiles: () => Promise<void>;
-  importBoardFiles: (files: File[]) => Promise<ImportResult[]>;
+  importBoardFiles: (files: File[]) => Promise<ImportResult[] | undefined>;
   importAndOpenBoardFiles: (files: File[]) => Promise<void>;
 }
 
@@ -17,7 +17,9 @@ export function useImportBoardFiles(): UseImportBoardFilesReturn {
   const { showSnackbar } = useSnackbar();
   const navigate = useNavigate();
 
-  async function importBoardFiles(files: File[]): Promise<ImportResult[]> {
+  async function importBoardFiles(
+    files: File[],
+  ): Promise<ImportResult[] | undefined> {
     if (files.length === 0) {
       return [];
     }
@@ -48,17 +50,19 @@ export function useImportBoardFiles(): UseImportBoardFilesReturn {
         severity: "error",
       });
 
-      throw error;
+      return undefined;
     }
   }
 
   async function importAndOpenBoardFiles(files: File[]) {
     const results = await importBoardFiles(files);
 
-    if (results.length === 1) {
-      const [result] = results;
-      void navigate(boardSetPath(result));
+    if (results?.length !== 1) {
+      return;
     }
+
+    const [result] = results;
+    void navigate(boardSetPath(result));
   }
 
   async function pickAndImportBoardFiles() {


### PR DESCRIPTION
## What changed

- make the snackbar-owning import hook resolve with an explicit failure outcome after reporting an import error
- prevent navigation when an import fails
- catch file-handler access failures and report them through the existing localized import-error snackbar
- exercise both failure paths without caller-side rejection handling

## Why

The UI import hook reported failures and then rethrew them, while production event handlers deliberately discarded its promise. Invalid imports could therefore produce unhandled promise rejections after the user had already been notified.

Keeping `importBoardSets` throwable preserves the low-level operation contract; the UI hook now owns failures it has already translated into user-visible feedback.

## Impact

Import failures remain visible to users but no longer leak as unhandled rejections. Successful imports and single-board navigation are unchanged.

## Validation

- `npm run lint`
- `npm test` — 570 passed, 7 skipped
- `npm run build`
