### PR TITLE
Make locale changes reactive

### DIFF
--- a/src/app/layouts/app-header.tsx
+++ b/src/app/layouts/app-header.tsx
@@ -7,6 +7,7 @@ import IconButton from "@mui/material/IconButton";
 import Toolbar from "@mui/material/Toolbar";
 import Tooltip from "@mui/material/Tooltip";
 import { m } from "@paraglide/messages.js";
+import { useTranslate } from "@shared/language/use-translate";
 import { flipForLtr } from "@shared/theme/rtl";
 import { safeAreaGutter } from "@shared/theme/safe-area";
 
@@ -21,6 +22,8 @@ export function AppHeader({
   onLibraryClick,
   onSettingsClick,
 }: AppHeaderProps) {
+  const t = useTranslate();
+
   return (
     <AppBar position="static">
       <Toolbar
@@ -46,9 +49,9 @@ export function AppHeader({
           }}
         >
           {!libraryButtonHidden && (
-            <Tooltip title={m.libraryOpen()}>
+            <Tooltip title={t(m.libraryOpen)}>
               <IconButton
-                aria-label={m.libraryOpen()}
+                aria-label={t(m.libraryOpen)}
                 size="large"
                 edge="start"
                 color="inherit"
@@ -65,9 +68,9 @@ export function AppHeader({
         </Box>
 
         <Box sx={{ display: "flex", alignItems: "center", justifySelf: "end" }}>
-          <Tooltip title={m.settingsOpen()}>
+          <Tooltip title={t(m.settingsOpen)}>
             <IconButton
-              aria-label={m.settingsOpen()}
+              aria-label={t(m.settingsOpen)}
               size="large"
               edge="end"
               color="inherit"

--- a/src/app/layouts/app-shell.test.tsx
+++ b/src/app/layouts/app-shell.test.tsx
@@ -40,4 +40,45 @@ describe("AppShell", () => {
       .element(screen.getByRole("dialog", { name: "AAC Board AI" }))
       .not.toBeInTheDocument();
   });
+
+  test("updates the mounted shell and open settings drawer across locale changes", async () => {
+    const screen = await renderAppShell();
+
+    await screen.getByRole("button", { name: "Continue" }).click();
+    await expect
+      .element(screen.getByRole("dialog", { name: "AAC Board AI" }))
+      .not.toBeInTheDocument();
+
+    const openSettings = screen.getByRole("button", {
+      name: "Open settings",
+    });
+    const openSettingsButton = openSettings.element();
+    await openSettings.click();
+
+    await screen.getByRole("combobox", { name: "Language" }).click();
+    await screen.getByRole("option", { name: "বাংলা" }).click();
+
+    await expect
+      .element(screen.getByRole("heading", { name: "সেটিংস" }))
+      .toBeVisible();
+    await expect
+      .element(screen.getByRole("combobox", { name: "ভাষা" }))
+      .toBeVisible();
+    expect(openSettingsButton).toHaveAttribute("aria-label", "সেটিংস খুলুন");
+    expect(document.documentElement).toHaveAttribute("lang", "bn");
+    expect(document.documentElement).toHaveAttribute("dir", "ltr");
+
+    await screen.getByRole("combobox", { name: "ভাষা" }).click();
+    await screen.getByRole("option", { name: "עברית" }).click();
+
+    await expect
+      .element(screen.getByRole("heading", { name: "הגדרות" }))
+      .toBeVisible();
+    await expect
+      .element(screen.getByRole("combobox", { name: "שפה" }))
+      .toBeVisible();
+    expect(openSettingsButton).toHaveAttribute("aria-label", "פתיחת הגדרות");
+    expect(document.documentElement).toHaveAttribute("lang", "he");
+    expect(document.documentElement).toHaveAttribute("dir", "rtl");
+  });
 });

--- a/src/app/library/library-drawer.tsx
+++ b/src/app/library/library-drawer.tsx
@@ -8,6 +8,7 @@ import Toolbar from "@mui/material/Toolbar";
 import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
+import { useTranslate } from "@shared/language/use-translate";
 import { flipForLtr } from "@shared/theme/rtl";
 import { safeAreaGutter, safeAreaInset } from "@shared/theme/safe-area";
 import { useMatches, useNavigate } from "react-router";
@@ -23,6 +24,8 @@ export function LibraryDrawer({
   onClose,
   variant = "temporary",
 }: LibraryDrawerProps) {
+  const t = useTranslate();
+
   const navigate = useNavigate();
   const activeMatch = useMatches().find((match) => match.params.setId);
   const activeSetId = activeMatch?.params.setId;
@@ -37,7 +40,7 @@ export function LibraryDrawer({
       variant={variant}
       slotProps={{
         paper: {
-          "aria-label": m.libraryTitle(),
+          "aria-label": t(m.libraryTitle),
           ...(variant === "persistent" && { component: "aside" }),
           sx: {
             width: LIBRARY_DRAWER_WIDTH,
@@ -55,12 +58,12 @@ export function LibraryDrawer({
         })}
       >
         <Typography component="h2" variant="h6" sx={{ flexGrow: 1 }}>
-          {m.libraryTitle()}
+          {t(m.libraryTitle)}
         </Typography>
 
-        <Tooltip title={m.libraryClose()}>
+        <Tooltip title={t(m.libraryClose)}>
           <IconButton
-            aria-label={m.libraryClose()}
+            aria-label={t(m.libraryClose)}
             size="large"
             edge="end"
             color="inherit"

--- a/src/app/onboarding/onboarding-dialog.tsx
+++ b/src/app/onboarding/onboarding-dialog.tsx
@@ -13,6 +13,7 @@ import ListItemIcon from "@mui/material/ListItemIcon";
 import ListItemText from "@mui/material/ListItemText";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { m } from "@paraglide/messages.js";
+import { useTranslate } from "@shared/language/use-translate";
 import type { ReactNode } from "react";
 
 const APP_NAME = "AAC Board AI";
@@ -23,6 +24,7 @@ interface OnboardingDialogProps {
 }
 
 export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
+  const t = useTranslate();
   const fullScreen = useMediaQuery((theme) => theme.breakpoints.down("sm"));
 
   const highlights: {
@@ -34,20 +36,20 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
     {
       id: "rewriting",
       icon: <AutoAwesomeOutlinedIcon color="primary" fontSize="inherit" />,
-      primary: m.onboardingSmartRewritingTitle(),
-      secondary: m.onboardingSmartRewritingDescription(),
+      primary: t(m.onboardingSmartRewritingTitle),
+      secondary: t(m.onboardingSmartRewritingDescription),
     },
     {
       id: "translation",
       icon: <TranslateOutlinedIcon color="primary" fontSize="inherit" />,
-      primary: m.onboardingTranslationTitle(),
-      secondary: m.onboardingTranslationDescription(),
+      primary: t(m.onboardingTranslationTitle),
+      secondary: t(m.onboardingTranslationDescription),
     },
     {
       id: "privacy",
       icon: <LockOutlinedIcon color="primary" fontSize="inherit" />,
-      primary: m.onboardingPrivacyTitle(),
-      secondary: m.onboardingPrivacyDescription(),
+      primary: t(m.onboardingPrivacyTitle),
+      secondary: t(m.onboardingPrivacyDescription),
     },
   ];
 
@@ -120,7 +122,7 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
 
       <DialogActions sx={{ p: 3 }}>
         <Button fullWidth variant="contained" size="large" onClick={onClose}>
-          {m.onboardingContinue()}
+          {t(m.onboardingContinue)}
         </Button>
       </DialogActions>
     </Dialog>

--- a/src/app/routing/loaders/board-loader.ts
+++ b/src/app/routing/loaders/board-loader.ts
@@ -5,9 +5,9 @@ import {
   resolveTranslatedBoard,
   type Board,
 } from "@features/board";
-import { m } from "@paraglide/messages.js";
 import { getStoredLanguage } from "@shared/language/language-store";
 import { data, type LoaderFunctionArgs } from "react-router";
+import { createLocalizedRouteError, routeErrorCodes } from "../route-error";
 
 export async function boardLoader({
   params,
@@ -15,7 +15,9 @@ export async function boardLoader({
 }: LoaderFunctionArgs): Promise<Board> {
   const { setId, boardId } = params;
   if (!setId || !boardId) {
-    throw data(m.errorBoardNotFound(), { status: 404 });
+    throw data(createLocalizedRouteError(routeErrorCodes.boardNotFound), {
+      status: 404,
+    });
   }
 
   try {
@@ -28,7 +30,9 @@ export async function boardLoader({
       error instanceof BoardNotFoundError ||
       error instanceof InvalidIdError
     ) {
-      throw data(m.errorBoardNotFound(), { status: 404 });
+      throw data(createLocalizedRouteError(routeErrorCodes.boardNotFound), {
+        status: 404,
+      });
     }
 
     throw error;

--- a/src/app/routing/loaders/board-set-index-loader.ts
+++ b/src/app/routing/loaders/board-set-index-loader.ts
@@ -1,6 +1,6 @@
 import { boardSetPath, getBoardSet, InvalidIdError } from "@features/board";
-import { m } from "@paraglide/messages.js";
 import { data, redirect, type LoaderFunctionArgs } from "react-router";
+import { createLocalizedRouteError, routeErrorCodes } from "../route-error";
 
 export async function boardSetIndexLoader({
   params,
@@ -18,7 +18,9 @@ export async function boardSetIndexLoader({
   }
 
   if (!boardSet) {
-    throw data(m.errorBoardSetNotFound(), { status: 404 });
+    throw data(createLocalizedRouteError(routeErrorCodes.boardSetNotFound), {
+      status: 404,
+    });
   }
 
   return redirect(boardSetPath(boardSet));

--- a/src/app/routing/loaders/root-index-loader.ts
+++ b/src/app/routing/loaders/root-index-loader.ts
@@ -3,8 +3,8 @@ import {
   getBoardSets,
   importBoardFromUrl,
 } from "@features/board";
-import { m } from "@paraglide/messages.js";
 import { data, redirect, type LoaderFunctionArgs } from "react-router";
+import { createLocalizedRouteError, routeErrorCodes } from "../route-error";
 
 const DEFAULT_BOARD_URL = `${import.meta.env.BASE_URL}quick-core-24.obz`;
 
@@ -20,7 +20,9 @@ async function importFromBoardUrl(boardUrl: string): Promise<Response> {
 }
 
 function importFailed() {
-  return data(m.boardUrlImportFailed(), { status: 400 });
+  return data(createLocalizedRouteError(routeErrorCodes.boardUrlImportFailed), {
+    status: 400,
+  });
 }
 
 export async function rootIndexLoader({

--- a/src/app/routing/not-found.tsx
+++ b/src/app/routing/not-found.tsx
@@ -1,18 +1,21 @@
 import Button from "@mui/material/Button";
 import { m } from "@paraglide/messages.js";
 import { ErrorState } from "@shared/components/error-state";
+import { useTranslate } from "@shared/language/use-translate";
 import { Link } from "react-router";
 
 // Catch-all target for URLs that match no route (typo'd links, stale
 // bookmarks). Rendered inside the app shell so the header and a way home stay
 // available, rather than falling through to react-router's unstyled default.
 export function NotFound() {
+  const t = useTranslate();
+
   return (
     <ErrorState
-      title={m.errorPageNotFound()}
+      title={t(m.errorPageNotFound)}
       action={
         <Button component={Link} to="/" variant="contained">
-          {m.errorGoHome()}
+          {t(m.errorGoHome)}
         </Button>
       }
     />

--- a/src/app/routing/route-error-boundary.test.tsx
+++ b/src/app/routing/route-error-boundary.test.tsx
@@ -1,10 +1,13 @@
+import { AppProviders } from "@shared/providers/app-providers";
+import { setStoredLanguage } from "@shared/language/language-store";
 import { createMemoryRouter, data } from "react-router";
 import { RouterProvider } from "react-router/dom";
 import { describe, expect, test } from "vitest";
 import { render } from "vitest-browser-react";
 import { RouteErrorBoundary } from "./route-error-boundary";
+import { createLocalizedRouteError, routeErrorCodes } from "./route-error";
 
-function renderWithLoader(loader: () => never) {
+function renderWithLoader(loader: () => unknown) {
   const router = createMemoryRouter(
     [
       {
@@ -16,17 +19,26 @@ function renderWithLoader(loader: () => never) {
     { initialEntries: ["/"] },
   );
 
-  return render(<RouterProvider router={router} />);
+  return render(
+    <AppProviders>
+      <button onClick={() => setStoredLanguage("he")}>switch-to-hebrew</button>
+      <RouterProvider router={router} />
+    </AppProviders>,
+  );
+}
+
+function throwDataResponse(errorData: unknown): never {
+  // Mirrors the data() idiom used by real loaders (exempted from this
+  // rule via their `*-loader.ts` filename, which this test file isn't).
+  // eslint-disable-next-line @typescript-eslint/only-throw-error
+  throw data(errorData, { status: 404 });
 }
 
 describe("RouteErrorBoundary", () => {
   test("shows the custom title for a data() response with a string message", async () => {
-    const screen = await renderWithLoader(() => {
-      // Mirrors the data() idiom used by real loaders (exempted from this
-      // rule via their `*-loader.ts` filename, which this test file isn't).
-      // eslint-disable-next-line @typescript-eslint/only-throw-error
-      throw data("Custom title", { status: 404 });
-    });
+    const screen = await renderWithLoader(() =>
+      throwDataResponse("Custom title"),
+    );
 
     await expect.element(screen.getByText("Custom title")).toBeVisible();
   });
@@ -49,5 +61,18 @@ describe("RouteErrorBoundary", () => {
     await expect
       .element(screen.getByRole("link", { name: "Go home" }))
       .toHaveAttribute("href", "/");
+  });
+
+  test("retranslates a loader error that is already being displayed", async () => {
+    const screen = await renderWithLoader(() =>
+      throwDataResponse(
+        createLocalizedRouteError(routeErrorCodes.boardNotFound),
+      ),
+    );
+
+    await expect.element(screen.getByText("Board not found")).toBeVisible();
+
+    await screen.getByRole("button", { name: "switch-to-hebrew" }).click();
+    await expect.element(screen.getByText("הלוח לא נמצא")).toBeVisible();
   });
 });

--- a/src/app/routing/route-error-boundary.tsx
+++ b/src/app/routing/route-error-boundary.tsx
@@ -1,23 +1,56 @@
 import Button from "@mui/material/Button";
 import { m } from "@paraglide/messages.js";
 import { ErrorState } from "@shared/components/error-state";
+import { useTranslate } from "@shared/language/use-translate";
 import { isRouteErrorResponse, Link, useRouteError } from "react-router";
+import {
+  isLocalizedRouteError,
+  routeErrorCodes,
+  type RouteErrorCode,
+} from "./route-error";
 
 export function RouteErrorBoundary() {
+  const t = useTranslate();
   const error = useRouteError();
-  const title =
-    isRouteErrorResponse(error) && typeof error.data === "string"
-      ? error.data
-      : m.errorGenericTitle();
+  const title = getErrorTitle(error, t);
 
   return (
     <ErrorState
       title={title}
       action={
         <Button component={Link} to="/" variant="contained">
-          {m.errorGoHome()}
+          {t(m.errorGoHome)}
         </Button>
       }
     />
   );
+}
+
+function getErrorTitle(
+  error: unknown,
+  t: ReturnType<typeof useTranslate>,
+): string {
+  if (!isRouteErrorResponse(error)) {
+    return t(m.errorGenericTitle);
+  }
+
+  if (isLocalizedRouteError(error.data)) {
+    return translateRouteError(error.data.code, t);
+  }
+
+  return typeof error.data === "string" ? error.data : t(m.errorGenericTitle);
+}
+
+function translateRouteError(
+  code: RouteErrorCode,
+  t: ReturnType<typeof useTranslate>,
+): string {
+  switch (code) {
+    case routeErrorCodes.boardNotFound:
+      return t(m.errorBoardNotFound);
+    case routeErrorCodes.boardSetNotFound:
+      return t(m.errorBoardSetNotFound);
+    case routeErrorCodes.boardUrlImportFailed:
+      return t(m.boardUrlImportFailed);
+  }
 }

--- a/src/app/routing/route-error.ts
+++ b/src/app/routing/route-error.ts
@@ -1,0 +1,28 @@
+export const routeErrorCodes = {
+  boardNotFound: "board-not-found",
+  boardSetNotFound: "board-set-not-found",
+  boardUrlImportFailed: "board-url-import-failed",
+} as const;
+
+export type RouteErrorCode =
+  (typeof routeErrorCodes)[keyof typeof routeErrorCodes];
+
+export interface LocalizedRouteError {
+  code: RouteErrorCode;
+}
+
+export function createLocalizedRouteError(
+  code: RouteErrorCode,
+): LocalizedRouteError {
+  return { code };
+}
+
+export function isLocalizedRouteError(
+  error: unknown,
+): error is LocalizedRouteError {
+  if (!error || typeof error !== "object" || !("code" in error)) {
+    return false;
+  }
+
+  return Object.values(routeErrorCodes).includes(error.code as RouteErrorCode);
+}

--- a/src/app/routing/use-revalidate-on-language-change.ts
+++ b/src/app/routing/use-revalidate-on-language-change.ts
@@ -5,7 +5,7 @@ import { useRevalidator } from "react-router";
 // Board translations are resolved in the route loader, so a language change must
 // re-run the loaders to re-translate the board currently on screen.
 export function useRevalidateOnLanguageChange(): void {
-  const { language } = useLanguage();
+  const { communicationLanguage: language } = useLanguage();
   const { revalidate } = useRevalidator();
   const previousLanguage = useRef(language);
 

--- a/src/app/settings/appearance-settings.tsx
+++ b/src/app/settings/appearance-settings.tsx
@@ -5,8 +5,10 @@ import Radio from "@mui/material/Radio";
 import RadioGroup from "@mui/material/RadioGroup";
 import { useColorScheme } from "@mui/material/styles";
 import { m } from "@paraglide/messages.js";
+import { useTranslate } from "@shared/language/use-translate";
 
 export function AppearanceSettings() {
+  const t = useTranslate();
   const { mode, setMode } = useColorScheme();
 
   if (!mode) {
@@ -19,7 +21,7 @@ export function AppearanceSettings() {
         id="theme-toggle"
         sx={{ typography: "body2", color: "text.secondary" }}
       >
-        {m.themeLabel()}
+        {t(m.themeLabel)}
       </FormLabel>
       <RadioGroup
         aria-labelledby="theme-toggle"
@@ -33,17 +35,17 @@ export function AppearanceSettings() {
         <FormControlLabel
           value="system"
           control={<Radio />}
-          label={m.themeSystem()}
+          label={t(m.themeSystem)}
         />
         <FormControlLabel
           value="light"
           control={<Radio />}
-          label={m.themeLight()}
+          label={t(m.themeLight)}
         />
         <FormControlLabel
           value="dark"
           control={<Radio />}
-          label={m.themeDark()}
+          label={t(m.themeDark)}
         />
       </RadioGroup>
     </FormControl>

--- a/src/app/settings/board-settings.tsx
+++ b/src/app/settings/board-settings.tsx
@@ -4,6 +4,7 @@ import Stack from "@mui/material/Stack";
 import Switch from "@mui/material/Switch";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
+import { useTranslate } from "@shared/language/use-translate";
 import {
   setTileBorderVisible,
   setTileSaturation,
@@ -16,6 +17,7 @@ function formatSaturation(value: number): string {
 }
 
 export function BoardSettings() {
+  const t = useTranslate();
   const { saturation, borderVisible } = useTileColorConfig();
   const saturationLabel = formatSaturation(saturation);
 
@@ -23,7 +25,7 @@ export function BoardSettings() {
     <Stack spacing={3}>
       <FormControlLabel
         labelPlacement="start"
-        label={m.tileBorders()}
+        label={t(m.tileBorders)}
         sx={{ justifyContent: "space-between", m: 0 }}
         control={
           <Switch
@@ -36,14 +38,14 @@ export function BoardSettings() {
       <Stack spacing={0.5}>
         <Stack direction="row" sx={{ justifyContent: "space-between", gap: 2 }}>
           <Typography variant="body2" sx={{ color: "text.secondary" }}>
-            {m.tileSaturation()}
+            {t(m.tileSaturation)}
           </Typography>
           <Typography variant="body2" sx={{ fontWeight: 600 }}>
             {saturationLabel}
           </Typography>
         </Stack>
         <Slider
-          aria-label={m.tileSaturation()}
+          aria-label={t(m.tileSaturation)}
           getAriaValueText={formatSaturation}
           value={saturation}
           min={TILE_SATURATION.min}

--- a/src/app/settings/language-settings.tsx
+++ b/src/app/settings/language-settings.tsx
@@ -9,27 +9,30 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
 import { useLanguage } from "@shared/language/use-language";
+import { useTranslate } from "@shared/language/use-translate";
 import {
   isSupported,
   useGlobalDownloadProgress,
 } from "@shayc/react-built-in-ai";
 
 export function LanguageSettings() {
-  const { languages, language, setLanguage } = useLanguage();
+  const t = useTranslate();
+  const { languages, communicationLanguage, setCommunicationLanguage } =
+    useLanguage();
   const progress = useGlobalDownloadProgress("Translator");
   const isTranslationSupported = isSupported("Translator");
 
   return (
     <Stack spacing={2}>
       <FormControl size="small" fullWidth>
-        <InputLabel id="language-select-label">{m.languageLabel()}</InputLabel>
+        <InputLabel id="language-select-label">{t(m.languageLabel)}</InputLabel>
         <Select
           variant="outlined"
-          label={m.languageLabel()}
+          label={t(m.languageLabel)}
           labelId="language-select-label"
           id="language-select"
-          value={language}
-          onChange={(event) => setLanguage(event.target.value)}
+          value={communicationLanguage}
+          onChange={(event) => setCommunicationLanguage(event.target.value)}
         >
           {languages.map(({ code, name }) => (
             <MenuItem key={code} value={code}>
@@ -41,7 +44,7 @@ export function LanguageSettings() {
 
       {!isTranslationSupported && (
         <Typography sx={{ typography: "body2", color: "text.secondary" }}>
-          {m.languageTranslationUnavailable()}
+          {t(m.languageTranslationUnavailable)}
         </Typography>
       )}
 
@@ -51,9 +54,9 @@ export function LanguageSettings() {
           variant="outlined"
           icon={<DownloadingIcon fontSize="inherit" />}
         >
-          <AlertTitle>{m.languageDownloading()}</AlertTitle>
+          <AlertTitle>{t(m.languageDownloading)}</AlertTitle>
           <Typography>
-            {m.languageDownloadProgress({
+            {t(m.languageDownloadProgress, {
               progress: Math.round(progress * 100),
             })}
           </Typography>

--- a/src/app/settings/settings-drawer.tsx
+++ b/src/app/settings/settings-drawer.tsx
@@ -17,6 +17,7 @@ import Tooltip from "@mui/material/Tooltip";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
 import { ExternalLink } from "@shared/components/external-link";
+import { useTranslate } from "@shared/language/use-translate";
 import { safeAreaGutter, safeAreaInset } from "@shared/theme/safe-area";
 import { AppearanceSettings } from "./appearance-settings";
 import { BoardSettings } from "./board-settings";
@@ -40,6 +41,8 @@ const sectionHeadingSx = {
 } as const;
 
 export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
+  const t = useTranslate();
+
   return (
     <Drawer
       anchor="right"
@@ -47,7 +50,7 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
       onClose={onClose}
       slotProps={{
         paper: {
-          "aria-label": m.settingsTitle(),
+          "aria-label": t(m.settingsTitle),
           sx: [
             {
               width: safeAreaGutter(DRAWER_BASE_WIDTH, "right"),
@@ -69,12 +72,12 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
         })}
       >
         <Typography component="h2" variant="h6" sx={{ flexGrow: 1 }}>
-          {m.settingsTitle()}
+          {t(m.settingsTitle)}
         </Typography>
 
-        <Tooltip title={m.settingsClose()}>
+        <Tooltip title={t(m.settingsClose)}>
           <IconButton
-            aria-label={m.settingsClose()}
+            aria-label={t(m.settingsClose)}
             size="large"
             edge="end"
             color="inherit"
@@ -97,7 +100,7 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
       >
         <Typography component="h3" variant="subtitle1" sx={sectionHeadingSx}>
           <TuneOutlinedIcon fontSize="small" />
-          {m.settingsSectionGeneral()}
+          {t(m.settingsSectionGeneral)}
         </Typography>
         <Stack spacing={3}>
           <AppearanceSettings />
@@ -108,7 +111,7 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
 
         <Typography component="h3" variant="subtitle1" sx={sectionHeadingSx}>
           <AccessibilityNewOutlinedIcon fontSize="small" />
-          {m.settingsSectionSwitchAccess()}
+          {t(m.settingsSectionSwitchAccess)}
         </Typography>
         <SwitchScanningSettings />
 
@@ -116,7 +119,7 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
 
         <Typography component="h3" variant="subtitle1" sx={sectionHeadingSx}>
           <GridViewOutlinedIcon fontSize="small" />
-          {m.settingsSectionBoard()}
+          {t(m.settingsSectionBoard)}
         </Typography>
         <Stack spacing={3}>
           <BoardSettings />
@@ -126,7 +129,7 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
 
         <Typography component="h3" variant="subtitle1" sx={sectionHeadingSx}>
           <VolumeUpOutlinedIcon fontSize="small" />
-          {m.settingsSectionSpeech()}
+          {t(m.settingsSectionSpeech)}
         </Typography>
         <Stack spacing={3}>
           <SpeechSettings />
@@ -136,7 +139,7 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
 
         <Typography component="h3" variant="subtitle1" sx={sectionHeadingSx}>
           <AutoAwesomeIcon fontSize="small" />
-          {m.settingsSectionSuggestions()}
+          {t(m.settingsSectionSuggestions)}
         </Typography>
         <SuggestionsSettings />
 
@@ -144,7 +147,7 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
 
         <Typography component="h3" variant="subtitle1" sx={sectionHeadingSx}>
           <InfoOutlinedIcon fontSize="small" />
-          {m.settingsSectionAbout()}
+          {t(m.settingsSectionAbout)}
         </Typography>
         <ExternalLink
           href="https://github.com/shayc/aac-board-ai"
@@ -154,7 +157,7 @@ export function SettingsDrawer({ open, onClose }: SettingsDrawerProps) {
             fontSize="small"
             sx={{ verticalAlign: "text-bottom", mr: 2 }}
           />
-          {m.aboutSourceCode()}
+          {t(m.aboutSourceCode)}
         </ExternalLink>
       </Box>
     </Drawer>

--- a/src/app/settings/speech-settings.tsx
+++ b/src/app/settings/speech-settings.tsx
@@ -16,6 +16,7 @@ import {
   useHighlightConfig,
 } from "@shared/highlight/highlight-store";
 import { useLanguage } from "@shared/language/use-language";
+import { useTranslate } from "@shared/language/use-translate";
 import { speak } from "@shared/speech/speak";
 import {
   setPitch,
@@ -30,16 +31,18 @@ import {
 } from "@shared/speech/speech-store";
 
 export function SpeechSettings() {
+  const t = useTranslate();
   const voicesByLanguage = useVoicesByLanguage();
   const { voiceURI, rate, pitch, volume } = useSpeechConfig();
   const { highlightActivePart } = useHighlightConfig();
 
-  const { language } = useLanguage();
+  const { communicationLanguage: language } = useLanguage();
 
-  const voicesByLocale = Object.groupBy(
-    voicesByLanguage[language] ?? [],
-    (voice) => voice.lang,
-  );
+  const voices = voicesByLanguage[language] ?? [];
+  const voicesByLocale = Object.groupBy(voices, (voice) => voice.lang);
+  const selectedVoiceURI = voices.some((voice) => voice.voiceURI === voiceURI)
+    ? voiceURI
+    : "";
   const locales = Object.keys(voicesByLocale).sort((a, b) =>
     a.localeCompare(b),
   );
@@ -68,7 +71,7 @@ export function SpeechSettings() {
   const speechControls = [
     {
       id: "rate",
-      label: m.speechRate(),
+      label: t(m.speechRate),
       value: rate,
       min: SPEECH_RATE.min,
       max: SPEECH_RATE.max,
@@ -77,7 +80,7 @@ export function SpeechSettings() {
     },
     {
       id: "pitch",
-      label: m.speechPitch(),
+      label: t(m.speechPitch),
       value: pitch,
       min: SPEECH_PITCH.min,
       max: SPEECH_PITCH.max,
@@ -86,7 +89,7 @@ export function SpeechSettings() {
     },
     {
       id: "volume",
-      label: m.speechVolume(),
+      label: t(m.speechVolume),
       value: volume,
       min: SPEECH_VOLUME.min,
       max: SPEECH_VOLUME.max,
@@ -98,14 +101,16 @@ export function SpeechSettings() {
   return (
     <Stack spacing={3}>
       <FormControl size="small" fullWidth>
-        <InputLabel id="voice-select-label">{m.speechVoice()}</InputLabel>
+        <InputLabel id="voice-select-label">{t(m.speechVoice)}</InputLabel>
         <Select
           variant="outlined"
-          label={m.speechVoice()}
+          label={t(m.speechVoice)}
           labelId="voice-select-label"
           id="voice-select"
-          value={voiceURI ?? ""}
-          onChange={(event) => setVoiceURI(event.target.value || null)}
+          value={selectedVoiceURI}
+          onChange={(event) =>
+            setVoiceURI(event.target.value === "" ? null : event.target.value)
+          }
         >
           {locales.map(renderLocaleOptions)}
         </Select>
@@ -140,7 +145,7 @@ export function SpeechSettings() {
 
       <FormControlLabel
         labelPlacement="start"
-        label={m.playbackHighlight()}
+        label={t(m.playbackHighlight)}
         sx={{ justifyContent: "space-between", m: 0 }}
         control={
           <Switch
@@ -155,9 +160,9 @@ export function SpeechSettings() {
         color="primary"
         startIcon={<PlayArrowIcon />}
         sx={{ alignSelf: "flex-start" }}
-        onClick={() => void speak(m.speechVoicePreview())}
+        onClick={() => void speak(t(m.speechVoicePreview))}
       >
-        {m.speechPreview()}
+        {t(m.speechPreview)}
       </Button>
     </Stack>
   );

--- a/src/app/settings/suggestions-settings.tsx
+++ b/src/app/settings/suggestions-settings.tsx
@@ -5,15 +5,17 @@ import {
   setAISharedContext,
   useAISharedContext,
 } from "@shared/built-in-ai/shared-context-store";
+import { useTranslate } from "@shared/language/use-translate";
 import { isSupported } from "@shayc/react-built-in-ai";
 
 export function SuggestionsSettings() {
+  const t = useTranslate();
   const sharedContext = useAISharedContext();
 
   if (!isSupported("Rewriter")) {
     return (
       <Typography sx={{ typography: "body2", color: "text.secondary" }}>
-        {m.suggestionsUnsupported()}
+        {t(m.suggestionsUnsupported)}
       </Typography>
     );
   }
@@ -24,10 +26,10 @@ export function SuggestionsSettings() {
       fullWidth
       multiline
       rows={4}
-      label={m.aiCustomInstructions()}
+      label={t(m.aiCustomInstructions)}
       slotProps={{ inputLabel: { shrink: true } }}
-      placeholder={m.aiCustomInstructionsPlaceholder()}
-      helperText={m.aiCustomInstructionsHelper()}
+      placeholder={t(m.aiCustomInstructionsPlaceholder)}
+      helperText={t(m.aiCustomInstructionsHelper)}
       value={sharedContext}
       onChange={(event) => setAISharedContext(event.target.value)}
     />

--- a/src/app/settings/switch-input-presentation.ts
+++ b/src/app/settings/switch-input-presentation.ts
@@ -1,7 +1,8 @@
 import { m } from "@paraglide/messages.js";
+import type { Translate } from "@shared/language/use-translate";
 import type { SwitchInput } from "@shared/switch-scanning/switch-scanning-store";
 
-function getSwitchInputLabel(input: SwitchInput): string {
+function getSwitchInputLabel(t: Translate, input: SwitchInput): string {
   if (input.kind === "keyboard") {
     if (
       input.code === "MetaLeft" ||
@@ -11,14 +12,14 @@ function getSwitchInputLabel(input: SwitchInput): string {
       const platform = navigator.platform.toLocaleLowerCase();
 
       if (platform.includes("mac")) {
-        return m.switchScanningCommandKey();
+        return t(m.switchScanningCommandKey);
       }
 
       if (platform.includes("win")) {
-        return m.switchScanningWindowsKey();
+        return t(m.switchScanningWindowsKey);
       }
 
-      return m.switchScanningMetaKey();
+      return t(m.switchScanningMetaKey);
     }
 
     return input.label;
@@ -26,16 +27,16 @@ function getSwitchInputLabel(input: SwitchInput): string {
 
   switch (input.button) {
     case 0:
-      return m.switchScanningLeftMouseButton();
+      return t(m.switchScanningLeftMouseButton);
     case 1:
-      return m.switchScanningMiddleMouseButton();
+      return t(m.switchScanningMiddleMouseButton);
     case 2:
-      return m.switchScanningRightMouseButton();
+      return t(m.switchScanningRightMouseButton);
     default:
-      return m.switchScanningMouseInput({ button: input.button + 1 });
+      return t(m.switchScanningMouseInput, { button: input.button + 1 });
   }
 }
 
-export function formatSwitchInput(input: SwitchInput): string {
-  return getSwitchInputLabel(input);
+export function formatSwitchInput(t: Translate, input: SwitchInput): string {
+  return getSwitchInputLabel(t, input);
 }

--- a/src/app/settings/switch-input-setup.tsx
+++ b/src/app/settings/switch-input-setup.tsx
@@ -2,6 +2,7 @@ import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
+import { useTranslate } from "@shared/language/use-translate";
 import {
   setSwitchInput,
   type SwitchInput,
@@ -38,6 +39,8 @@ function SwitchInputButton({
   label,
   onListen,
 }: SwitchInputButtonProps) {
+  const t = useTranslate();
+
   return (
     <Stack spacing={0.5} sx={{ flex: 1 }} role="group" aria-label={label}>
       <Typography variant="body2" sx={{ color: "text.secondary" }}>
@@ -70,12 +73,12 @@ function SwitchInputButton({
         }}
       >
         {isListening ? (
-          m.switchScanningAssign()
+          t(m.switchScanningAssign)
         ) : (
           <>
-            <span>{formatSwitchInput(input)}</span>
+            <span>{formatSwitchInput(t, input)}</span>
             <Typography component="span" variant="body2" color="primary.main">
-              {m.switchScanningChange()}
+              {t(m.switchScanningChange)}
             </Typography>
           </>
         )}
@@ -85,6 +88,7 @@ function SwitchInputButton({
 }
 
 export function SwitchInputSetup({ inputs, method }: SwitchInputSetupProps) {
+  const t = useTranslate();
   const [listeningRole, setListeningRole] = useState<SwitchInputRole | null>(
     null,
   );
@@ -140,18 +144,18 @@ export function SwitchInputSetup({ inputs, method }: SwitchInputSetupProps) {
     switch (role) {
       case "single":
         if (method === "auto") {
-          return m.switchScanningSelectSwitch();
+          return t(m.switchScanningSelectSwitch);
         }
 
         if (method === "dwell") {
-          return m.switchScanningNextItemSwitch();
+          return t(m.switchScanningNextItemSwitch);
         }
 
-        return m.switchScanningScanSwitch();
+        return t(m.switchScanningScanSwitch);
       case "next":
-        return m.switchScanningNextItemSwitch();
+        return t(m.switchScanningNextItemSwitch);
       case "select":
-        return m.switchScanningSelectSwitch();
+        return t(m.switchScanningSelectSwitch);
     }
   }
 

--- a/src/app/settings/switch-scanning-advanced-settings.tsx
+++ b/src/app/settings/switch-scanning-advanced-settings.tsx
@@ -6,6 +6,7 @@ import Slider from "@mui/material/Slider";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
+import { useTranslate } from "@shared/language/use-translate";
 import {
   CYCLES_BEFORE_PAUSING,
   FIRST_ITEM_PAUSE_MS,
@@ -78,6 +79,8 @@ export function SwitchScanningAdvancedSettings({
   minimumPressDurationMs,
   formatSeconds,
 }: SwitchScanningAdvancedSettingsProps) {
+  const t = useTranslate();
+
   return (
     <Accordion
       disableGutters
@@ -95,7 +98,7 @@ export function SwitchScanningAdvancedSettings({
         sx={{ px: 0 }}
       >
         <Typography component="h4" variant="body2" sx={{ fontWeight: 500 }}>
-          {m.switchScanningAdvanced()}
+          {t(m.switchScanningAdvanced)}
         </Typography>
       </AccordionSummary>
       <AccordionDetails
@@ -107,7 +110,7 @@ export function SwitchScanningAdvancedSettings({
           {hasTimedScan && (
             <>
               <SettingSlider
-                label={m.switchScanningCyclesBeforePausing()}
+                label={t(m.switchScanningCyclesBeforePausing)}
                 value={cyclesBeforePausing}
                 min={CYCLES_BEFORE_PAUSING.min}
                 max={CYCLES_BEFORE_PAUSING.max}
@@ -116,7 +119,7 @@ export function SwitchScanningAdvancedSettings({
                 onChange={setCyclesBeforePausing}
               />
               <SettingSlider
-                label={m.switchScanningFirstItemPause()}
+                label={t(m.switchScanningFirstItemPause)}
                 value={firstItemPauseMs / MILLISECONDS_PER_SECOND}
                 min={FIRST_ITEM_PAUSE_MS.min / MILLISECONDS_PER_SECOND}
                 max={FIRST_ITEM_PAUSE_MS.max / MILLISECONDS_PER_SECOND}
@@ -129,7 +132,7 @@ export function SwitchScanningAdvancedSettings({
             </>
           )}
           <SettingSlider
-            label={m.switchScanningIgnoreRepeatedPresses()}
+            label={t(m.switchScanningIgnoreRepeatedPresses)}
             value={ignoreRepeatMs / MILLISECONDS_PER_SECOND}
             min={IGNORE_REPEAT_MS.min / MILLISECONDS_PER_SECOND}
             max={IGNORE_REPEAT_MS.max / MILLISECONDS_PER_SECOND}
@@ -140,7 +143,7 @@ export function SwitchScanningAdvancedSettings({
             }
           />
           <SettingSlider
-            label={m.switchScanningMinimumPressDuration()}
+            label={t(m.switchScanningMinimumPressDuration)}
             value={minimumPressDurationMs / MILLISECONDS_PER_SECOND}
             min={MINIMUM_PRESS_DURATION_MS.min / MILLISECONDS_PER_SECOND}
             max={MINIMUM_PRESS_DURATION_MS.max / MILLISECONDS_PER_SECOND}

--- a/src/app/settings/switch-scanning-settings.tsx
+++ b/src/app/settings/switch-scanning-settings.tsx
@@ -10,6 +10,7 @@ import Switch from "@mui/material/Switch";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
 import { useLanguage } from "@shared/language/use-language";
+import { type Translate, useTranslate } from "@shared/language/use-translate";
 import {
   DWELL_DURATION_MS,
   SCAN_INTERVAL_MS,
@@ -25,34 +26,38 @@ import { SwitchScanningAdvancedSettings } from "./switch-scanning-advanced-setti
 
 const MILLISECONDS_PER_SECOND = 1_000;
 
-function getMethodLabel(method: SwitchScanningMethod): string {
+function getMethodLabel(t: Translate, method: SwitchScanningMethod): string {
   switch (method) {
     case "auto":
-      return m.switchScanningMethodAuto();
+      return t(m.switchScanningMethodAuto);
     case "step":
-      return m.switchScanningMethodStep();
+      return t(m.switchScanningMethodStep);
     case "dwell":
-      return m.switchScanningMethodDwell();
+      return t(m.switchScanningMethodDwell);
     case "inverse":
-      return m.switchScanningMethodInverse();
+      return t(m.switchScanningMethodInverse);
   }
 }
 
-function getMethodDescription(method: SwitchScanningMethod): string {
+function getMethodDescription(
+  t: Translate,
+  method: SwitchScanningMethod,
+): string {
   switch (method) {
     case "auto":
-      return m.switchScanningMethodAutoDescription();
+      return t(m.switchScanningMethodAutoDescription);
     case "step":
-      return m.switchScanningMethodStepDescription();
+      return t(m.switchScanningMethodStepDescription);
     case "dwell":
-      return m.switchScanningMethodDwellDescription();
+      return t(m.switchScanningMethodDwellDescription);
     case "inverse":
-      return m.switchScanningMethodInverseDescription();
+      return t(m.switchScanningMethodInverseDescription);
   }
 }
 
 export function SwitchScanningSettings() {
-  const { language } = useLanguage();
+  const t = useTranslate();
+  const { communicationLanguage: language } = useLanguage();
   const config = useSwitchScanningConfig();
   const {
     enabled,
@@ -74,19 +79,19 @@ export function SwitchScanningSettings() {
     maximumFractionDigits: 1,
   });
   const formatOptionalSeconds = (value: number) =>
-    value === 0 ? m.switchScanningOff() : seconds.format(value);
+    value === 0 ? t(m.switchScanningOff) : seconds.format(value);
 
   const timing =
     method === "dwell"
       ? {
-          label: m.switchScanningDwellDuration(),
+          label: t(m.switchScanningDwellDuration),
           value: dwellDurationMs,
           range: DWELL_DURATION_MS,
           onChange: setDwellDurationMs,
         }
       : method === "auto" || method === "inverse"
         ? {
-            label: m.switchScanningInterval(),
+            label: t(m.switchScanningInterval),
             value: scanIntervalMs,
             range: SCAN_INTERVAL_MS,
             onChange: setScanIntervalMs,
@@ -97,7 +102,7 @@ export function SwitchScanningSettings() {
     <Stack spacing={3}>
       <FormControlLabel
         labelPlacement="start"
-        label={m.switchScanningEnabled()}
+        label={t(m.switchScanningEnabled)}
         sx={{ justifyContent: "space-between", m: 0 }}
         control={
           <Switch
@@ -111,23 +116,23 @@ export function SwitchScanningSettings() {
         <Stack spacing={3}>
           <FormControl size="small" fullWidth>
             <InputLabel id="switch-scanning-method-label">
-              {m.switchScanningMethod()}
+              {t(m.switchScanningMethod)}
             </InputLabel>
             <Select
               id="switch-scanning-method"
               labelId="switch-scanning-method-label"
-              label={m.switchScanningMethod()}
+              label={t(m.switchScanningMethod)}
               value={method}
               onChange={(event) => setSwitchScanningMethod(event.target.value)}
             >
               {(["auto", "dwell", "inverse", "step"] as const).map((option) => (
                 <MenuItem key={option} value={option}>
-                  {getMethodLabel(option)}
+                  {getMethodLabel(t, option)}
                 </MenuItem>
               ))}
             </Select>
             <FormHelperText sx={{ color: "text.secondary", mx: 0 }}>
-              {getMethodDescription(method)}
+              {getMethodDescription(t, method)}
             </FormHelperText>
           </FormControl>
 

--- a/src/features/board/board-scanning.tsx
+++ b/src/features/board/board-scanning.tsx
@@ -1,5 +1,6 @@
 import Chip from "@mui/material/Chip";
 import { m } from "@paraglide/messages.js";
+import { useTranslate } from "@shared/language/use-translate";
 import { useScanGroup, useScanTarget } from "@shayc/switch-scanning/react";
 import { getNavigationTargetId } from "./button-readers";
 import {
@@ -64,14 +65,15 @@ export function ScannableGridRow({
   rowIndex,
   ...rowProps
 }: ScannableGridRowProps) {
+  const t = useTranslate();
   const rowNumber = rowIndex + 1;
   const sequence = buttons.flatMap((button) =>
     button ? [getTileScanId(boardId, button.id)] : [],
   );
   const scanGroup = useScanGroup({
     id: getRowScanId(boardId, rowIndex),
-    label: m.switchScanningRow({ row: rowNumber }),
-    exitLabel: m.switchScanningRowExit({ row: rowNumber }),
+    label: t(m.switchScanningRow, { row: rowNumber }),
+    exitLabel: t(m.switchScanningRowExit, { row: rowNumber }),
     disabled: sequence.length === 0,
     sequence,
   });

--- a/src/features/board/board-sets/board-set-delete-dialog.test.tsx
+++ b/src/features/board/board-sets/board-set-delete-dialog.test.tsx
@@ -1,12 +1,18 @@
+import { AppProviders } from "@shared/providers/app-providers";
 import { expectNoA11yViolations } from "@shared/testing/axe";
+import type { ReactNode } from "react";
 import { describe, expect, test, vi } from "vitest";
 import { render } from "vitest-browser-react";
 import { BoardSetDeleteDialog } from "./board-set-delete-dialog";
 import { makeBoardSet } from "./test-utils";
 
+function renderWithProviders(children: ReactNode) {
+  return render(<AppProviders>{children}</AppProviders>);
+}
+
 describe("BoardSetDeleteDialog", () => {
   test("has no a11y violations when open", async () => {
-    const screen = await render(
+    const screen = await renderWithProviders(
       <BoardSetDeleteDialog
         boardSet={makeBoardSet({ name: "Core Words" })}
         onConfirm={vi.fn()}
@@ -19,7 +25,7 @@ describe("BoardSetDeleteDialog", () => {
   });
 
   test("shows the board set name and an irreversible warning when open", async () => {
-    const screen = await render(
+    const screen = await renderWithProviders(
       <BoardSetDeleteDialog
         boardSet={makeBoardSet({ name: "Core Words" })}
         onConfirm={vi.fn()}
@@ -36,7 +42,7 @@ describe("BoardSetDeleteDialog", () => {
   });
 
   test("renders nothing when no board set is targeted", async () => {
-    const screen = await render(
+    const screen = await renderWithProviders(
       <BoardSetDeleteDialog
         boardSet={null}
         onConfirm={vi.fn()}
@@ -52,7 +58,7 @@ describe("BoardSetDeleteDialog", () => {
   test("calls onConfirm when Delete is clicked", async () => {
     const onConfirm = vi.fn();
     const onClose = vi.fn();
-    const screen = await render(
+    const screen = await renderWithProviders(
       <BoardSetDeleteDialog
         boardSet={makeBoardSet()}
         onConfirm={onConfirm}
@@ -69,7 +75,7 @@ describe("BoardSetDeleteDialog", () => {
   test("calls onClose when Cancel is clicked", async () => {
     const onConfirm = vi.fn();
     const onClose = vi.fn();
-    const screen = await render(
+    const screen = await renderWithProviders(
       <BoardSetDeleteDialog
         boardSet={makeBoardSet()}
         onConfirm={onConfirm}

--- a/src/features/board/board-sets/board-set-delete-dialog.tsx
+++ b/src/features/board/board-sets/board-set-delete-dialog.tsx
@@ -5,6 +5,7 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
 import { m } from "@paraglide/messages.js";
+import { useTranslate } from "@shared/language/use-translate";
 import type { BoardSetRecord } from "../storage/boards-db";
 
 interface BoardSetDeleteDialogProps {
@@ -18,6 +19,8 @@ export function BoardSetDeleteDialog({
   onConfirm,
   onClose,
 }: BoardSetDeleteDialogProps) {
+  const t = useTranslate();
+
   return (
     <Dialog
       open={boardSet !== null}
@@ -26,19 +29,21 @@ export function BoardSetDeleteDialog({
       aria-describedby="delete-dialog-description"
     >
       <DialogTitle id="delete-dialog-title">
-        {boardSet ? m.libraryDeleteConfirmTitle({ name: boardSet.name }) : null}
+        {boardSet
+          ? t(m.libraryDeleteConfirmTitle, { name: boardSet.name })
+          : null}
       </DialogTitle>
 
       <DialogContent>
         <DialogContentText id="delete-dialog-description">
-          {m.libraryDeleteIrreversible()}
+          {t(m.libraryDeleteIrreversible)}
         </DialogContentText>
       </DialogContent>
 
       <DialogActions>
-        <Button onClick={onClose}>{m.libraryCancel()}</Button>
+        <Button onClick={onClose}>{t(m.libraryCancel)}</Button>
         <Button onClick={onConfirm} color="error">
-          {m.libraryDelete()}
+          {t(m.libraryDelete)}
         </Button>
       </DialogActions>
     </Dialog>

--- a/src/features/board/board-sets/board-set-info-dialog.test.tsx
+++ b/src/features/board/board-sets/board-set-info-dialog.test.tsx
@@ -1,12 +1,18 @@
+import { AppProviders } from "@shared/providers/app-providers";
 import { expectNoA11yViolations } from "@shared/testing/axe";
+import type { ReactNode } from "react";
 import { describe, expect, test, vi } from "vitest";
 import { render } from "vitest-browser-react";
 import { BoardSetInfoDialog } from "./board-set-info-dialog";
 import { makeBoardSet } from "./test-utils";
 
+function renderWithProviders(children: ReactNode) {
+  return render(<AppProviders>{children}</AppProviders>);
+}
+
 describe("BoardSetInfoDialog", () => {
   test("has no a11y violations when open", async () => {
-    const screen = await render(
+    const screen = await renderWithProviders(
       <BoardSetInfoDialog
         boardSet={makeBoardSet({ name: "Core Words", author: "Jane" })}
         onClose={vi.fn()}
@@ -18,7 +24,7 @@ describe("BoardSetInfoDialog", () => {
   });
 
   test("shows the name and author", async () => {
-    const screen = await render(
+    const screen = await renderWithProviders(
       <BoardSetInfoDialog
         boardSet={makeBoardSet({ name: "Core Words", author: "Jane" })}
         onClose={vi.fn()}
@@ -30,7 +36,7 @@ describe("BoardSetInfoDialog", () => {
   });
 
   test("builds chips from grid dimensions and license", async () => {
-    const screen = await render(
+    const screen = await renderWithProviders(
       <BoardSetInfoDialog
         boardSet={makeBoardSet({
           gridRows: 2,
@@ -47,7 +53,7 @@ describe("BoardSetInfoDialog", () => {
   });
 
   test("omits the author line and chips when those fields are absent", async () => {
-    const screen = await render(
+    const screen = await renderWithProviders(
       <BoardSetInfoDialog boardSet={makeBoardSet()} onClose={vi.fn()} />,
     );
 
@@ -57,7 +63,7 @@ describe("BoardSetInfoDialog", () => {
   });
 
   test("shows the description when present", async () => {
-    const screen = await render(
+    const screen = await renderWithProviders(
       <BoardSetInfoDialog
         boardSet={makeBoardSet({ description: "A starter vocabulary board." })}
         onClose={vi.fn()}
@@ -70,7 +76,7 @@ describe("BoardSetInfoDialog", () => {
   });
 
   test("renders nothing when no board set is targeted", async () => {
-    const screen = await render(
+    const screen = await renderWithProviders(
       <BoardSetInfoDialog boardSet={null} onClose={vi.fn()} />,
     );
 
@@ -79,7 +85,7 @@ describe("BoardSetInfoDialog", () => {
 
   test("calls onClose when Close is clicked", async () => {
     const onClose = vi.fn();
-    const screen = await render(
+    const screen = await renderWithProviders(
       <BoardSetInfoDialog boardSet={makeBoardSet()} onClose={onClose} />,
     );
 

--- a/src/features/board/board-sets/board-set-info-dialog.tsx
+++ b/src/features/board/board-sets/board-set-info-dialog.tsx
@@ -7,6 +7,7 @@ import DialogTitle from "@mui/material/DialogTitle";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
+import { useTranslate, type Translate } from "@shared/language/use-translate";
 import type { BoardSetRecord } from "../storage/boards-db";
 
 interface BoardSetInfoDialogProps {
@@ -18,7 +19,8 @@ export function BoardSetInfoDialog({
   boardSet,
   onClose,
 }: BoardSetInfoDialogProps) {
-  const chipLabels = boardSet ? buildChipLabels(boardSet) : [];
+  const t = useTranslate();
+  const chipLabels = boardSet ? buildChipLabels(t, boardSet) : [];
 
   return (
     <Dialog
@@ -32,7 +34,7 @@ export function BoardSetInfoDialog({
         {boardSet?.name}
         {boardSet?.author && (
           <Typography variant="body2" sx={{ color: "text.secondary" }}>
-            {m.libraryByAuthor({ author: boardSet.author })}
+            {t(m.libraryByAuthor, { author: boardSet.author })}
           </Typography>
         )}
       </DialogTitle>
@@ -59,18 +61,18 @@ export function BoardSetInfoDialog({
       </DialogContent>
 
       <DialogActions>
-        <Button onClick={onClose}>{m.close()}</Button>
+        <Button onClick={onClose}>{t(m.close)}</Button>
       </DialogActions>
     </Dialog>
   );
 }
 
-function buildChipLabels(boardSet: BoardSetRecord): string[] {
+function buildChipLabels(t: Translate, boardSet: BoardSetRecord): string[] {
   const labels: string[] = [];
 
   if (boardSet.gridRows && boardSet.gridColumns) {
     labels.push(
-      m.libraryGridDimensions({
+      t(m.libraryGridDimensions, {
         rows: boardSet.gridRows,
         columns: boardSet.gridColumns,
       }),

--- a/src/features/board/board-sets/board-set-library.tsx
+++ b/src/features/board/board-sets/board-set-library.tsx
@@ -9,6 +9,7 @@ import ListItemText from "@mui/material/ListItemText";
 import { m } from "@paraglide/messages.js";
 import { EmptyState } from "@shared/components/empty-state";
 import { LoadingState } from "@shared/components/loading-state";
+import { useTranslate } from "@shared/language/use-translate";
 import { useSnackbar } from "@shared/snackbar/use-snackbar";
 import { useState } from "react";
 import { useImportBoardFiles } from "../import/use-import-board-files";
@@ -28,6 +29,7 @@ export function BoardSetLibrary({
   selectedSetId,
   onSelect,
 }: BoardSetLibraryProps) {
+  const t = useTranslate();
   const { boardSets, isLoading } = useBoardSets();
   const { pickAndImportBoardFiles } = useImportBoardFiles();
   const { showSnackbar } = useSnackbar();
@@ -46,12 +48,12 @@ export function BoardSetLibrary({
     try {
       await deleteBoardSet(setId);
       showSnackbar({
-        message: m.libraryDeleted({ name }),
+        message: (translate) => translate(m.libraryDeleted, { name }),
         severity: "success",
       });
     } catch {
       showSnackbar({
-        message: m.libraryDeleteFailed({ name }),
+        message: (translate) => translate(m.libraryDeleteFailed, { name }),
         severity: "error",
       });
     }
@@ -60,7 +62,7 @@ export function BoardSetLibrary({
   if (isLoading) {
     return (
       <Box sx={{ px: 2, height: "100%" }}>
-        <LoadingState message={m.libraryLoading()} />
+        <LoadingState message={t(m.libraryLoading)} />
       </Box>
     );
   }
@@ -69,15 +71,15 @@ export function BoardSetLibrary({
     return (
       <Box sx={{ px: 2, height: "100%" }}>
         <EmptyState
-          title={m.libraryEmptyTitle()}
-          description={m.libraryEmptyDescription()}
+          title={t(m.libraryEmptyTitle)}
+          description={t(m.libraryEmptyDescription)}
           action={
             <Button
               variant="contained"
               startIcon={<LibraryAddOutlinedIcon />}
               onClick={() => void pickAndImportBoardFiles()}
             >
-              {m.libraryImportBoards()}
+              {t(m.libraryImportBoards)}
             </Button>
           }
         />
@@ -93,7 +95,7 @@ export function BoardSetLibrary({
             <ListItemIcon>
               <LibraryAddOutlinedIcon />
             </ListItemIcon>
-            <ListItemText primary={m.libraryImportBoards()} />
+            <ListItemText primary={t(m.libraryImportBoards)} />
           </ListItemButton>
         </ListItem>
       </List>

--- a/src/features/board/board-sets/board-set-list.test.tsx
+++ b/src/features/board/board-sets/board-set-list.test.tsx
@@ -1,11 +1,17 @@
+import { AppProviders } from "@shared/providers/app-providers";
+import type { ReactNode } from "react";
 import { describe, expect, test, vi } from "vitest";
 import { render } from "vitest-browser-react";
 import { BoardSetList } from "./board-set-list";
 import { makeBoardSet } from "./test-utils";
 
+function renderWithProviders(children: ReactNode) {
+  return render(<AppProviders>{children}</AppProviders>);
+}
+
 describe("BoardSetList", () => {
   test("renders an item per board set with its name", async () => {
-    const screen = await render(
+    const screen = await renderWithProviders(
       <BoardSetList
         boardSets={[
           makeBoardSet({ setId: "a", name: "Core Words" }),
@@ -23,7 +29,7 @@ describe("BoardSetList", () => {
 
   test("calls onSelect with the board set when its row is clicked", async () => {
     const onSelect = vi.fn();
-    const screen = await render(
+    const screen = await renderWithProviders(
       <BoardSetList
         boardSets={[makeBoardSet({ name: "Core Words" })]}
         onSelect={onSelect}
@@ -43,7 +49,7 @@ describe("BoardSetList", () => {
   test("opens the row menu and routes Info to onInfo", async () => {
     const onInfo = vi.fn();
     const onDelete = vi.fn();
-    const screen = await render(
+    const screen = await renderWithProviders(
       <BoardSetList
         boardSets={[makeBoardSet({ name: "Core Words" })]}
         onSelect={vi.fn()}
@@ -65,7 +71,7 @@ describe("BoardSetList", () => {
   test("routes the menu's Delete to onDelete", async () => {
     const onInfo = vi.fn();
     const onDelete = vi.fn();
-    const screen = await render(
+    const screen = await renderWithProviders(
       <BoardSetList
         boardSets={[makeBoardSet({ name: "Core Words" })]}
         onSelect={vi.fn()}

--- a/src/features/board/board-sets/board-set-list.tsx
+++ b/src/features/board/board-sets/board-set-list.tsx
@@ -13,6 +13,7 @@ import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import Tooltip from "@mui/material/Tooltip";
 import { m } from "@paraglide/messages.js";
+import { useTranslate } from "@shared/language/use-translate";
 import { useState } from "react";
 import type { BoardSetRecord } from "../storage/boards-db";
 
@@ -31,6 +32,7 @@ export function BoardSetList({
   onDelete,
   selectedSetId,
 }: BoardSetListProps) {
+  const t = useTranslate();
   const [menuAnchor, setMenuAnchor] = useState<{
     element: HTMLElement;
     boardSet: BoardSetRecord;
@@ -72,7 +74,7 @@ export function BoardSetList({
         <List
           subheader={
             <ListSubheader id="board-set-list-subheader">
-              {m.libraryBoards()}
+              {t(m.libraryBoards)}
             </ListSubheader>
           }
           sx={(theme) => ({
@@ -101,10 +103,10 @@ export function BoardSetList({
                 key={boardSet.setId}
                 data-menu-open={isMenuOpen || undefined}
                 secondaryAction={
-                  <Tooltip title={m.libraryMoreOptions()}>
+                  <Tooltip title={t(m.libraryMoreOptions)}>
                     <IconButton
                       edge="end"
-                      aria-label={m.libraryMoreOptionsFor({
+                      aria-label={t(m.libraryMoreOptionsFor, {
                         name: boardSet.name,
                       })}
                       aria-controls={isMenuOpen ? "board-set-menu" : undefined}
@@ -152,13 +154,13 @@ export function BoardSetList({
           <ListItemIcon>
             <InfoOutlinedIcon fontSize="small" />
           </ListItemIcon>
-          <ListItemText>{m.libraryInfo()}</ListItemText>
+          <ListItemText>{t(m.libraryInfo)}</ListItemText>
         </MenuItem>
         <MenuItem onClick={handleDelete}>
           <ListItemIcon>
             <DeleteOutlinedIcon fontSize="small" />
           </ListItemIcon>
-          <ListItemText>{m.libraryDelete()}</ListItemText>
+          <ListItemText>{t(m.libraryDelete)}</ListItemText>
         </MenuItem>
       </Menu>
     </>

--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -6,6 +6,7 @@ import useMediaQuery from "@mui/material/useMediaQuery";
 import { m } from "@paraglide/messages.js";
 import { useHighlightConfig } from "@shared/highlight/highlight-store";
 import { useLanguage } from "@shared/language/use-language";
+import { useTranslate } from "@shared/language/use-translate";
 import { SwitchScanningBoundary } from "@shared/switch-scanning/switch-scanning-boundary";
 import { switchScanningSx } from "@shared/switch-scanning/switch-scanning-presentation";
 import { safeAreaInset } from "@shared/theme/safe-area";
@@ -56,6 +57,7 @@ export function BoardViewer({ board }: BoardViewerProps) {
 }
 
 function BoardViewerContent({ board }: BoardViewerProps) {
+  const t = useTranslate();
   const { direction } = useLanguage();
   const isSmallScreen = useMediaQuery((theme) => theme.breakpoints.down("sm"));
   const { highlightActivePart } = useHighlightConfig();
@@ -178,7 +180,7 @@ function BoardViewerContent({ board }: BoardViewerProps) {
       <Box sx={{ flex: 1, minHeight: 0 }}>
         <Grid<BoardButton>
           ref={gridRef}
-          ariaLabel={board.name ?? m.boardGridLabel()}
+          ariaLabel={board.name ?? t(m.boardGridLabel)}
           items={board.buttons}
           rows={board.grid.rows}
           columns={board.grid.columns}

--- a/src/features/board/import/board-file-drop-overlay.tsx
+++ b/src/features/board/import/board-file-drop-overlay.tsx
@@ -5,12 +5,15 @@ import Paper from "@mui/material/Paper";
 import { alpha } from "@mui/material/styles";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
+import { useTranslate } from "@shared/language/use-translate";
 
 interface BoardFileDropOverlayProps {
   open: boolean;
 }
 
 export function BoardFileDropOverlay({ open }: BoardFileDropOverlayProps) {
+  const t = useTranslate();
+
   return (
     <Backdrop
       open={open}
@@ -37,7 +40,7 @@ export function BoardFileDropOverlay({ open }: BoardFileDropOverlayProps) {
           })}
         >
           <FileDownloadOutlinedIcon color="primary" sx={{ fontSize: 56 }} />
-          <Typography variant="h6">{m.libraryDropToImport()}</Typography>
+          <Typography variant="h6">{t(m.libraryDropToImport)}</Typography>
         </Paper>
       </Grow>
     </Backdrop>

--- a/src/features/board/import/use-file-handler-launch.ts
+++ b/src/features/board/import/use-file-handler-launch.ts
@@ -22,7 +22,8 @@ export function useFileHandlerLaunch(): void {
         await importAndOpenBoardFiles(opened.filter(isBoardFile));
       } catch {
         showSnackbar({
-          message: m.libraryImportFailedBoards({ count: handles.length }),
+          message: (translate) =>
+            translate(m.libraryImportFailedBoards, { count: handles.length }),
           severity: "error",
         });
       }

--- a/src/features/board/import/use-import-board-files.ts
+++ b/src/features/board/import/use-import-board-files.ts
@@ -27,14 +27,14 @@ export function useImportBoardFiles(): UseImportBoardFilesReturn {
     const count = files.length;
 
     showSnackbar({
-      message: m.libraryImportingBoards({ count }),
+      message: (translate) => translate(m.libraryImportingBoards, { count }),
     });
 
     try {
       const results = await importBoardSets(files);
 
       showSnackbar({
-        message: m.libraryImportedBoards({ count }),
+        message: (translate) => translate(m.libraryImportedBoards, { count }),
         severity: "success",
       });
 
@@ -45,8 +45,8 @@ export function useImportBoardFiles(): UseImportBoardFilesReturn {
 
       showSnackbar({
         message: tooLarge
-          ? m.libraryImportTooLargeBoards({ count })
-          : m.libraryImportFailedBoards({ count }),
+          ? (translate) => translate(m.libraryImportTooLargeBoards, { count })
+          : (translate) => translate(m.libraryImportFailedBoards, { count }),
         severity: "error",
       });
 

--- a/src/features/board/message/backspace-button.test.tsx
+++ b/src/features/board/message/backspace-button.test.tsx
@@ -2,11 +2,16 @@ import {
   createTheme,
   ThemeProvider as MUIThemeProvider,
 } from "@mui/material/styles";
-import { createRef } from "react";
+import { AppProviders } from "@shared/providers/app-providers";
+import { createRef, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { assertDefined } from "@shared/testing/assert-defined";
 import { render } from "vitest-browser-react";
 import { BackspaceButton } from "./backspace-button";
+
+function renderWithProviders(children: ReactNode) {
+  return render(<AppProviders>{children}</AppProviders>);
+}
 
 function createHandlers() {
   return {
@@ -44,7 +49,7 @@ describe("BackspaceButton", () => {
     const handlers = createHandlers();
     const onClick = vi.fn();
     const ref = createRef<HTMLButtonElement>();
-    const screen = await render(
+    const screen = await renderWithProviders(
       <BackspaceButton
         {...handlers}
         ref={ref}
@@ -65,7 +70,7 @@ describe("BackspaceButton", () => {
   test("calls onPress when clicked", async () => {
     const handlers = createHandlers();
 
-    const screen = await render(<BackspaceButton {...handlers} />);
+    const screen = await renderWithProviders(<BackspaceButton {...handlers} />);
 
     const button = screen.getByRole("button", { name: "Backspace" });
     await button.click();
@@ -77,7 +82,7 @@ describe("BackspaceButton", () => {
   test("calls onLongPress when long-pressed", async () => {
     const handlers = createHandlers();
 
-    const screen = await render(<BackspaceButton {...handlers} />);
+    const screen = await renderWithProviders(<BackspaceButton {...handlers} />);
 
     const button = screen.getByRole("button", { name: "Backspace" });
     longPress(button.element());
@@ -91,7 +96,7 @@ describe("BackspaceButton", () => {
       const theme = createTheme({ direction: "rtl" });
       const handlers = createHandlers();
 
-      const screen = await render(
+      const screen = await renderWithProviders(
         <MUIThemeProvider theme={theme}>
           <BackspaceButton {...handlers} />
         </MUIThemeProvider>,
@@ -110,7 +115,7 @@ describe("BackspaceButton", () => {
       const theme = createTheme({ direction: "ltr" });
       const handlers = createHandlers();
 
-      const screen = await render(
+      const screen = await renderWithProviders(
         <MUIThemeProvider theme={theme}>
           <BackspaceButton {...handlers} />
         </MUIThemeProvider>,

--- a/src/features/board/message/backspace-button.tsx
+++ b/src/features/board/message/backspace-button.tsx
@@ -1,6 +1,7 @@
 import BackspaceOutlinedIcon from "@mui/icons-material/BackspaceOutlined";
 import Button, { type ButtonProps } from "@mui/material/Button";
 import { m } from "@paraglide/messages.js";
+import { useTranslate } from "@shared/language/use-translate";
 import { mergeSx } from "@shared/theme/merge-sx";
 import { flipForRtl } from "@shared/theme/rtl";
 import { mergeProps, useLongPress, usePress } from "react-aria";
@@ -29,10 +30,11 @@ export function BackspaceButton({
   sx,
   ...buttonProps
 }: BackspaceButtonProps) {
+  const t = useTranslate();
   const { pressProps } = usePress({ onPress });
 
   const { longPressProps } = useLongPress({
-    accessibilityDescription: m.messageBackspaceLongPressHint(),
+    accessibilityDescription: t(m.messageBackspaceLongPressHint),
     threshold: LONG_PRESS_THRESHOLD_MS,
     onLongPress,
   });
@@ -40,7 +42,7 @@ export function BackspaceButton({
   return (
     <Button
       {...mergeProps(buttonProps, pressProps, longPressProps)}
-      aria-label={m.messageBackspace()}
+      aria-label={t(m.messageBackspace)}
       size="large"
       color="inherit"
       variant="contained"

--- a/src/features/board/message/message-bar.test.tsx
+++ b/src/features/board/message/message-bar.test.tsx
@@ -1,4 +1,5 @@
-import { createRef } from "react";
+import { AppProviders } from "@shared/providers/app-providers";
+import { createRef, type ReactNode } from "react";
 import {
   afterEach,
   beforeEach,
@@ -11,6 +12,10 @@ import {
 import { render } from "vitest-browser-react";
 import { MessageBar, type MessageBarProps } from "./message-bar";
 import type { MessagePart } from "./use-message";
+
+function renderWithProviders(children: ReactNode) {
+  return render(<AppProviders>{children}</AppProviders>);
+}
 
 function createProps(
   overrides: Partial<MessageBarProps> = {},
@@ -54,7 +59,9 @@ describe("MessageBar", () => {
       { id: "c", label: "water" },
     ];
 
-    const screen = await render(<MessageBar {...createProps({ parts })} />);
+    const screen = await renderWithProviders(
+      <MessageBar {...createProps({ parts })} />,
+    );
 
     await expect.element(screen.getByText("I")).toBeVisible();
     await expect.element(screen.getByText("want")).toBeVisible();
@@ -64,7 +71,9 @@ describe("MessageBar", () => {
   test("re-enables text selection so the composed message can be copied", async () => {
     const parts: MessagePart[] = [{ id: "a", label: "I" }];
 
-    const screen = await render(<MessageBar {...createProps({ parts })} />);
+    const screen = await renderWithProviders(
+      <MessageBar {...createProps({ parts })} />,
+    );
 
     const label = screen.getByText("I").element();
     const styles = getComputedStyle(label);
@@ -74,21 +83,23 @@ describe("MessageBar", () => {
 
   describe("scroll-into-view", () => {
     test("scrolls the newest part to the trailing edge when a part is added", async () => {
-      const screen = await render(
+      const screen = await renderWithProviders(
         <MessageBar {...createProps({ parts: [] })} />,
       );
 
       expect(scrollIntoView).not.toHaveBeenCalled();
 
       await screen.rerender(
-        <MessageBar
-          {...createProps({
-            parts: [
-              { id: "a", label: "I" },
-              { id: "b", label: "want" },
-            ],
-          })}
-        />,
+        <AppProviders>
+          <MessageBar
+            {...createProps({
+              parts: [
+                { id: "a", label: "I" },
+                { id: "b", label: "want" },
+              ],
+            })}
+          />
+        </AppProviders>,
       );
 
       await vi.waitFor(() => {
@@ -110,7 +121,9 @@ describe("MessageBar", () => {
         { id: "c", label: "water" },
       ];
 
-      const screen = await render(<MessageBar {...createProps({ parts })} />);
+      const screen = await renderWithProviders(
+        <MessageBar {...createProps({ parts })} />,
+      );
 
       // Drain the mount-time scroll-to-end so only the active-part scroll remains.
       await vi.waitFor(() => expect(scrollIntoView).toHaveBeenCalled());
@@ -119,7 +132,9 @@ describe("MessageBar", () => {
       // Same `parts` reference: the append effect stays put, isolating the
       // active-part effect we are asserting on.
       await screen.rerender(
-        <MessageBar {...createProps({ parts, activePartId: "b" })} />,
+        <AppProviders>
+          <MessageBar {...createProps({ parts, activePartId: "b" })} />
+        </AppProviders>,
       );
 
       await vi.waitFor(() => {
@@ -140,7 +155,7 @@ describe("MessageBar", () => {
         { id: "b", label: "want" },
       ];
 
-      await render(
+      await renderWithProviders(
         <MessageBar {...createProps({ parts, activePartId: null })} />,
       );
 
@@ -156,7 +171,7 @@ describe("MessageBar", () => {
   describe("controls", () => {
     test("forwards play button slot props", async () => {
       const ref = createRef<HTMLButtonElement>();
-      const screen = await render(
+      const screen = await renderWithProviders(
         <MessageBar
           {...createProps()}
           slotProps={{ playButton: { ref, className: "play-button-slot" } }}
@@ -171,7 +186,7 @@ describe("MessageBar", () => {
     test("delegates play to onPlayClick while idle", async () => {
       const onPlayClick = vi.fn();
 
-      const screen = await render(
+      const screen = await renderWithProviders(
         <MessageBar {...createProps({ isPlaying: false, onPlayClick })} />,
       );
 
@@ -183,7 +198,7 @@ describe("MessageBar", () => {
     test("delegates stop to onStopClick while playing", async () => {
       const onStopClick = vi.fn();
 
-      const screen = await render(
+      const screen = await renderWithProviders(
         <MessageBar {...createProps({ isPlaying: true, onStopClick })} />,
       );
 

--- a/src/features/board/message/play-button.test.tsx
+++ b/src/features/board/message/play-button.test.tsx
@@ -1,7 +1,12 @@
-import { createRef } from "react";
+import { AppProviders } from "@shared/providers/app-providers";
+import { createRef, type ReactNode } from "react";
 import { describe, expect, test, vi } from "vitest";
 import { render } from "vitest-browser-react";
 import { PlayButton } from "./play-button";
+
+function renderWithProviders(children: ReactNode) {
+  return render(<AppProviders>{children}</AppProviders>);
+}
 
 function createHandlers() {
   return {
@@ -14,7 +19,7 @@ describe("PlayButton", () => {
   test("forwards root element props and refs", async () => {
     const handlers = createHandlers();
     const ref = createRef<HTMLButtonElement>();
-    const screen = await render(
+    const screen = await renderWithProviders(
       <PlayButton
         {...handlers}
         ref={ref}
@@ -31,7 +36,9 @@ describe("PlayButton", () => {
   test("calls onPlayClick when clicked while not playing", async () => {
     const handlers = createHandlers();
 
-    const screen = await render(<PlayButton isPlaying={false} {...handlers} />);
+    const screen = await renderWithProviders(
+      <PlayButton isPlaying={false} {...handlers} />,
+    );
 
     const button = screen.getByRole("button", { name: "Play message" });
     await button.click();
@@ -43,7 +50,9 @@ describe("PlayButton", () => {
   test("calls onStopClick when clicked while playing", async () => {
     const handlers = createHandlers();
 
-    const screen = await render(<PlayButton isPlaying={true} {...handlers} />);
+    const screen = await renderWithProviders(
+      <PlayButton isPlaying={true} {...handlers} />,
+    );
 
     const button = screen.getByRole("button", { name: "Stop message" });
     await button.click();

--- a/src/features/board/message/play-button.tsx
+++ b/src/features/board/message/play-button.tsx
@@ -2,6 +2,7 @@ import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import StopIcon from "@mui/icons-material/Stop";
 import Fab, { type FabProps } from "@mui/material/Fab";
 import { m } from "@paraglide/messages.js";
+import { useTranslate } from "@shared/language/use-translate";
 import { mergeSx } from "@shared/theme/merge-sx";
 
 const iconSx = { fontSize: 32 };
@@ -26,7 +27,8 @@ export function PlayButton({
   sx,
   ...fabProps
 }: PlayButtonProps) {
-  const label = isPlaying ? m.messageStop() : m.messagePlay();
+  const t = useTranslate();
+  const label = isPlaying ? t(m.messageStop) : t(m.messagePlay);
 
   return (
     <Fab

--- a/src/features/board/navigation/board-selector.tsx
+++ b/src/features/board/navigation/board-selector.tsx
@@ -1,11 +1,13 @@
 import Autocomplete from "@mui/material/Autocomplete";
 import TextField from "@mui/material/TextField";
 import { m } from "@paraglide/messages.js";
+import { useTranslate } from "@shared/language/use-translate";
 import { useState } from "react";
 import { useBoardNavigation } from "./use-board-navigation";
 import { useBoardsInSet } from "./use-boards-in-set";
 
 export function BoardSelector() {
+  const t = useTranslate();
   const { setId, boardId, goToBoard } = useBoardNavigation();
   const { boards } = useBoardsInSet({ setId });
   const [inputValue, setInputValue] = useState("");
@@ -47,7 +49,7 @@ export function BoardSelector() {
             },
             htmlInput: {
               ...params.slotProps?.htmlInput,
-              "aria-label": m.board(),
+              "aria-label": t(m.board),
             },
           }}
         />

--- a/src/features/board/navigation/nav-buttons.test.tsx
+++ b/src/features/board/navigation/nav-buttons.test.tsx
@@ -2,6 +2,7 @@ import {
   createTheme,
   ThemeProvider as MUIThemeProvider,
 } from "@mui/material/styles";
+import { AppProviders } from "@shared/providers/app-providers";
 import { createRef } from "react";
 import { createMemoryRouter, type InitialEntry } from "react-router";
 import { RouterProvider } from "react-router/dom";
@@ -40,9 +41,11 @@ async function renderAt(
   );
 
   const screen = await render(
-    <MUIThemeProvider theme={theme}>
-      <RouterProvider router={router} />
-    </MUIThemeProvider>,
+    <AppProviders>
+      <MUIThemeProvider theme={theme}>
+        <RouterProvider router={router} />
+      </MUIThemeProvider>
+    </AppProviders>,
   );
 
   return { router, screen };

--- a/src/features/board/navigation/nav-buttons.tsx
+++ b/src/features/board/navigation/nav-buttons.tsx
@@ -3,6 +3,7 @@ import HomeOutlinedIcon from "@mui/icons-material/HomeOutlined";
 import Box from "@mui/material/Box";
 import Button, { type ButtonProps } from "@mui/material/Button";
 import { m } from "@paraglide/messages.js";
+import { useTranslate } from "@shared/language/use-translate";
 import { mergeSx } from "@shared/theme/merge-sx";
 import { flipForRtl } from "@shared/theme/rtl";
 import { useBoardNavigation } from "./use-board-navigation";
@@ -34,6 +35,7 @@ export function NavButtons({
   onBackClick,
   onHomeClick,
 }: NavButtonsProps = {}) {
+  const t = useTranslate();
   const { setId, canGoBack, canGoHome, isHome, goBack, goHome } =
     useBoardNavigation();
   const { sx: backButtonSx, ...backButtonProps } = slotProps?.backButton ?? {};
@@ -57,7 +59,7 @@ export function NavButtons({
     <Box sx={{ display: "flex", gap: 1 }}>
       <Button
         {...backButtonProps}
-        aria-label={m.navBack()}
+        aria-label={t(m.navBack)}
         size="large"
         color="inherit"
         disabled={!canGoBack}
@@ -70,7 +72,7 @@ export function NavButtons({
 
       <Button
         {...homeButtonProps}
-        aria-label={m.navHome()}
+        aria-label={t(m.navHome)}
         size="large"
         color="inherit"
         disabled={!canGoHome || (isHome && !onHomeClick)}

--- a/src/features/board/navigation/use-boards-in-set.ts
+++ b/src/features/board/navigation/use-boards-in-set.ts
@@ -1,7 +1,7 @@
 import { useLatestAsync } from "@shared/hooks/use-latest-async";
 import { useLanguage } from "@shared/language/use-language";
-import { findTranslations } from "../translation/board-strings";
 import { listBoards } from "../storage/boards-db";
+import { findTranslations } from "../translation/board-strings";
 
 interface UseBoardsInSetOptions {
   setId: string | undefined;
@@ -21,7 +21,7 @@ interface UseBoardsInSetReturn {
 export function useBoardsInSet({
   setId,
 }: UseBoardsInSetOptions): UseBoardsInSetReturn {
-  const { language } = useLanguage();
+  const { communicationLanguage: language } = useLanguage();
   const { value, error, isPending } = useLatestAsync({
     enabled: setId !== undefined,
     deps: [setId ?? ""],

--- a/src/features/board/suggestions/suggestion-bar.test.tsx
+++ b/src/features/board/suggestions/suggestion-bar.test.tsx
@@ -1,7 +1,13 @@
+import { AppProviders } from "@shared/providers/app-providers";
 import { expectNoA11yViolations } from "@shared/testing/axe";
+import type { ReactNode } from "react";
 import { describe, expect, test, vi } from "vitest";
 import { render } from "vitest-browser-react";
 import { SuggestionBar, type SuggestionBarProps } from "./suggestion-bar";
+
+function renderWithProviders(children: ReactNode) {
+  return render(<AppProviders>{children}</AppProviders>);
+}
 
 function makeProps(
   overrides: Partial<SuggestionBarProps> = {},
@@ -19,7 +25,9 @@ describe("SuggestionBar", () => {
   test("renders a chip for each phrase", async () => {
     const phrases = ["Hello", "How are you?", "Thank you"];
 
-    const screen = await render(<SuggestionBar {...makeProps({ phrases })} />);
+    const screen = await renderWithProviders(
+      <SuggestionBar {...makeProps({ phrases })} />,
+    );
 
     for (const phrase of phrases) {
       await expect
@@ -30,7 +38,7 @@ describe("SuggestionBar", () => {
 
   test("calls onPhraseClick with the correct value when a phrase chip is clicked", async () => {
     const props = makeProps({ phrases: ["Hello", "Goodbye"] });
-    const screen = await render(<SuggestionBar {...props} />);
+    const screen = await renderWithProviders(<SuggestionBar {...props} />);
 
     await screen.getByRole("button", { name: "Hello" }).click();
 
@@ -45,7 +53,7 @@ describe("SuggestionBar", () => {
 
   test("offers an enable chip when activation is needed", async () => {
     const props = makeProps({ status: { kind: "needs-activation" } });
-    const screen = await render(<SuggestionBar {...props} />);
+    const screen = await renderWithProviders(<SuggestionBar {...props} />);
 
     await screen.getByRole("button", { name: "Enable suggestions" }).click();
 
@@ -53,7 +61,7 @@ describe("SuggestionBar", () => {
   });
 
   test("shows download progress while the model downloads", async () => {
-    const screen = await render(
+    const screen = await renderWithProviders(
       <SuggestionBar
         {...makeProps({ status: { kind: "downloading", percent: 43 } })}
       />,
@@ -65,7 +73,7 @@ describe("SuggestionBar", () => {
   });
 
   test("shows a percentless download message while progress is unknown", async () => {
-    const screen = await render(
+    const screen = await renderWithProviders(
       <SuggestionBar
         {...makeProps({ status: { kind: "downloading", percent: null } })}
       />,
@@ -77,7 +85,7 @@ describe("SuggestionBar", () => {
   });
 
   test("announces unavailability after a failed request", async () => {
-    const screen = await render(
+    const screen = await renderWithProviders(
       <SuggestionBar {...makeProps({ status: { kind: "unavailable" } })} />,
     );
 
@@ -89,7 +97,7 @@ describe("SuggestionBar", () => {
   });
 
   test("has no accessibility violations", async () => {
-    const screen = await render(
+    const screen = await renderWithProviders(
       <SuggestionBar
         {...makeProps({ phrases: ["Hello", "How are you?", "Thank you"] })}
       />,

--- a/src/features/board/suggestions/suggestion-status.tsx
+++ b/src/features/board/suggestions/suggestion-status.tsx
@@ -2,6 +2,7 @@ import AutoAwesomeIcon from "@mui/icons-material/AutoAwesome";
 import Chip, { type ChipProps } from "@mui/material/Chip";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
+import { useTranslate } from "@shared/language/use-translate";
 import type { SuggestionStatusView } from "./derive-suggestion-status";
 
 interface SuggestionStatusProps {
@@ -20,6 +21,8 @@ export function SuggestionStatus({
   enableButtonProps,
   onEnable,
 }: SuggestionStatusProps) {
+  const t = useTranslate();
+
   if (status === null || status.kind === "pending") {
     return null;
   }
@@ -30,7 +33,7 @@ export function SuggestionStatus({
         <Chip
           {...enableButtonProps}
           icon={<AutoAwesomeIcon />}
-          label={m.suggestionsEnable()}
+          label={t(m.suggestionsEnable)}
           color="primary"
           variant="outlined"
           onClick={onEnable}
@@ -40,14 +43,14 @@ export function SuggestionStatus({
       return (
         <Typography variant="body2" sx={{ color: "text.secondary" }}>
           {status.percent === null
-            ? m.suggestionsDownloadingIndeterminate()
-            : m.suggestionsDownloading({ progress: status.percent })}
+            ? t(m.suggestionsDownloadingIndeterminate)
+            : t(m.suggestionsDownloading, { progress: status.percent })}
         </Typography>
       );
     case "unavailable":
       return (
         <Typography variant="body2" sx={{ color: "text.secondary" }}>
-          {m.suggestionsUnavailable()}
+          {t(m.suggestionsUnavailable)}
         </Typography>
       );
     default:

--- a/src/features/board/suggestions/use-message-suggestions.ts
+++ b/src/features/board/suggestions/use-message-suggestions.ts
@@ -26,7 +26,7 @@ export function useMessageSuggestions(text: string): MessageSuggestions {
     SHARED_CONTEXT_DEBOUNCE_MS,
   );
 
-  const { language } = useLanguage();
+  const { communicationLanguage: language } = useLanguage();
 
   const proofreading = useProofreadSuggestion(text, language);
   const sameToneRewrite = useRewriteSuggestion({

--- a/src/features/board/use-board-scanning.ts
+++ b/src/features/board/use-board-scanning.ts
@@ -1,4 +1,5 @@
 import { m } from "@paraglide/messages.js";
+import { useTranslate } from "@shared/language/use-translate";
 import {
   type ScanTargetProps,
   useScanTarget,
@@ -37,33 +38,34 @@ export function useBoardScanning({
   navigation,
   suggestions,
 }: UseBoardScanningOptions): UseBoardScanningReturn {
+  const t = useTranslate();
   const playTarget = useScanTarget({
     id: PLAY_SCAN_ID,
-    label: isPlaying ? m.messageStop() : m.messagePlay(),
+    label: isPlaying ? t(m.messageStop) : t(m.messagePlay),
     disabled: !hasMessage,
   });
 
   const backTarget = useScanTarget({
     id: BACK_SCAN_ID,
-    label: m.navBack(),
+    label: t(m.navBack),
     disabled: !navigation.canGoBack,
   });
 
   const homeTarget = useScanTarget({
     id: HOME_SCAN_ID,
-    label: m.navHome(),
+    label: t(m.navHome),
     disabled: !navigation.canGoHome,
   });
 
   const suggestionsEnableTarget = useScanTarget({
     id: SUGGESTIONS_ENABLE_SCAN_ID,
-    label: m.suggestionsEnable(),
+    label: t(m.suggestionsEnable),
     disabled: !suggestions.needsActivation,
   });
 
   const backspaceTarget = useScanTarget({
     id: BACKSPACE_SCAN_ID,
-    label: m.messageBackspace(),
+    label: t(m.messageBackspace),
     disabled: !hasMessage,
   });
 

--- a/src/shared/components/external-link.tsx
+++ b/src/shared/components/external-link.tsx
@@ -1,10 +1,13 @@
 import Link, { type LinkProps } from "@mui/material/Link";
 import visuallyHidden from "@mui/utils/visuallyHidden";
 import { m } from "@paraglide/messages.js";
+import { useTranslate } from "@shared/language/use-translate";
 
 type ExternalLinkProps = Omit<LinkProps, "target" | "rel">;
 
 export function ExternalLink({ children, ...props }: ExternalLinkProps) {
+  const t = useTranslate();
+
   return (
     <Link
       {...props}
@@ -14,7 +17,7 @@ export function ExternalLink({ children, ...props }: ExternalLinkProps) {
       sx={{ whiteSpace: "nowrap" }}
     >
       {children}
-      <span style={visuallyHidden}> {m.opensInNewTab()}</span>
+      <span style={visuallyHidden}> {t(m.opensInNewTab)}</span>
     </Link>
   );
 }

--- a/src/shared/components/loading-state.tsx
+++ b/src/shared/components/loading-state.tsx
@@ -3,12 +3,16 @@ import Fade from "@mui/material/Fade";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
+import { useTranslate } from "@shared/language/use-translate";
 
 interface LoadingStateProps {
   message?: string;
 }
 
-export function LoadingState({ message = m.loading() }: LoadingStateProps) {
+export function LoadingState({ message }: LoadingStateProps) {
+  const t = useTranslate();
+  const resolvedMessage = message ?? t(m.loading);
+
   return (
     <Fade in timeout={400} style={{ transitionDelay: "300ms" }}>
       <Stack
@@ -20,7 +24,9 @@ export function LoadingState({ message = m.loading() }: LoadingStateProps) {
         }}
       >
         <CircularProgress />
-        {message && <Typography color="text.secondary">{message}</Typography>}
+        {resolvedMessage && (
+          <Typography color="text.secondary">{resolvedMessage}</Typography>
+        )}
       </Stack>
     </Fade>
   );

--- a/src/shared/language/language-context.ts
+++ b/src/shared/language/language-context.ts
@@ -1,8 +1,10 @@
+import type { Locale } from "@paraglide/runtime";
 import { createContext } from "react";
 
 export interface LanguageContextValue {
-  language: string;
-  setLanguage: (language: string) => void;
+  communicationLanguage: string;
+  setCommunicationLanguage: (language: string) => void;
+  uiLocale: Locale;
   languages: { code: string; name: string }[];
   direction: "ltr" | "rtl";
 }

--- a/src/shared/language/language-provider.tsx
+++ b/src/shared/language/language-provider.tsx
@@ -1,9 +1,12 @@
-import { baseLocale, isLocale, setLocale } from "@paraglide/runtime";
 import { useVoiceLanguageSync } from "@shared/speech/use-voice-language-sync";
 import { getTextDirection } from "@shared/utils/locale";
 import { useLayoutEffect, type ReactNode } from "react";
 import { LanguageContext, type LanguageContextValue } from "./language-context";
-import { setStoredLanguage, useStoredLanguage } from "./language-store";
+import {
+  resolveUiLocale,
+  setStoredLanguage,
+  useStoredLanguage,
+} from "./language-store";
 import { useAvailableLanguages } from "./use-available-languages";
 
 interface LanguageProviderProps {
@@ -11,23 +14,22 @@ interface LanguageProviderProps {
 }
 
 export function LanguageProvider({ children }: LanguageProviderProps) {
-  const language = useStoredLanguage();
+  const communicationLanguage = useStoredLanguage();
+  const uiLocale = resolveUiLocale(communicationLanguage);
   const languages = useAvailableLanguages();
-  const direction = getTextDirection(language);
-
-  // Sync Paraglide locale during render so children see translated strings on first paint.
-  void setLocale(isLocale(language) ? language : baseLocale, { reload: false });
+  const direction = getTextDirection(communicationLanguage);
 
   useLayoutEffect(() => {
     document.documentElement.dir = direction;
-    document.documentElement.lang = language;
-  }, [direction, language]);
+    document.documentElement.lang = communicationLanguage;
+  }, [communicationLanguage, direction]);
 
-  useVoiceLanguageSync({ language });
+  useVoiceLanguageSync({ language: communicationLanguage });
 
   const contextValue: LanguageContextValue = {
-    language,
-    setLanguage: setStoredLanguage,
+    communicationLanguage,
+    setCommunicationLanguage: setStoredLanguage,
+    uiLocale,
     languages,
     direction,
   };

--- a/src/shared/language/language-store.test.ts
+++ b/src/shared/language/language-store.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, test } from "vitest";
 import {
   DEFAULT_LANGUAGE,
-  getStoredLanguage,
   getPreferredLanguage,
+  getStoredLanguage,
+  getUiLocale,
   parseStoredLanguage,
+  resolveUiLocale,
   setStoredLanguage,
 } from "./language-store";
 
@@ -42,5 +44,13 @@ describe("language store", () => {
     setStoredLanguage("fr");
 
     expect(getStoredLanguage()).toBe("fr");
+  });
+
+  test("derives a translated UI locale from the communication language", () => {
+    expect(resolveUiLocale("he")).toBe("he");
+    expect(resolveUiLocale("ca")).toBe(DEFAULT_LANGUAGE);
+
+    setStoredLanguage("bn");
+    expect(getUiLocale()).toBe("bn");
   });
 });

--- a/src/shared/language/language-store.ts
+++ b/src/shared/language/language-store.ts
@@ -1,4 +1,10 @@
-import { baseLocale, isLocale } from "@paraglide/runtime";
+import {
+  baseLocale,
+  isLocale,
+  overwriteGetLocale,
+  overwriteSetLocale,
+  type Locale,
+} from "@paraglide/runtime";
 import { getLanguageCode } from "@shared/utils/locale";
 import { createPersistedStore } from "@shared/utils/persisted-store";
 import { useSyncExternalStore } from "react";
@@ -28,6 +34,10 @@ const store = createPersistedStore<string>(
   parseStoredLanguage,
 );
 
+export function resolveUiLocale(language: string): Locale {
+  return isLocale(language) ? language : baseLocale;
+}
+
 export function getStoredLanguage(): string {
   return store.getSnapshot();
 }
@@ -39,3 +49,16 @@ export function setStoredLanguage(language: string): void {
 export function useStoredLanguage(): string {
   return useSyncExternalStore(store.subscribe, store.getSnapshot);
 }
+
+export function getUiLocale(): Locale {
+  return resolveUiLocale(getStoredLanguage());
+}
+
+export function useUiLocale(): Locale {
+  return resolveUiLocale(useStoredLanguage());
+}
+
+// The communication language store is the app's locale authority. Paraglide
+// delegates to it so message functions and React always observe one snapshot.
+overwriteGetLocale(getUiLocale);
+overwriteSetLocale((locale) => setStoredLanguage(locale));

--- a/src/shared/language/use-translate.ts
+++ b/src/shared/language/use-translate.ts
@@ -1,0 +1,29 @@
+import type { Locale, LocalizedString } from "@paraglide/runtime";
+import { useLanguage } from "./use-language";
+
+interface MessageOptions {
+  locale?: Locale;
+}
+
+type Message<Inputs extends object> = (
+  inputs: Inputs,
+  options?: MessageOptions,
+) => LocalizedString;
+
+type MessageInputs<Inputs extends object> = keyof Inputs extends never
+  ? [inputs?: Inputs]
+  : [inputs: Inputs];
+
+export type Translate = <Inputs extends object>(
+  message: Message<Inputs>,
+  ...inputs: MessageInputs<Inputs>
+) => LocalizedString;
+
+export function useTranslate(): Translate {
+  const { uiLocale } = useLanguage();
+
+  return <Inputs extends object>(
+    message: Message<Inputs>,
+    ...inputs: MessageInputs<Inputs>
+  ) => message(inputs[0] ?? ({} as Inputs), { locale: uiLocale });
+}

--- a/src/shared/snackbar/snackbar-context.ts
+++ b/src/shared/snackbar/snackbar-context.ts
@@ -1,9 +1,11 @@
+import type { Translate } from "@shared/language/use-translate";
 import { createContext, type ReactNode } from "react";
 
 export type SnackbarSeverity = "success" | "error" | "info" | "warning";
+export type SnackbarMessage = string | ((translate: Translate) => string);
 
 export interface SnackbarOptions {
-  message: string;
+  message: SnackbarMessage;
   severity?: SnackbarSeverity;
   duration?: number;
   action?: ReactNode;

--- a/src/shared/snackbar/snackbar-provider.test.tsx
+++ b/src/shared/snackbar/snackbar-provider.test.tsx
@@ -1,3 +1,5 @@
+import { m } from "@paraglide/messages.js";
+import { setStoredLanguage } from "@shared/language/language-store";
 import { AppProviders } from "@shared/providers/app-providers";
 import { expectNoA11yViolations } from "@shared/testing/axe";
 import { describe, expect, test, vi } from "vitest";
@@ -22,6 +24,7 @@ function ShowButtons({
           {name}
         </button>
       ))}
+      <button onClick={() => setStoredLanguage("he")}>switch-to-hebrew</button>
       <button>outside</button>
     </>
   );
@@ -86,5 +89,24 @@ describe("SnackbarProvider", () => {
     });
 
     await expectNoA11yViolations(document.body);
+  });
+
+  test("retranslates a visible localized message when the locale changes", async () => {
+    const screen = await renderSnackbars({
+      "show-imported": {
+        message: (t) => t(m.libraryImportedBoards, { count: 1 }),
+        duration: LONG_DURATION,
+      },
+    });
+
+    await screen.getByRole("button", { name: "show-imported" }).click();
+    await expect
+      .element(screen.getByRole("alert"))
+      .toHaveTextContent("Board imported");
+
+    await screen.getByRole("button", { name: "switch-to-hebrew" }).click();
+    await expect
+      .element(screen.getByRole("alert"))
+      .toHaveTextContent("הלוח יובא בהצלחה");
   });
 });

--- a/src/shared/snackbar/snackbar-provider.tsx
+++ b/src/shared/snackbar/snackbar-provider.tsx
@@ -1,6 +1,7 @@
 import Alert from "@mui/material/Alert";
 import Snackbar, { type SnackbarCloseReason } from "@mui/material/Snackbar";
 import useMediaQuery from "@mui/material/useMediaQuery";
+import { useTranslate } from "@shared/language/use-translate";
 import { type ReactNode, useReducer, useRef } from "react";
 import {
   SnackbarContext,
@@ -37,6 +38,7 @@ interface SnackbarProviderProps {
 }
 
 export function SnackbarProvider({ children }: SnackbarProviderProps) {
+  const t = useTranslate();
   const [state, dispatch] = useReducer(snackbarReducer, initialState);
   const nextKeyRef = useRef(0);
   const isSmallScreen = useMediaQuery((theme) => theme.breakpoints.down("sm"));
@@ -70,6 +72,10 @@ export function SnackbarProvider({ children }: SnackbarProviderProps) {
   const contextValue: SnackbarContextValue = {
     showSnackbar,
   };
+  const message =
+    typeof state.current?.message === "function"
+      ? state.current.message(t)
+      : state.current?.message;
 
   return (
     <SnackbarContext value={contextValue}>
@@ -92,7 +98,7 @@ export function SnackbarProvider({ children }: SnackbarProviderProps) {
           onClose={handleClose}
           sx={{ width: "100%" }}
         >
-          {state.current?.message}
+          {message}
         </Alert>
       </Snackbar>
     </SnackbarContext>


### PR DESCRIPTION
## Summary

- connect Paraglide locale access to the persisted reactive language store
- add a typed `useTranslate` API and migrate mounted UI translation calls
- keep queued snackbars and loader errors locale-independent so they retranslate while visible
- update shell language/direction behavior and keep speech selection valid across language changes
- add browser coverage for English → Bengali → Hebrew without remounting

## Root cause

Changing Paraglide's global locale updated imperative message lookups, but React components calling generated messages did not subscribe to language state. Mounted shell controls and drawers therefore retained strings from their previous render. Pretranslated asynchronous messages could also become stale while queued or displayed.

## Impact

Language changes now update the board, mounted application shell, open settings drawer, queued notifications, and route errors immediately. The implementation does not force a root remount, preserving focus and other interaction state important to AAC users.

## Validation

- `npm run lint`
- `npm test` — 559 tests across 78 files
- `npm run build`
