### PR TITLE
refactor: simplify language context API

### DIFF
--- a/src/app/routing/use-revalidate-on-language-change.ts
+++ b/src/app/routing/use-revalidate-on-language-change.ts
@@ -5,7 +5,7 @@ import { useRevalidator } from "react-router";
 // Board translations are resolved in the route loader, so a language change must
 // re-run the loaders to re-translate the board currently on screen.
 export function useRevalidateOnLanguageChange(): void {
-  const { communicationLanguage: language } = useLanguage();
+  const { language } = useLanguage();
   const { revalidate } = useRevalidator();
   const previousLanguage = useRef(language);
 

--- a/src/app/settings/language-settings.tsx
+++ b/src/app/settings/language-settings.tsx
@@ -8,6 +8,7 @@ import Select from "@mui/material/Select";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
+import { useAvailableLanguages } from "@shared/language/use-available-languages";
 import { useLanguage } from "@shared/language/use-language";
 import { useTranslate } from "@shared/language/use-translate";
 import {
@@ -17,8 +18,8 @@ import {
 
 export function LanguageSettings() {
   const t = useTranslate();
-  const { languages, communicationLanguage, setCommunicationLanguage } =
-    useLanguage();
+  const { language, setLanguage } = useLanguage();
+  const availableLanguages = useAvailableLanguages();
   const progress = useGlobalDownloadProgress("Translator");
   const isTranslationSupported = isSupported("Translator");
 
@@ -31,10 +32,10 @@ export function LanguageSettings() {
           label={t(m.languageLabel)}
           labelId="language-select-label"
           id="language-select"
-          value={communicationLanguage}
-          onChange={(event) => setCommunicationLanguage(event.target.value)}
+          value={language}
+          onChange={(event) => setLanguage(event.target.value)}
         >
-          {languages.map(({ code, name }) => (
+          {availableLanguages.map(({ code, name }) => (
             <MenuItem key={code} value={code}>
               {name}
             </MenuItem>

--- a/src/app/settings/speech-settings.tsx
+++ b/src/app/settings/speech-settings.tsx
@@ -36,7 +36,7 @@ export function SpeechSettings() {
   const { voiceURI, rate, pitch, volume } = useSpeechConfig();
   const { highlightActivePart } = useHighlightConfig();
 
-  const { communicationLanguage: language } = useLanguage();
+  const { language } = useLanguage();
 
   const voices = voicesByLanguage[language] ?? [];
   const voicesByLocale = Object.groupBy(voices, (voice) => voice.lang);

--- a/src/app/settings/switch-scanning-settings.tsx
+++ b/src/app/settings/switch-scanning-settings.tsx
@@ -57,7 +57,7 @@ function getMethodDescription(
 
 export function SwitchScanningSettings() {
   const t = useTranslate();
-  const { communicationLanguage: language } = useLanguage();
+  const { language } = useLanguage();
   const config = useSwitchScanningConfig();
   const {
     enabled,

--- a/src/features/board/navigation/use-boards-in-set.ts
+++ b/src/features/board/navigation/use-boards-in-set.ts
@@ -21,7 +21,7 @@ interface UseBoardsInSetReturn {
 export function useBoardsInSet({
   setId,
 }: UseBoardsInSetOptions): UseBoardsInSetReturn {
-  const { communicationLanguage: language } = useLanguage();
+  const { language } = useLanguage();
   const { value, error, isPending } = useLatestAsync({
     enabled: setId !== undefined,
     deps: [setId ?? ""],

--- a/src/features/board/suggestions/use-message-suggestions.ts
+++ b/src/features/board/suggestions/use-message-suggestions.ts
@@ -26,7 +26,7 @@ export function useMessageSuggestions(text: string): MessageSuggestions {
     SHARED_CONTEXT_DEBOUNCE_MS,
   );
 
-  const { communicationLanguage: language } = useLanguage();
+  const { language } = useLanguage();
 
   const proofreading = useProofreadSuggestion(text, language);
   const sameToneRewrite = useRewriteSuggestion({

--- a/src/shared/language/language-context.ts
+++ b/src/shared/language/language-context.ts
@@ -1,12 +1,9 @@
-import type { Locale } from "@paraglide/runtime";
 import { createContext } from "react";
 
-export interface LanguageContextValue {
-  communicationLanguage: string;
-  setCommunicationLanguage: (language: string) => void;
-  uiLocale: Locale;
-  languages: { code: string; name: string }[];
-  direction: "ltr" | "rtl";
+interface LanguageContextValue {
+  readonly language: string;
+  readonly direction: "ltr" | "rtl";
+  setLanguage: (language: string) => void;
 }
 
 export const LanguageContext = createContext<LanguageContextValue | null>(null);

--- a/src/shared/language/language-provider.tsx
+++ b/src/shared/language/language-provider.tsx
@@ -1,36 +1,27 @@
 import { useVoiceLanguageSync } from "@shared/speech/use-voice-language-sync";
 import { getTextDirection } from "@shared/utils/locale";
 import { useLayoutEffect, type ReactNode } from "react";
-import { LanguageContext, type LanguageContextValue } from "./language-context";
-import {
-  resolveUiLocale,
-  setStoredLanguage,
-  useStoredLanguage,
-} from "./language-store";
-import { useAvailableLanguages } from "./use-available-languages";
+import { LanguageContext } from "./language-context";
+import { setStoredLanguage, useStoredLanguage } from "./language-store";
 
 interface LanguageProviderProps {
   children: ReactNode;
 }
 
 export function LanguageProvider({ children }: LanguageProviderProps) {
-  const communicationLanguage = useStoredLanguage();
-  const uiLocale = resolveUiLocale(communicationLanguage);
-  const languages = useAvailableLanguages();
-  const direction = getTextDirection(communicationLanguage);
+  const language = useStoredLanguage();
+  const direction = getTextDirection(language);
 
   useLayoutEffect(() => {
     document.documentElement.dir = direction;
-    document.documentElement.lang = communicationLanguage;
-  }, [communicationLanguage, direction]);
+    document.documentElement.lang = language;
+  }, [direction, language]);
 
-  useVoiceLanguageSync({ language: communicationLanguage });
+  useVoiceLanguageSync({ language });
 
-  const contextValue: LanguageContextValue = {
-    communicationLanguage,
-    setCommunicationLanguage: setStoredLanguage,
-    uiLocale,
-    languages,
+  const contextValue = {
+    language,
+    setLanguage: setStoredLanguage,
     direction,
   };
 

--- a/src/shared/language/use-language.ts
+++ b/src/shared/language/use-language.ts
@@ -1,7 +1,7 @@
 import { use } from "react";
-import { LanguageContext, type LanguageContextValue } from "./language-context";
+import { LanguageContext } from "./language-context";
 
-export function useLanguage(): LanguageContextValue {
+export function useLanguage() {
   const context = use(LanguageContext);
 
   if (!context) {

--- a/src/shared/language/use-translate.ts
+++ b/src/shared/language/use-translate.ts
@@ -1,5 +1,5 @@
 import type { Locale, LocalizedString } from "@paraglide/runtime";
-import { useLanguage } from "./use-language";
+import { useUiLocale } from "./language-store";
 
 interface MessageOptions {
   locale?: Locale;
@@ -20,7 +20,7 @@ export type Translate = <Inputs extends object>(
 ) => LocalizedString;
 
 export function useTranslate(): Translate {
-  const { uiLocale } = useLanguage();
+  const uiLocale = useUiLocale();
 
   return <Inputs extends object>(
     message: Message<Inputs>,


### PR DESCRIPTION
## Summary

- expose only the selected language, setter, and text direction through the language context
- derive the fallback UI locale inside `useTranslate()`
- discover selectable languages only in the language settings UI
- simplify consumers from `communicationLanguage` aliases to `language`

## Why

The app intentionally uses one selected language for UI text, board content, direction, and speech. The context was also exposing two derived implementation details: the Paraglide UI fallback locale and the voice-driven language option list. Keeping those details with their consumers makes the API smaller and preserves the documented one-language model.

This is an internal refactor with no user-facing behavior change.

## Validation

- `npm run lint`
- `npm test` — 559 tests passed across 78 files
- `npm run build`
