### PR TITLE
Refactor message domain boundaries

### DIFF
--- a/src/features/board/activation/button-activation.test.ts
+++ b/src/features/board/activation/button-activation.test.ts
@@ -1,50 +1,35 @@
 import { stubAudio } from "@shared/testing/stub-audio";
 import { stubSpeech } from "@shared/testing/stub-speech";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import type { UseMessagePlaybackReturn } from "../message/playback/use-message-playback";
-import type { MessagePart, UseMessageReturn } from "../message/use-message";
-import type { UseBoardNavigationReturn } from "../navigation/use-board-navigation";
+import type { MessagePart } from "../message/message-types";
 import type { BoardButton } from "../types";
 import { createButtonActivation } from "./button-activation";
 
-function createMessageStub(parts: MessagePart[] = []): UseMessageReturn {
+type ActivationOptions = Parameters<typeof createButtonActivation>[0];
+
+function createMessageStub(
+  parts: MessagePart[] = [],
+): ActivationOptions["message"] {
   return {
     parts,
-    text: parts.map((p) => p.label ?? "").join(" "),
-    setFromText: vi.fn(),
-    removeLastPart: vi.fn(),
     setParts: vi.fn(),
-    clear: vi.fn(),
   };
 }
 
-function createPlaybackStub(): UseMessagePlaybackReturn {
+function createPlaybackStub(): ActivationOptions["playback"] {
   return {
-    isPlaying: false,
-    activePartId: null,
     play: vi.fn(() => Promise.resolve()),
-    stop: vi.fn(),
   };
 }
 
-function createNavigationStub(): UseBoardNavigationReturn {
+function createNavigationStub(): ActivationOptions["navigation"] {
   return {
-    setId: "set-1",
-    boardId: "board-1",
-    canGoBack: false,
-    canGoHome: true,
-    isHome: false,
     goToBoard: vi.fn(),
-    goBack: vi.fn(),
     goHome: vi.fn(),
   };
 }
 
-interface SetupOptions {
-  message?: UseMessageReturn;
-  playback?: UseMessagePlaybackReturn;
-  navigation?: UseBoardNavigationReturn;
-}
+type SetupOptions = Partial<ActivationOptions>;
 
 function setup(opts: SetupOptions = {}) {
   const message = opts.message ?? createMessageStub();

--- a/src/features/board/activation/button-activation.ts
+++ b/src/features/board/activation/button-activation.ts
@@ -7,16 +7,28 @@ import {
   appendTextToLastPart,
   dropLastPart,
 } from "../message/message-transforms";
-import type { UseMessagePlaybackReturn } from "../message/playback/use-message-playback";
-import type { MessagePart, UseMessageReturn } from "../message/use-message";
-import type { UseBoardNavigationReturn } from "../navigation/use-board-navigation";
+import type { MessagePart } from "../message/message-types";
 import type { BoardButton } from "../types";
 import { resolveButtonIntents } from "./button-intent-resolver";
 
+interface ActivationMessage {
+  parts: MessagePart[];
+  setParts: (parts: MessagePart[]) => void;
+}
+
+interface ActivationPlayback {
+  play: (parts: MessagePart[]) => Promise<void>;
+}
+
+interface ActivationNavigation {
+  goToBoard: (targetBoardId: string) => void;
+  goHome: () => void;
+}
+
 interface ButtonActivationOptions {
-  message: Pick<UseMessageReturn, "parts" | "setParts">;
-  playback: Pick<UseMessagePlaybackReturn, "play">;
-  navigation: Pick<UseBoardNavigationReturn, "goToBoard" | "goHome">;
+  message: ActivationMessage;
+  playback: ActivationPlayback;
+  navigation: ActivationNavigation;
 }
 
 interface ButtonActivation {

--- a/src/features/board/activation/button-intent-resolver.ts
+++ b/src/features/board/activation/button-intent-resolver.ts
@@ -1,5 +1,5 @@
 import { getNavigationTargetId, getSpokenText } from "../button-readers";
-import type { MessagePartContent } from "../message/use-message";
+import type { MessagePartContent } from "../message/message-types";
 import type { BoardAction, BoardButton } from "../types";
 
 type ButtonIntent =

--- a/src/features/board/message/message-bar.test.tsx
+++ b/src/features/board/message/message-bar.test.tsx
@@ -11,7 +11,7 @@ import {
 } from "vitest";
 import { render } from "vitest-browser-react";
 import { MessageBar, type MessageBarProps } from "./message-bar";
-import type { MessagePart } from "./use-message";
+import type { MessagePart } from "./message-types";
 
 function renderWithProviders(children: ReactNode) {
   return render(<AppProviders>{children}</AppProviders>);

--- a/src/features/board/message/message-bar.tsx
+++ b/src/features/board/message/message-bar.tsx
@@ -2,7 +2,7 @@ import Stack from "@mui/material/Stack";
 import { useEffect, useRef } from "react";
 import { Pictogram } from "../pictogram/pictogram";
 import { PlayButton, type PlayButtonRootProps } from "./play-button";
-import type { MessagePart } from "./use-message";
+import type { MessagePart } from "./message-types";
 
 interface MessageBarSlotProps {
   playButton?: Omit<PlayButtonRootProps, "disabled">;

--- a/src/features/board/message/message-transforms.test.ts
+++ b/src/features/board/message/message-transforms.test.ts
@@ -5,7 +5,7 @@ import {
   appendTextToLastPart,
   dropLastPart,
 } from "./message-transforms";
-import type { MessagePart } from "./use-message";
+import type { MessagePart } from "./message-types";
 
 describe("appendPart", () => {
   test("appends a new part with a minted id", () => {

--- a/src/features/board/message/message-transforms.ts
+++ b/src/features/board/message/message-transforms.ts
@@ -1,5 +1,5 @@
 import { randomId } from "@shared/utils/random-id";
-import type { MessagePart, MessagePartContent } from "./use-message";
+import type { MessagePart, MessagePartContent } from "./message-types";
 
 export function createPart(content: MessagePartContent): MessagePart {
   return { ...content, id: randomId() };

--- a/src/features/board/message/message-types.ts
+++ b/src/features/board/message/message-types.ts
@@ -1,0 +1,12 @@
+export interface MessagePartContent {
+  label?: string;
+  vocalization?: string;
+  imageSrc?: string;
+  soundSrc?: string;
+}
+
+// Identity is ours, minted at creation — a button's id can't serve, since it isn't
+// unique across occurrences (same button added twice, or ids colliding across boards).
+export interface MessagePart extends MessagePartContent {
+  id: string;
+}

--- a/src/features/board/message/playback/plan-playback.test.ts
+++ b/src/features/board/message/playback/plan-playback.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import type { MessagePart } from "../use-message";
+import type { MessagePart } from "../message-types";
 import { planPlayback } from "./plan-playback";
 
 describe("planPlayback", () => {

--- a/src/features/board/message/playback/plan-playback.ts
+++ b/src/features/board/message/playback/plan-playback.ts
@@ -1,5 +1,5 @@
 import { getSpokenText } from "../../button-readers";
-import type { MessagePart } from "../use-message";
+import type { MessagePart } from "../message-types";
 import {
   createSpokenPartTracker,
   type SpokenPart,

--- a/src/features/board/message/playback/use-message-playback.test.ts
+++ b/src/features/board/message/playback/use-message-playback.test.ts
@@ -2,7 +2,7 @@ import { stubAudio } from "@shared/testing/stub-audio";
 import { stubSpeech } from "@shared/testing/stub-speech";
 import { beforeEach, describe, expect, test } from "vitest";
 import { renderHook } from "vitest-browser-react";
-import type { MessagePart } from "../use-message";
+import type { MessagePart } from "../message-types";
 import { useMessagePlayback } from "./use-message-playback";
 
 describe("useMessagePlayback", () => {

--- a/src/features/board/message/playback/use-message-playback.ts
+++ b/src/features/board/message/playback/use-message-playback.ts
@@ -2,7 +2,7 @@ import { playAudio } from "@shared/audio/play-audio";
 import { speak } from "@shared/speech/speak";
 import { assertNever } from "@shared/utils/assert-never";
 import { useRef, useState } from "react";
-import type { MessagePart } from "../use-message";
+import type { MessagePart } from "../message-types";
 import { planPlayback } from "./plan-playback";
 
 export interface UseMessagePlaybackReturn {

--- a/src/features/board/message/use-message.ts
+++ b/src/features/board/message/use-message.ts
@@ -1,15 +1,6 @@
 import { useState } from "react";
-import type { BoardButton } from "../types";
 import { createPart, dropLastPart } from "./message-transforms";
-
-export type MessagePartContent = Pick<
-  BoardButton,
-  "label" | "vocalization" | "imageSrc" | "soundSrc"
->;
-
-// Identity is ours, minted at creation — a button's id can't serve, since it isn't
-// unique across occurrences (same button added twice, or ids colliding across boards).
-export type MessagePart = { id: string } & MessagePartContent;
+import type { MessagePart } from "./message-types";
 
 export interface UseMessageReturn {
   parts: MessagePart[];


### PR DESCRIPTION
## Summary

- move `MessagePart` and `MessagePartContent` into a hook-independent message model
- define message content explicitly instead of deriving it from `BoardButton`
- make button activation declare the narrow message, playback, and navigation capabilities it consumes
- narrow activation test stubs to those domain capabilities

## Why

The message model lived in `use-message.ts`, forcing pure transforms and activation code to import vocabulary from a React hook. Because the hook also imports the transforms, this created the project's only source-level cycle and inverted the intended dependency direction.

This change makes the message model a leaf dependency and lets React hooks structurally adapt to the activation engine without wrapper objects.

## Impact

There is no intended user-facing behavior change. Internal imports of the message types now point to `message-types.ts`.

## Validation

- `npm run lint`
- `npm test` — 78 test files, 559 tests passed
- `npm run build`
