### PR TITLE
Fix consistency debt

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ edge://flags/#edge-llm-rewriter-api-for-phi-mini
 Requires Node.js 24+.
 
 ```bash
-git clone [https://github.com/shayc/aac-board-ai.git](https://github.com/shayc/aac-board-ai.git)
+git clone https://github.com/shayc/aac-board-ai.git
 cd aac-board-ai
 npm install && npm run dev
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -222,8 +222,9 @@ Rules that constrain every file but are visible in none — several are _absence
   appends a locale's entries to `obf.strings` after a translation resolves. The
   in-memory `Board` is still _derived on read_ via `obfToBoard`, so the mapping
   can evolve and any board can be re-derived losslessly.
-- **Board data reaches components only through route loaders** — never fetched in a
-  component effect. Data (and its translation) is ready before render.
+- **The active hydrated board reaches components through route loaders.** Its data
+  and translation are ready before render. Ancillary board summaries may be loaded
+  by feature hooks through the storage API.
 - **Built-in AI is reached only through `@shayc/react-built-in-ai`.** Support is
   detected by probing for the task-specific global — `isSupported(name)` is just
   `globalThis[name] != null` for `Proofreader`, `Rewriter`, `Translator` — never a
@@ -323,9 +324,10 @@ The known fragilities:
   in-app changes (like cached translations) cannot leave the device — export is the
   missing half of the "share via files" answer. No-sync is by design, but users
   will ask for it.
-- **The language list follows installed TTS voices.** A device with sparse voices
-  offers fewer languages than the UI is translated into — capability, not
-  translation, is the limit.
+- **Speech support varies by language and device.** The language list combines every
+  translated UI locale with languages exposed by installed TTS voices. Sparse voice
+  coverage does not hide translated UI languages, but it can leave some languages
+  without a matching speech voice.
 - **Deploy config is host-specific.** Static hosting is portable, but the current
   config is Netlify-only (`netlify.toml`).
 

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "تغيير",
   "switchScanningNextItemSwitch": "مفتاح العنصر التالي",
   "switchScanningScanSwitch": "مفتاح المسح",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "تجاهل الضغطات المتكررة",
   "switchScanningMinimumPressDuration": "الحد الأدنى لمدة الضغط",
   "switchScanningAssign": "اضغط على مفتاح للتعيين",
-  "switchScanningNextItem": "العنصر التالي",
   "switchScanningSelectSwitch": "مفتاح الاختيار",
   "switchScanningMouseInput": "زر الماوس {button}",
-  "switchScanningActions": "الإجراءات",
-  "switchScanningActionsExit": "العودة من الإجراءات",
   "switchScanningRow": "الصف {row}",
   "switchScanningRowExit": "العودة من الصف {row}",
   "loading": "جارٍ التحميل...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "تم استيراد اللوحة",
         "countPlural=*": "تم استيراد اللوحات"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "تم استبدال اللوحة",
-        "countPlural=*": "تم استبدال اللوحات"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "الوصول باستخدام المفتاح",
   "switchScanningEnabled": "تفعيل المسح بالمفتاح",
   "switchScanningMethod": "طريقة المسح",
-  "switchScanningOneSwitch": "مفتاح واحد",
-  "switchScanningTwoSwitches": "مفتاحان",
   "switchScanningMethodAuto": "تلقائي",
   "switchScanningMethodStep": "التنقل بمفتاحين",
   "switchScanningMethodDwell": "المكوث بمفتاح واحد",
@@ -165,8 +151,5 @@
   "errorGoHome": "الانتقال إلى الرئيسية",
   "errorBoardNotFound": "اللوحة غير موجودة",
   "errorBoardSetNotFound": "اللوحة غير موجودة",
-  "boardUrlReplaceConfirmTitle": "استبدال \"{name}\"؟",
-  "boardUrlReplaceConfirmDescription": "الاستيراد من {host} سيستبدل هذه اللوحة وكل ما فيها. لا يمكن التراجع عن هذا الإجراء.",
-  "boardUrlReplace": "استبدال",
   "boardUrlImportFailed": "تعذّر استيراد اللوحة من الرابط"
 }

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "Промяна",
   "switchScanningNextItemSwitch": "Превключвател за следващ елемент",
   "switchScanningScanSwitch": "Превключвател за сканиране",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "Игнориране на повторни натискания",
   "switchScanningMinimumPressDuration": "Минимална продължителност на натискане",
   "switchScanningAssign": "Натиснете превключвател за задаване",
-  "switchScanningNextItem": "Следващ елемент",
   "switchScanningSelectSwitch": "Превключвател за избиране",
   "switchScanningMouseInput": "Бутон на мишката {button}",
-  "switchScanningActions": "Действия",
-  "switchScanningActionsExit": "Назад от действията",
   "switchScanningRow": "Ред {row}",
   "switchScanningRowExit": "Назад от ред {row}",
   "loading": "Зареждане...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "Дъската е импортирана",
         "countPlural=*": "Дъските са импортирани"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Дъската е заменена",
-        "countPlural=*": "Дъските са заменени"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "Достъп с превключвател",
   "switchScanningEnabled": "Включване на сканирането с превключвател",
   "switchScanningMethod": "Метод на сканиране",
-  "switchScanningOneSwitch": "Един превключвател",
-  "switchScanningTwoSwitches": "Два превключвателя",
   "switchScanningMethodAuto": "Автоматично",
   "switchScanningMethodStep": "Стъпка с два превключвателя",
   "switchScanningMethodDwell": "Задържане с един превключвател",
@@ -165,8 +151,5 @@
   "errorGoHome": "Към началото",
   "errorBoardNotFound": "Дъската не е намерена",
   "errorBoardSetNotFound": "Дъската не е намерена",
-  "boardUrlReplaceConfirmTitle": "Да се замени ли „{name}“?",
-  "boardUrlReplaceConfirmDescription": "Импортирането от {host} ще замени тази дъска и всичко в нея. Това действие не може да бъде отменено.",
-  "boardUrlReplace": "Замяна",
   "boardUrlImportFailed": "Дъската не може да бъде импортирана от връзката"
 }

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "পরিবর্তন করুন",
   "switchScanningNextItemSwitch": "পরবর্তী আইটেমের সুইচ",
   "switchScanningScanSwitch": "স্ক্যান সুইচ",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "বারবার চাপ উপেক্ষা করুন",
   "switchScanningMinimumPressDuration": "সর্বনিম্ন চাপের সময়কাল",
   "switchScanningAssign": "বরাদ্দ করতে একটি সুইচ চাপুন",
-  "switchScanningNextItem": "পরবর্তী আইটেম",
   "switchScanningSelectSwitch": "নির্বাচনের সুইচ",
   "switchScanningMouseInput": "মাউস বোতাম {button}",
-  "switchScanningActions": "কাজসমূহ",
-  "switchScanningActionsExit": "কাজসমূহ থেকে ফিরে যান",
   "switchScanningRow": "সারি {row}",
   "switchScanningRowExit": "{row} নম্বর সারি থেকে ফিরে যান",
   "loading": "লোড হচ্ছে…",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "বোর্ড আমদানি করা হয়েছে",
         "countPlural=*": "বোর্ড আমদানি করা হয়েছে"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "বোর্ড প্রতিস্থাপিত হয়েছে",
-        "countPlural=*": "বোর্ড প্রতিস্থাপিত হয়েছে"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "সুইচ অ্যাক্সেস",
   "switchScanningEnabled": "সুইচ স্ক্যানিং চালু করুন",
   "switchScanningMethod": "স্ক্যান পদ্ধতি",
-  "switchScanningOneSwitch": "একটি সুইচ",
-  "switchScanningTwoSwitches": "দুটি সুইচ",
   "switchScanningMethodAuto": "স্বয়ংক্রিয়",
   "switchScanningMethodStep": "দুই-সুইচ ধাপ",
   "switchScanningMethodDwell": "এক-সুইচ অপেক্ষা",
@@ -165,8 +151,5 @@
   "errorGoHome": "হোমে যান",
   "errorBoardNotFound": "বোর্ড পাওয়া যায়নি",
   "errorBoardSetNotFound": "বোর্ড পাওয়া যায়নি",
-  "boardUrlReplaceConfirmTitle": "\"{name}\" প্রতিস্থাপন করবেন?",
-  "boardUrlReplaceConfirmDescription": "{host} থেকে আমদানি করলে এই বোর্ড এবং এর ভেতরের সবকিছু প্রতিস্থাপিত হবে। এই ক্রিয়াটি পূর্বাবস্থায় ফেরানো যাবে না।",
-  "boardUrlReplace": "প্রতিস্থাপন করুন",
   "boardUrlImportFailed": "লিঙ্ক থেকে বোর্ড আমদানি করা যায়নি"
 }

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "Změnit",
   "switchScanningNextItemSwitch": "Spínač další položky",
   "switchScanningScanSwitch": "Skenovací spínač",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "Ignorovat opakovaná stisknutí",
   "switchScanningMinimumPressDuration": "Minimální doba stisknutí",
   "switchScanningAssign": "Stisknutím spínače ho přiřaďte",
-  "switchScanningNextItem": "Další položka",
   "switchScanningSelectSwitch": "Spínač pro výběr",
   "switchScanningMouseInput": "Tlačítko myši {button}",
-  "switchScanningActions": "Akce",
-  "switchScanningActionsExit": "Zpět z akcí",
   "switchScanningRow": "Řádek {row}",
   "switchScanningRowExit": "Zpět z řádku {row}",
   "loading": "Načítání...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "Tabulka importována",
         "countPlural=*": "Tabulky importovány"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Tabulka nahrazena",
-        "countPlural=*": "Tabulky nahrazeny"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "Ovládání spínačem",
   "switchScanningEnabled": "Zapnout skenování spínačem",
   "switchScanningMethod": "Způsob skenování",
-  "switchScanningOneSwitch": "Jeden spínač",
-  "switchScanningTwoSwitches": "Dva spínače",
   "switchScanningMethodAuto": "Automatické",
   "switchScanningMethodStep": "Krokování dvěma spínači",
   "switchScanningMethodDwell": "Prodleva s jedním spínačem",
@@ -165,8 +151,5 @@
   "errorGoHome": "Přejít domů",
   "errorBoardNotFound": "Tabulka nebyla nalezena",
   "errorBoardSetNotFound": "Tabulka nebyla nalezena",
-  "boardUrlReplaceConfirmTitle": "Nahradit „{name}“?",
-  "boardUrlReplaceConfirmDescription": "Import z {host} nahradí tuto tabulku a vše v ní. Tuto akci nelze vrátit zpět.",
-  "boardUrlReplace": "Nahradit",
   "boardUrlImportFailed": "Tabulku se nepodařilo importovat z odkazu"
 }

--- a/messages/da.json
+++ b/messages/da.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "Skift",
   "switchScanningNextItemSwitch": "Kontakt til næste element",
   "switchScanningScanSwitch": "Scanningskontakt",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "Ignorer gentagne tryk",
   "switchScanningMinimumPressDuration": "Minimumvarighed for tryk",
   "switchScanningAssign": "Tryk på en kontakt for at tildele den",
-  "switchScanningNextItem": "Næste element",
   "switchScanningSelectSwitch": "Kontakt til valg",
   "switchScanningMouseInput": "Museknap {button}",
-  "switchScanningActions": "Handlinger",
-  "switchScanningActionsExit": "Tilbage fra handlinger",
   "switchScanningRow": "Række {row}",
   "switchScanningRowExit": "Tilbage fra række {row}",
   "loading": "Indlæser...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "Tavle importeret",
         "countPlural=*": "Tavler importeret"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Tavle erstattet",
-        "countPlural=*": "Tavler erstattet"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "Kontakttilgang",
   "switchScanningEnabled": "Slå kontaktscanning til",
   "switchScanningMethod": "Scanningsmetode",
-  "switchScanningOneSwitch": "Én kontakt",
-  "switchScanningTwoSwitches": "To kontakter",
   "switchScanningMethodAuto": "Automatisk",
   "switchScanningMethodStep": "Trin med to kontakter",
   "switchScanningMethodDwell": "Dvæletid med én kontakt",
@@ -165,8 +151,5 @@
   "errorGoHome": "Gå til start",
   "errorBoardNotFound": "Tavlen blev ikke fundet",
   "errorBoardSetNotFound": "Tavlen blev ikke fundet",
-  "boardUrlReplaceConfirmTitle": "Erstat \"{name}\"?",
-  "boardUrlReplaceConfirmDescription": "Import fra {host} erstatter denne tavle og alt i den. Denne handling kan ikke fortrydes.",
-  "boardUrlReplace": "Erstat",
   "boardUrlImportFailed": "Tavlen kunne ikke importeres fra linket"
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "Ändern",
   "switchScanningNextItemSwitch": "Schalter für nächstes Element",
   "switchScanningScanSwitch": "Scan-Schalter",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "Wiederholte Betätigungen ignorieren",
   "switchScanningMinimumPressDuration": "Mindestbetätigungsdauer",
   "switchScanningAssign": "Zum Zuweisen eine Taste drücken",
-  "switchScanningNextItem": "Nächstes Element",
   "switchScanningSelectSwitch": "Taste zum Auswählen",
   "switchScanningMouseInput": "Maustaste {button}",
-  "switchScanningActions": "Aktionen",
-  "switchScanningActionsExit": "Zurück von den Aktionen",
   "switchScanningRow": "Zeile {row}",
   "switchScanningRowExit": "Zurück aus Zeile {row}",
   "loading": "Wird geladen...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "Tafel importiert",
         "countPlural=*": "Tafeln importiert"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Tafel ersetzt",
-        "countPlural=*": "Tafeln ersetzt"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "Tastersteuerung",
   "switchScanningEnabled": "Tastenscanning aktivieren",
   "switchScanningMethod": "Scanmethode",
-  "switchScanningOneSwitch": "Eine Taste",
-  "switchScanningTwoSwitches": "Zwei Tasten",
   "switchScanningMethodAuto": "Automatisch",
   "switchScanningMethodStep": "Zwei-Tasten-Schritt",
   "switchScanningMethodDwell": "Ein-Tasten-Verweilen",
@@ -165,8 +151,5 @@
   "errorGoHome": "Zur Startseite",
   "errorBoardNotFound": "Tafel nicht gefunden",
   "errorBoardSetNotFound": "Tafel nicht gefunden",
-  "boardUrlReplaceConfirmTitle": "„{name}“ ersetzen?",
-  "boardUrlReplaceConfirmDescription": "Der Import von {host} ersetzt diese Tafel und alles darin. Diese Aktion kann nicht rückgängig gemacht werden.",
-  "boardUrlReplace": "Ersetzen",
   "boardUrlImportFailed": "Tafel konnte nicht über den Link importiert werden"
 }

--- a/messages/el.json
+++ b/messages/el.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "Αλλαγή",
   "switchScanningNextItemSwitch": "Διακόπτης επόμενου στοιχείου",
   "switchScanningScanSwitch": "Διακόπτης σάρωσης",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "Παράβλεψη επαναλαμβανόμενων πατημάτων",
   "switchScanningMinimumPressDuration": "Ελάχιστη διάρκεια πατήματος",
   "switchScanningAssign": "Πατήστε έναν διακόπτη για αντιστοίχιση",
-  "switchScanningNextItem": "Επόμενο στοιχείο",
   "switchScanningSelectSwitch": "Διακόπτης επιλογής",
   "switchScanningMouseInput": "Κουμπί ποντικιού {button}",
-  "switchScanningActions": "Ενέργειες",
-  "switchScanningActionsExit": "Πίσω από τις ενέργειες",
   "switchScanningRow": "Σειρά {row}",
   "switchScanningRowExit": "Πίσω από τη σειρά {row}",
   "loading": "Φόρτωση...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "Ο πίνακας εισήχθη",
         "countPlural=*": "Οι πίνακες εισήχθησαν"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Ο πίνακας αντικαταστάθηκε",
-        "countPlural=*": "Οι πίνακες αντικαταστάθηκαν"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "Πρόσβαση με διακόπτη",
   "switchScanningEnabled": "Ενεργοποίηση σάρωσης με διακόπτη",
   "switchScanningMethod": "Μέθοδος σάρωσης",
-  "switchScanningOneSwitch": "Ένας διακόπτης",
-  "switchScanningTwoSwitches": "Δύο διακόπτες",
   "switchScanningMethodAuto": "Αυτόματη",
   "switchScanningMethodStep": "Βήμα με δύο διακόπτες",
   "switchScanningMethodDwell": "Παραμονή με έναν διακόπτη",
@@ -165,8 +151,5 @@
   "errorGoHome": "Μετάβαση στην αρχική",
   "errorBoardNotFound": "Ο πίνακας δεν βρέθηκε",
   "errorBoardSetNotFound": "Ο πίνακας δεν βρέθηκε",
-  "boardUrlReplaceConfirmTitle": "Αντικατάσταση «{name}»;",
-  "boardUrlReplaceConfirmDescription": "Η εισαγωγή από το {host} θα αντικαταστήσει αυτόν τον πίνακα και ό,τι περιέχει. Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.",
-  "boardUrlReplace": "Αντικατάσταση",
   "boardUrlImportFailed": "Δεν ήταν δυνατή η εισαγωγή του πίνακα από τον σύνδεσμο"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningAssign": "Press your switch",
   "switchScanningOff": "Off",
   "switchScanningChange": "Change",
@@ -13,8 +14,6 @@
   "switchScanningCommandKey": "Command key",
   "switchScanningWindowsKey": "Windows key",
   "switchScanningMetaKey": "Meta key",
-  "switchScanningActions": "Actions",
-  "switchScanningActionsExit": "Back from actions",
   "switchScanningRow": "Row {row}",
   "switchScanningRowExit": "Back from row {row}",
   "loading": "Loading...",
@@ -44,16 +43,6 @@
       "match": {
         "countPlural=one": "Board imported",
         "countPlural=*": "Boards imported"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Board replaced",
-        "countPlural=*": "Boards replaced"
       }
     }
   ],
@@ -100,8 +89,6 @@
   "settingsSectionSwitchAccess": "Switch access",
   "switchScanningEnabled": "Switch scanning",
   "switchScanningMethod": "Scan method",
-  "switchScanningOneSwitch": "One switch",
-  "switchScanningTwoSwitches": "Two switches",
   "switchScanningMethodAuto": "Automatic scan",
   "switchScanningMethodStep": "Two-switch step",
   "switchScanningMethodDwell": "Step and wait",
@@ -164,8 +151,5 @@
   "errorGoHome": "Go home",
   "errorBoardNotFound": "Board not found",
   "errorBoardSetNotFound": "Board not found",
-  "boardUrlReplaceConfirmTitle": "Replace \"{name}\"?",
-  "boardUrlReplaceConfirmDescription": "Importing from {host} will replace this board and everything in it. This cannot be undone.",
-  "boardUrlReplace": "Replace",
   "boardUrlImportFailed": "Couldn't import board from link"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "Cambiar",
   "switchScanningNextItemSwitch": "Pulsador de elemento siguiente",
   "switchScanningScanSwitch": "Pulsador de barrido",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "Ignorar pulsaciones repetidas",
   "switchScanningMinimumPressDuration": "Duración mínima de pulsación",
   "switchScanningAssign": "Pulsa un pulsador para asignarlo",
-  "switchScanningNextItem": "Elemento siguiente",
   "switchScanningSelectSwitch": "Pulsador de selección",
   "switchScanningMouseInput": "Botón del ratón {button}",
-  "switchScanningActions": "Acciones",
-  "switchScanningActionsExit": "Volver desde las acciones",
   "switchScanningRow": "Fila {row}",
   "switchScanningRowExit": "Volver desde la fila {row}",
   "loading": "Cargando...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "Tablero importado",
         "countPlural=*": "Tableros importados"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Tablero reemplazado",
-        "countPlural=*": "Tableros reemplazados"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "Acceso con pulsador",
   "switchScanningEnabled": "Activar barrido con pulsador",
   "switchScanningMethod": "Método de barrido",
-  "switchScanningOneSwitch": "Un pulsador",
-  "switchScanningTwoSwitches": "Dos pulsadores",
   "switchScanningMethodAuto": "Automático",
   "switchScanningMethodStep": "Paso con dos pulsadores",
   "switchScanningMethodDwell": "Permanencia con un pulsador",
@@ -165,8 +151,5 @@
   "errorGoHome": "Ir al inicio",
   "errorBoardNotFound": "Tablero no encontrado",
   "errorBoardSetNotFound": "Tablero no encontrado",
-  "boardUrlReplaceConfirmTitle": "¿Reemplazar \"{name}\"?",
-  "boardUrlReplaceConfirmDescription": "Importar desde {host} reemplazará este tablero y todo su contenido. Esta acción no se puede deshacer.",
-  "boardUrlReplace": "Reemplazar",
   "boardUrlImportFailed": "No se pudo importar el tablero desde el enlace"
 }

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "Vaihda",
   "switchScanningNextItemSwitch": "Seuraavan kohteen kytkin",
   "switchScanningScanSwitch": "Skannauskytkin",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "Ohita toistuvat painallukset",
   "switchScanningMinimumPressDuration": "Painalluksen vähimmäiskesto",
   "switchScanningAssign": "Määritä kytkin painamalla sitä",
-  "switchScanningNextItem": "Seuraava kohde",
   "switchScanningSelectSwitch": "Valintakytkin",
   "switchScanningMouseInput": "Hiiren painike {button}",
-  "switchScanningActions": "Toiminnot",
-  "switchScanningActionsExit": "Takaisin toiminnoista",
   "switchScanningRow": "Rivi {row}",
   "switchScanningRowExit": "Takaisin riviltä {row}",
   "loading": "Ladataan...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "Taulu tuotu",
         "countPlural=*": "Taulut tuotu"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Taulu korvattu",
-        "countPlural=*": "Taulut korvattu"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "Kytkinohjaus",
   "switchScanningEnabled": "Ota kytkinskannaus käyttöön",
   "switchScanningMethod": "Skannaustapa",
-  "switchScanningOneSwitch": "Yksi kytkin",
-  "switchScanningTwoSwitches": "Kaksi kytkintä",
   "switchScanningMethodAuto": "Automaattinen",
   "switchScanningMethodStep": "Kahden kytkimen askellus",
   "switchScanningMethodDwell": "Yhden kytkimen viivevalinta",
@@ -165,8 +151,5 @@
   "errorGoHome": "Siirry etusivulle",
   "errorBoardNotFound": "Taulua ei löytynyt",
   "errorBoardSetNotFound": "Taulua ei löytynyt",
-  "boardUrlReplaceConfirmTitle": "Korvataanko ”{name}”?",
-  "boardUrlReplaceConfirmDescription": "Tuonti osoitteesta {host} korvaa tämän taulun ja kaiken sen sisällön. Tätä toimintoa ei voi kumota.",
-  "boardUrlReplace": "Korvaa",
   "boardUrlImportFailed": "Taulun tuonti linkistä epäonnistui"
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "Modifier",
   "switchScanningNextItemSwitch": "Contacteur d’élément suivant",
   "switchScanningScanSwitch": "Contacteur de balayage",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "Ignorer les pressions répétées",
   "switchScanningMinimumPressDuration": "Durée minimale de pression",
   "switchScanningAssign": "Appuyez sur un contacteur pour l’attribuer",
-  "switchScanningNextItem": "Élément suivant",
   "switchScanningSelectSwitch": "Contacteur de sélection",
   "switchScanningMouseInput": "Bouton de souris {button}",
-  "switchScanningActions": "Actions",
-  "switchScanningActionsExit": "Quitter les actions",
   "switchScanningRow": "Ligne {row}",
   "switchScanningRowExit": "Quitter la ligne {row}",
   "loading": "Chargement...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "Tableau importé",
         "countPlural=*": "Tableaux importés"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Tableau remplacé",
-        "countPlural=*": "Tableaux remplacés"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "Accès par contacteur",
   "switchScanningEnabled": "Activer le balayage par contacteur",
   "switchScanningMethod": "Méthode de balayage",
-  "switchScanningOneSwitch": "Un contacteur",
-  "switchScanningTwoSwitches": "Deux contacteurs",
   "switchScanningMethodAuto": "Automatique",
   "switchScanningMethodStep": "Pas à deux contacteurs",
   "switchScanningMethodDwell": "Temporisation à un contacteur",
@@ -165,8 +151,5 @@
   "errorGoHome": "Aller à l'accueil",
   "errorBoardNotFound": "Tableau introuvable",
   "errorBoardSetNotFound": "Tableau introuvable",
-  "boardUrlReplaceConfirmTitle": "Remplacer « {name} » ?",
-  "boardUrlReplaceConfirmDescription": "L'importation depuis {host} remplacera ce tableau et tout son contenu. Cette action est irréversible.",
-  "boardUrlReplace": "Remplacer",
   "boardUrlImportFailed": "Impossible d'importer le tableau depuis le lien"
 }

--- a/messages/he.json
+++ b/messages/he.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "שינוי",
   "switchScanningNextItemSwitch": "מתג לפריט הבא",
   "switchScanningScanSwitch": "מתג סריקה",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "התעלמות מלחיצות חוזרות",
   "switchScanningMinimumPressDuration": "משך לחיצה מינימלי",
   "switchScanningAssign": "יש ללחוץ על מתג כדי להקצות אותו",
-  "switchScanningNextItem": "הפריט הבא",
   "switchScanningSelectSwitch": "מתג בחירה",
   "switchScanningMouseInput": "לחצן עכבר {button}",
-  "switchScanningActions": "פעולות",
-  "switchScanningActionsExit": "חזרה מהפעולות",
   "switchScanningRow": "שורה {row}",
   "switchScanningRowExit": "חזרה משורה {row}",
   "loading": "טעינה...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "הלוח יובא בהצלחה",
         "countPlural=*": "הלוחות יובאו בהצלחה"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "הלוח הוחלף בהצלחה",
-        "countPlural=*": "הלוחות הוחלפו בהצלחה"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "גישה באמצעות מתג",
   "switchScanningEnabled": "הפעלת סריקה באמצעות מתג",
   "switchScanningMethod": "שיטת סריקה",
-  "switchScanningOneSwitch": "מתג אחד",
-  "switchScanningTwoSwitches": "שני מתגים",
   "switchScanningMethodAuto": "אוטומטית",
   "switchScanningMethodStep": "צעד באמצעות שני מתגים",
   "switchScanningMethodDwell": "השהיה באמצעות מתג אחד",
@@ -165,8 +151,5 @@
   "errorGoHome": "חזרה לעמוד הבית",
   "errorBoardNotFound": "הלוח לא נמצא",
   "errorBoardSetNotFound": "הלוח לא נמצא",
-  "boardUrlReplaceConfirmTitle": "להחליף את \"{name}\"?",
-  "boardUrlReplaceConfirmDescription": "ייבוא מ-{host} יחליף את הלוח הזה ואת כל מה שבו. לא ניתן לבטל פעולה זו.",
-  "boardUrlReplace": "החלפה",
   "boardUrlImportFailed": "ייבוא הלוח מהקישור נכשל"
 }

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "बदलें",
   "switchScanningNextItemSwitch": "अगले आइटम का स्विच",
   "switchScanningScanSwitch": "स्कैन स्विच",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "बार-बार दबाने को अनदेखा करें",
   "switchScanningMinimumPressDuration": "दबाने की न्यूनतम अवधि",
   "switchScanningAssign": "असाइन करने के लिए स्विच दबाएँ",
-  "switchScanningNextItem": "अगला आइटम",
   "switchScanningSelectSwitch": "चुनने का स्विच",
   "switchScanningMouseInput": "माउस बटन {button}",
-  "switchScanningActions": "कार्रवाइयाँ",
-  "switchScanningActionsExit": "कार्रवाइयों से वापस जाएँ",
   "switchScanningRow": "पंक्ति {row}",
   "switchScanningRowExit": "पंक्ति {row} से वापस जाएँ",
   "loading": "लोड हो रहा है…",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "बोर्ड आयात हो गया",
         "countPlural=*": "बोर्ड आयात हो गए"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "बोर्ड बदल दिया गया",
-        "countPlural=*": "बोर्ड बदल दिए गए"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "स्विच एक्सेस",
   "switchScanningEnabled": "स्विच स्कैनिंग चालू करें",
   "switchScanningMethod": "स्कैन विधि",
-  "switchScanningOneSwitch": "एक स्विच",
-  "switchScanningTwoSwitches": "दो स्विच",
   "switchScanningMethodAuto": "स्वचालित",
   "switchScanningMethodStep": "दो-स्विच चरण",
   "switchScanningMethodDwell": "एक-स्विच ठहराव",
@@ -165,8 +151,5 @@
   "errorGoHome": "होम पर जाएँ",
   "errorBoardNotFound": "बोर्ड नहीं मिला",
   "errorBoardSetNotFound": "बोर्ड नहीं मिला",
-  "boardUrlReplaceConfirmTitle": "\"{name}\" को बदलें?",
-  "boardUrlReplaceConfirmDescription": "{host} से आयात करने पर यह बोर्ड और इसमें मौजूद सब कुछ बदल जाएगा। यह क्रिया पूर्ववत नहीं की जा सकती।",
-  "boardUrlReplace": "बदलें",
   "boardUrlImportFailed": "लिंक से बोर्ड आयात नहीं किया जा सका"
 }

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "Promijeni",
   "switchScanningNextItemSwitch": "Sklopka za sljedeću stavku",
   "switchScanningScanSwitch": "Sklopka za skeniranje",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "Zanemari ponovljene pritiske",
   "switchScanningMinimumPressDuration": "Minimalno trajanje pritiska",
   "switchScanningAssign": "Pritisnite prekidač da biste ga dodijelili",
-  "switchScanningNextItem": "Sljedeća stavka",
   "switchScanningSelectSwitch": "Prekidač za odabir",
   "switchScanningMouseInput": "Tipka miša {button}",
-  "switchScanningActions": "Radnje",
-  "switchScanningActionsExit": "Natrag iz radnji",
   "switchScanningRow": "Redak {row}",
   "switchScanningRowExit": "Natrag iz retka {row}",
   "loading": "Učitavanje...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "Ploča uvezena",
         "countPlural=*": "Ploče uvezene"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Ploča zamijenjena",
-        "countPlural=*": "Ploče zamijenjene"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "Pristup prekidačem",
   "switchScanningEnabled": "Uključi skeniranje prekidačem",
   "switchScanningMethod": "Način skeniranja",
-  "switchScanningOneSwitch": "Jedan prekidač",
-  "switchScanningTwoSwitches": "Dva prekidača",
   "switchScanningMethodAuto": "Automatski",
   "switchScanningMethodStep": "Korak s dva prekidača",
   "switchScanningMethodDwell": "Zadržavanje s jednim prekidačem",
@@ -165,8 +151,5 @@
   "errorGoHome": "Idi na početnu",
   "errorBoardNotFound": "Ploča nije pronađena",
   "errorBoardSetNotFound": "Ploča nije pronađena",
-  "boardUrlReplaceConfirmTitle": "Zamijeniti „{name}”?",
-  "boardUrlReplaceConfirmDescription": "Uvoz s {host} zamijenit će ovu ploču i sve u njoj. Ovu radnju nije moguće poništiti.",
-  "boardUrlReplace": "Zamijeni",
   "boardUrlImportFailed": "Ploču nije moguće uvesti s poveznice"
 }

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "Módosítás",
   "switchScanningNextItemSwitch": "Következő elem kapcsolója",
   "switchScanningScanSwitch": "Pásztázó kapcsoló",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "Ismételt megnyomások figyelmen kívül hagyása",
   "switchScanningMinimumPressDuration": "Minimális nyomvatartási idő",
   "switchScanningAssign": "Nyomjon meg egy kapcsolót a hozzárendeléshez",
-  "switchScanningNextItem": "Következő elem",
   "switchScanningSelectSwitch": "Kiválasztó kapcsoló",
   "switchScanningMouseInput": "{button}. egérgomb",
-  "switchScanningActions": "Műveletek",
-  "switchScanningActionsExit": "Vissza a műveletekből",
   "switchScanningRow": "{row}. sor",
   "switchScanningRowExit": "Vissza a(z) {row}. sorból",
   "loading": "Betöltés...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "Tábla importálva",
         "countPlural=*": "Táblák importálva"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Tábla lecserélve",
-        "countPlural=*": "Táblák lecserélve"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "Kapcsolós hozzáférés",
   "switchScanningEnabled": "Kapcsolós pásztázás bekapcsolása",
   "switchScanningMethod": "Pásztázási mód",
-  "switchScanningOneSwitch": "Egy kapcsoló",
-  "switchScanningTwoSwitches": "Két kapcsoló",
   "switchScanningMethodAuto": "Automatikus",
   "switchScanningMethodStep": "Kétkapcsolós léptetés",
   "switchScanningMethodDwell": "Egykapcsolós várakozás",
@@ -165,8 +151,5 @@
   "errorGoHome": "Ugrás a kezdőlapra",
   "errorBoardNotFound": "A tábla nem található",
   "errorBoardSetNotFound": "A tábla nem található",
-  "boardUrlReplaceConfirmTitle": "Lecseréled a(z) „{name}” táblát?",
-  "boardUrlReplaceConfirmDescription": "A(z) {host} helyről történő importálás lecseréli ezt a táblát és minden tartalmát. Ez a művelet nem vonható vissza.",
-  "boardUrlReplace": "Csere",
   "boardUrlImportFailed": "A tábla importálása a hivatkozásról nem sikerült"
 }

--- a/messages/id.json
+++ b/messages/id.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "Ubah",
   "switchScanningNextItemSwitch": "Sakelar item berikutnya",
   "switchScanningScanSwitch": "Sakelar pemindaian",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "Abaikan penekanan berulang",
   "switchScanningMinimumPressDuration": "Durasi penekanan minimum",
   "switchScanningAssign": "Tekan sakelar untuk menetapkannya",
-  "switchScanningNextItem": "Item berikutnya",
   "switchScanningSelectSwitch": "Sakelar pilih",
   "switchScanningMouseInput": "Tombol mouse {button}",
-  "switchScanningActions": "Tindakan",
-  "switchScanningActionsExit": "Kembali dari tindakan",
   "switchScanningRow": "Baris {row}",
   "switchScanningRowExit": "Kembali dari baris {row}",
   "loading": "Memuat...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "Papan diimpor",
         "countPlural=*": "Papan diimpor"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Papan diganti",
-        "countPlural=*": "Papan diganti"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "Akses sakelar",
   "switchScanningEnabled": "Aktifkan pemindaian sakelar",
   "switchScanningMethod": "Metode pemindaian",
-  "switchScanningOneSwitch": "Satu sakelar",
-  "switchScanningTwoSwitches": "Dua sakelar",
   "switchScanningMethodAuto": "Otomatis",
   "switchScanningMethodStep": "Langkah dua sakelar",
   "switchScanningMethodDwell": "Jeda satu sakelar",
@@ -165,8 +151,5 @@
   "errorGoHome": "Ke beranda",
   "errorBoardNotFound": "Papan tidak ditemukan",
   "errorBoardSetNotFound": "Papan tidak ditemukan",
-  "boardUrlReplaceConfirmTitle": "Ganti \"{name}\"?",
-  "boardUrlReplaceConfirmDescription": "Mengimpor dari {host} akan mengganti papan ini beserta seluruh isinya. Tindakan ini tidak dapat dibatalkan.",
-  "boardUrlReplace": "Ganti",
   "boardUrlImportFailed": "Tidak dapat mengimpor papan dari tautan"
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "Cambia",
   "switchScanningNextItemSwitch": "Sensore per elemento successivo",
   "switchScanningScanSwitch": "Sensore di scansione",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "Ignora pressioni ripetute",
   "switchScanningMinimumPressDuration": "Durata minima della pressione",
   "switchScanningAssign": "Premi un sensore per assegnarlo",
-  "switchScanningNextItem": "Elemento successivo",
   "switchScanningSelectSwitch": "Sensore di selezione",
   "switchScanningMouseInput": "Pulsante del mouse {button}",
-  "switchScanningActions": "Azioni",
-  "switchScanningActionsExit": "Indietro dalle azioni",
   "switchScanningRow": "Riga {row}",
   "switchScanningRowExit": "Indietro dalla riga {row}",
   "loading": "Caricamento...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "Tabella importata",
         "countPlural=*": "Tabelle importate"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Tabella sostituita",
-        "countPlural=*": "Tabelle sostituite"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "Accesso con sensore",
   "switchScanningEnabled": "Attiva la scansione con sensore",
   "switchScanningMethod": "Metodo di scansione",
-  "switchScanningOneSwitch": "Un sensore",
-  "switchScanningTwoSwitches": "Due sensori",
   "switchScanningMethodAuto": "Automatica",
   "switchScanningMethodStep": "Passo con due sensori",
   "switchScanningMethodDwell": "Permanenza con un sensore",
@@ -165,8 +151,5 @@
   "errorGoHome": "Vai alla home",
   "errorBoardNotFound": "Tabella non trovata",
   "errorBoardSetNotFound": "Tabella non trovata",
-  "boardUrlReplaceConfirmTitle": "Sostituire \"{name}\"?",
-  "boardUrlReplaceConfirmDescription": "L'importazione da {host} sostituirà questa tabella e tutto il suo contenuto. Questa azione non può essere annullata.",
-  "boardUrlReplace": "Sostituisci",
   "boardUrlImportFailed": "Impossibile importare la tabella dal link"
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "変更",
   "switchScanningNextItemSwitch": "次の項目スイッチ",
   "switchScanningScanSwitch": "スキャンスイッチ",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "連続した押下を無視",
   "switchScanningMinimumPressDuration": "最小押下時間",
   "switchScanningAssign": "割り当てるスイッチを押してください",
-  "switchScanningNextItem": "次の項目",
   "switchScanningSelectSwitch": "選択スイッチ",
   "switchScanningMouseInput": "マウスボタン {button}",
-  "switchScanningActions": "操作",
-  "switchScanningActionsExit": "操作から戻る",
   "switchScanningRow": "{row} 行目",
   "switchScanningRowExit": "{row} 行目から戻る",
   "loading": "読み込んでいます…",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "ボードをインポートしました",
         "countPlural=*": "ボードをインポートしました"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "ボードを置き換えました",
-        "countPlural=*": "ボードを置き換えました"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "スイッチアクセス",
   "switchScanningEnabled": "スイッチスキャンを有効にする",
   "switchScanningMethod": "スキャン方法",
-  "switchScanningOneSwitch": "1つのスイッチ",
-  "switchScanningTwoSwitches": "2つのスイッチ",
   "switchScanningMethodAuto": "自動",
   "switchScanningMethodStep": "2スイッチステップ",
   "switchScanningMethodDwell": "1スイッチ滞留",
@@ -165,8 +151,5 @@
   "errorGoHome": "ホームに戻る",
   "errorBoardNotFound": "ボードが見つかりません",
   "errorBoardSetNotFound": "ボードが見つかりません",
-  "boardUrlReplaceConfirmTitle": "「{name}」を置き換えますか？",
-  "boardUrlReplaceConfirmDescription": "{host} からインポートすると、このボードとその中のすべてが置き換えられます。この操作は取り消せません。",
-  "boardUrlReplace": "置き換える",
   "boardUrlImportFailed": "リンクからボードをインポートできませんでした"
 }

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "ಬದಲಿಸಿ",
   "switchScanningNextItemSwitch": "ಮುಂದಿನ ಅಂಶದ ಸ್ವಿಚ್",
   "switchScanningScanSwitch": "ಸ್ಕ್ಯಾನ್ ಸ್ವಿಚ್",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "ಪುನರಾವರ್ತಿತ ಒತ್ತುವಿಕೆಗಳನ್ನು ನಿರ್ಲಕ್ಷಿಸಿ",
   "switchScanningMinimumPressDuration": "ಕನಿಷ್ಠ ಒತ್ತುವ ಅವಧಿ",
   "switchScanningAssign": "ನಿಯೋಜಿಸಲು ಸ್ವಿಚ್ ಒತ್ತಿರಿ",
-  "switchScanningNextItem": "ಮುಂದಿನ ಐಟಂ",
   "switchScanningSelectSwitch": "ಆಯ್ಕೆ ಸ್ವಿಚ್",
   "switchScanningMouseInput": "ಮೌಸ್ ಬಟನ್ {button}",
-  "switchScanningActions": "ಕ್ರಿಯೆಗಳು",
-  "switchScanningActionsExit": "ಕ್ರಿಯೆಗಳಿಂದ ಹಿಂದೆ",
   "switchScanningRow": "ಸಾಲು {row}",
   "switchScanningRowExit": "{row}ನೇ ಸಾಲಿನಿಂದ ಹಿಂದೆ",
   "loading": "ಲೋಡ್ ಆಗುತ್ತಿದೆ…",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "ಬೋರ್ಡ್ ಆಮದಾಗಿದೆ",
         "countPlural=*": "ಬೋರ್ಡ್‌ಗಳು ಆಮದಾಗಿವೆ"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "ಬೋರ್ಡ್ ಬದಲಾಯಿಸಲಾಗಿದೆ",
-        "countPlural=*": "ಬೋರ್ಡ್‌ಗಳು ಬದಲಾಯಿಸಲಾಗಿವೆ"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "ಸ್ವಿಚ್ ಪ್ರವೇಶ",
   "switchScanningEnabled": "ಸ್ವಿಚ್ ಸ್ಕ್ಯಾನಿಂಗ್ ಸಕ್ರಿಯಗೊಳಿಸಿ",
   "switchScanningMethod": "ಸ್ಕ್ಯಾನ್ ವಿಧಾನ",
-  "switchScanningOneSwitch": "ಒಂದು ಸ್ವಿಚ್",
-  "switchScanningTwoSwitches": "ಎರಡು ಸ್ವಿಚ್‌ಗಳು",
   "switchScanningMethodAuto": "ಸ್ವಯಂಚಾಲಿತ",
   "switchScanningMethodStep": "ಎರಡು-ಸ್ವಿಚ್ ಹಂತ",
   "switchScanningMethodDwell": "ಒಂದು-ಸ್ವಿಚ್ ಕಾಯುವಿಕೆ",
@@ -165,8 +151,5 @@
   "errorGoHome": "ಮುಖಪುಟಕ್ಕೆ ಹೋಗಿ",
   "errorBoardNotFound": "ಬೋರ್ಡ್ ಕಂಡುಬಂದಿಲ್ಲ",
   "errorBoardSetNotFound": "ಬೋರ್ಡ್ ಕಂಡುಬಂದಿಲ್ಲ",
-  "boardUrlReplaceConfirmTitle": "\"{name}\" ಅನ್ನು ಬದಲಾಯಿಸುವುದೇ?",
-  "boardUrlReplaceConfirmDescription": "{host} ನಿಂದ ಆಮದು ಮಾಡಿದರೆ ಈ ಬೋರ್ಡ್ ಮತ್ತು ಅದರಲ್ಲಿರುವ ಎಲ್ಲವೂ ಬದಲಾಗುತ್ತದೆ. ಈ ಕ್ರಿಯೆಯನ್ನು ರದ್ದುಗೊಳಿಸಲಾಗದು.",
-  "boardUrlReplace": "ಬದಲಾಯಿಸಿ",
   "boardUrlImportFailed": "ಲಿಂಕ್‌ನಿಂದ ಬೋರ್ಡ್ ಆಮದು ಮಾಡಲಾಗಲಿಲ್ಲ"
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "변경",
   "switchScanningNextItemSwitch": "다음 항목 스위치",
   "switchScanningScanSwitch": "스캔 스위치",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "반복 누르기 무시",
   "switchScanningMinimumPressDuration": "최소 누르기 시간",
   "switchScanningAssign": "할당할 스위치를 누르세요",
-  "switchScanningNextItem": "다음 항목",
   "switchScanningSelectSwitch": "선택 스위치",
   "switchScanningMouseInput": "마우스 버튼 {button}",
-  "switchScanningActions": "작업",
-  "switchScanningActionsExit": "작업에서 뒤로",
   "switchScanningRow": "{row}행",
   "switchScanningRowExit": "{row}행에서 뒤로",
   "loading": "불러오는 중…",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "보드를 가져왔습니다",
         "countPlural=*": "보드를 가져왔습니다"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "보드를 교체했습니다",
-        "countPlural=*": "보드를 교체했습니다"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "스위치 제어",
   "switchScanningEnabled": "스위치 스캔 사용",
   "switchScanningMethod": "스캔 방식",
-  "switchScanningOneSwitch": "스위치 1개",
-  "switchScanningTwoSwitches": "스위치 2개",
   "switchScanningMethodAuto": "자동",
   "switchScanningMethodStep": "2스위치 단계",
   "switchScanningMethodDwell": "1스위치 머무르기",
@@ -165,8 +151,5 @@
   "errorGoHome": "홈으로",
   "errorBoardNotFound": "보드를 찾을 수 없음",
   "errorBoardSetNotFound": "보드를 찾을 수 없음",
-  "boardUrlReplaceConfirmTitle": "\"{name}\"을(를) 교체하시겠어요?",
-  "boardUrlReplaceConfirmDescription": "{host}에서 가져오면 이 보드와 그 안의 모든 내용이 교체됩니다. 이 작업은 되돌릴 수 없습니다.",
-  "boardUrlReplace": "교체",
   "boardUrlImportFailed": "링크에서 보드를 가져올 수 없습니다"
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "Wijzigen",
   "switchScanningNextItemSwitch": "Schakelaar voor volgend item",
   "switchScanningScanSwitch": "Scanschakelaar",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "Herhaalde drukken negeren",
   "switchScanningMinimumPressDuration": "Minimale drukduur",
   "switchScanningAssign": "Druk op een schakelaar om deze toe te wijzen",
-  "switchScanningNextItem": "Volgend item",
   "switchScanningSelectSwitch": "Selectieschakelaar",
   "switchScanningMouseInput": "Muisknop {button}",
-  "switchScanningActions": "Acties",
-  "switchScanningActionsExit": "Terug uit acties",
   "switchScanningRow": "Rij {row}",
   "switchScanningRowExit": "Terug uit rij {row}",
   "loading": "Laden...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "Bord geïmporteerd",
         "countPlural=*": "Borden geïmporteerd"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Bord vervangen",
-        "countPlural=*": "Borden vervangen"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "Schakelaarbediening",
   "switchScanningEnabled": "Scannen met schakelaar inschakelen",
   "switchScanningMethod": "Scanmethode",
-  "switchScanningOneSwitch": "Eén schakelaar",
-  "switchScanningTwoSwitches": "Twee schakelaars",
   "switchScanningMethodAuto": "Automatisch",
   "switchScanningMethodStep": "Stap met twee schakelaars",
   "switchScanningMethodDwell": "Verblijven met één schakelaar",
@@ -165,8 +151,5 @@
   "errorGoHome": "Naar start",
   "errorBoardNotFound": "Bord niet gevonden",
   "errorBoardSetNotFound": "Bord niet gevonden",
-  "boardUrlReplaceConfirmTitle": "\"{name}\" vervangen?",
-  "boardUrlReplaceConfirmDescription": "Importeren van {host} vervangt dit bord en alles erin. Deze actie kan niet ongedaan worden gemaakt.",
-  "boardUrlReplace": "Vervangen",
   "boardUrlImportFailed": "Kan bord niet importeren via de link"
 }

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "Zmień",
   "switchScanningNextItemSwitch": "Przełącznik następnego elementu",
   "switchScanningScanSwitch": "Przełącznik skanowania",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "Ignoruj powtórne naciśnięcia",
   "switchScanningMinimumPressDuration": "Minimalny czas naciśnięcia",
   "switchScanningAssign": "Naciśnij przełącznik, aby go przypisać",
-  "switchScanningNextItem": "Następny element",
   "switchScanningSelectSwitch": "Przełącznik wyboru",
   "switchScanningMouseInput": "Przycisk myszy {button}",
-  "switchScanningActions": "Działania",
-  "switchScanningActionsExit": "Wróć z działań",
   "switchScanningRow": "Wiersz {row}",
   "switchScanningRowExit": "Wróć z wiersza {row}",
   "loading": "Ładowanie...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "Zaimportowano tablicę",
         "countPlural=*": "Zaimportowano tablice"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Zastąpiono tablicę",
-        "countPlural=*": "Zastąpiono tablice"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "Dostęp przełącznikiem",
   "switchScanningEnabled": "Włącz skanowanie przełącznikiem",
   "switchScanningMethod": "Metoda skanowania",
-  "switchScanningOneSwitch": "Jeden przełącznik",
-  "switchScanningTwoSwitches": "Dwa przełączniki",
   "switchScanningMethodAuto": "Automatyczna",
   "switchScanningMethodStep": "Krok dwoma przełącznikami",
   "switchScanningMethodDwell": "Zatrzymanie jednym przełącznikiem",
@@ -165,8 +151,5 @@
   "errorGoHome": "Przejdź do strony głównej",
   "errorBoardNotFound": "Nie znaleziono tablicy",
   "errorBoardSetNotFound": "Nie znaleziono tablicy",
-  "boardUrlReplaceConfirmTitle": "Zastąpić „{name}”?",
-  "boardUrlReplaceConfirmDescription": "Import z {host} zastąpi tę tablicę i całą jej zawartość. Tej operacji nie można cofnąć.",
-  "boardUrlReplace": "Zastąp",
   "boardUrlImportFailed": "Nie udało się zaimportować tablicy z linku"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "Alterar",
   "switchScanningNextItemSwitch": "Acionador do próximo item",
   "switchScanningScanSwitch": "Acionador de varredura",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "Ignorar acionamentos repetidos",
   "switchScanningMinimumPressDuration": "Duração mínima do acionamento",
   "switchScanningAssign": "Prima um acionador para o atribuir",
-  "switchScanningNextItem": "Item seguinte",
   "switchScanningSelectSwitch": "Acionador de seleção",
   "switchScanningMouseInput": "Botão do rato {button}",
-  "switchScanningActions": "Ações",
-  "switchScanningActionsExit": "Voltar das ações",
   "switchScanningRow": "Linha {row}",
   "switchScanningRowExit": "Voltar da linha {row}",
   "loading": "Carregando...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "Prancha importada",
         "countPlural=*": "Pranchas importadas"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Prancha substituída",
-        "countPlural=*": "Pranchas substituídas"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "Acesso por acionador",
   "switchScanningEnabled": "Ativar varredura por acionador",
   "switchScanningMethod": "Método de varredura",
-  "switchScanningOneSwitch": "Um acionador",
-  "switchScanningTwoSwitches": "Dois acionadores",
   "switchScanningMethodAuto": "Automática",
   "switchScanningMethodStep": "Passo com dois acionadores",
   "switchScanningMethodDwell": "Permanência com um acionador",
@@ -165,8 +151,5 @@
   "errorGoHome": "Ir para o início",
   "errorBoardNotFound": "Prancha não encontrada",
   "errorBoardSetNotFound": "Prancha não encontrada",
-  "boardUrlReplaceConfirmTitle": "Substituir \"{name}\"?",
-  "boardUrlReplaceConfirmDescription": "Importar de {host} substituirá esta prancha e tudo o que há nela. Esta ação não pode ser desfeita.",
-  "boardUrlReplace": "Substituir",
   "boardUrlImportFailed": "Não foi possível importar a prancha do link"
 }

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "Schimbă",
   "switchScanningNextItemSwitch": "Comutator pentru elementul următor",
   "switchScanningScanSwitch": "Comutator de scanare",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "Ignoră apăsările repetate",
   "switchScanningMinimumPressDuration": "Durata minimă a apăsării",
   "switchScanningAssign": "Apasă un comutator pentru a-l atribui",
-  "switchScanningNextItem": "Elementul următor",
   "switchScanningSelectSwitch": "Comutator de selectare",
   "switchScanningMouseInput": "Butonul mouse-ului {button}",
-  "switchScanningActions": "Acțiuni",
-  "switchScanningActionsExit": "Înapoi din acțiuni",
   "switchScanningRow": "Rândul {row}",
   "switchScanningRowExit": "Înapoi din rândul {row}",
   "loading": "Se încarcă...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "Tablă importată",
         "countPlural=*": "Table importate"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Tablă înlocuită",
-        "countPlural=*": "Table înlocuite"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "Acces cu comutator",
   "switchScanningEnabled": "Activează scanarea cu comutator",
   "switchScanningMethod": "Metodă de scanare",
-  "switchScanningOneSwitch": "Un comutator",
-  "switchScanningTwoSwitches": "Două comutatoare",
   "switchScanningMethodAuto": "Automată",
   "switchScanningMethodStep": "Pas cu două comutatoare",
   "switchScanningMethodDwell": "Staționare cu un comutator",
@@ -165,8 +151,5 @@
   "errorGoHome": "Mergi la pagina principală",
   "errorBoardNotFound": "Tabla nu a fost găsită",
   "errorBoardSetNotFound": "Tabla nu a fost găsită",
-  "boardUrlReplaceConfirmTitle": "Înlocuiești „{name}”?",
-  "boardUrlReplaceConfirmDescription": "Importul de la {host} va înlocui această tablă și tot conținutul ei. Această acțiune nu poate fi anulată.",
-  "boardUrlReplace": "Înlocuiește",
   "boardUrlImportFailed": "Tabla nu a putut fi importată din link"
 }

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "Изменить",
   "switchScanningNextItemSwitch": "Переключатель следующего элемента",
   "switchScanningScanSwitch": "Переключатель сканирования",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "Игнорировать повторные нажатия",
   "switchScanningMinimumPressDuration": "Минимальная длительность нажатия",
   "switchScanningAssign": "Нажмите переключатель, чтобы назначить его",
-  "switchScanningNextItem": "Следующий элемент",
   "switchScanningSelectSwitch": "Переключатель выбора",
   "switchScanningMouseInput": "Кнопка мыши {button}",
-  "switchScanningActions": "Действия",
-  "switchScanningActionsExit": "Назад из действий",
   "switchScanningRow": "Строка {row}",
   "switchScanningRowExit": "Назад из строки {row}",
   "loading": "Загрузка...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "Доска импортирована",
         "countPlural=*": "Доски импортированы"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Доска заменена",
-        "countPlural=*": "Доски заменены"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "Управление переключателем",
   "switchScanningEnabled": "Включить сканирование переключателем",
   "switchScanningMethod": "Метод сканирования",
-  "switchScanningOneSwitch": "Один переключатель",
-  "switchScanningTwoSwitches": "Два переключателя",
   "switchScanningMethodAuto": "Автоматический",
   "switchScanningMethodStep": "Шаг двумя переключателями",
   "switchScanningMethodDwell": "Задержка с одним переключателем",
@@ -165,8 +151,5 @@
   "errorGoHome": "На главную",
   "errorBoardNotFound": "Доска не найдена",
   "errorBoardSetNotFound": "Доска не найдена",
-  "boardUrlReplaceConfirmTitle": "Заменить «{name}»?",
-  "boardUrlReplaceConfirmDescription": "Импорт с сайта {host} заменит эту доску и всё её содержимое. Это действие нельзя отменить.",
-  "boardUrlReplace": "Заменить",
   "boardUrlImportFailed": "Не удалось импортировать доску по ссылке"
 }

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "Zmeniť",
   "switchScanningNextItemSwitch": "Spínač ďalšej položky",
   "switchScanningScanSwitch": "Skenovací spínač",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "Ignorovať opakované stlačenia",
   "switchScanningMinimumPressDuration": "Minimálne trvanie stlačenia",
   "switchScanningAssign": "Stlačením spínača ho priraďte",
-  "switchScanningNextItem": "Ďalšia položka",
   "switchScanningSelectSwitch": "Spínač na výber",
   "switchScanningMouseInput": "Tlačidlo myši {button}",
-  "switchScanningActions": "Akcie",
-  "switchScanningActionsExit": "Späť z akcií",
   "switchScanningRow": "Riadok {row}",
   "switchScanningRowExit": "Späť z riadka {row}",
   "loading": "Načítava sa...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "Tabuľka importovaná",
         "countPlural=*": "Tabuľky importované"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Tabuľka nahradená",
-        "countPlural=*": "Tabuľky nahradené"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "Ovládanie spínačom",
   "switchScanningEnabled": "Zapnúť skenovanie spínačom",
   "switchScanningMethod": "Spôsob skenovania",
-  "switchScanningOneSwitch": "Jeden spínač",
-  "switchScanningTwoSwitches": "Dva spínače",
   "switchScanningMethodAuto": "Automatické",
   "switchScanningMethodStep": "Krokovanie dvoma spínačmi",
   "switchScanningMethodDwell": "Zotrvanie s jedným spínačom",
@@ -165,8 +151,5 @@
   "errorGoHome": "Prejsť domov",
   "errorBoardNotFound": "Tabuľka sa nenašla",
   "errorBoardSetNotFound": "Tabuľka sa nenašla",
-  "boardUrlReplaceConfirmTitle": "Nahradiť „{name}“?",
-  "boardUrlReplaceConfirmDescription": "Import z {host} nahradí túto tabuľku a všetko v nej. Túto akciu nie je možné vrátiť späť.",
-  "boardUrlReplace": "Nahradiť",
   "boardUrlImportFailed": "Tabuľku sa nepodarilo importovať z odkazu"
 }

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "Spremeni",
   "switchScanningNextItemSwitch": "Stikalo za naslednji element",
   "switchScanningScanSwitch": "Stikalo za pregledovanje",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "Prezri ponovljene pritiske",
   "switchScanningMinimumPressDuration": "Najkrajše trajanje pritiska",
   "switchScanningAssign": "Pritisnite stikalo, da ga dodelite",
-  "switchScanningNextItem": "Naslednji element",
   "switchScanningSelectSwitch": "Stikalo za izbiro",
   "switchScanningMouseInput": "Gumb miške {button}",
-  "switchScanningActions": "Dejanja",
-  "switchScanningActionsExit": "Nazaj iz dejanj",
   "switchScanningRow": "Vrstica {row}",
   "switchScanningRowExit": "Nazaj iz vrstice {row}",
   "loading": "Nalaganje...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "Tabla uvožena",
         "countPlural=*": "Table uvožene"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Tabla zamenjana",
-        "countPlural=*": "Table zamenjane"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "Dostop s stikalom",
   "switchScanningEnabled": "Vklopi skeniranje s stikalom",
   "switchScanningMethod": "Način skeniranja",
-  "switchScanningOneSwitch": "Eno stikalo",
-  "switchScanningTwoSwitches": "Dve stikali",
   "switchScanningMethodAuto": "Samodejno",
   "switchScanningMethodStep": "Korak z dvema stikaloma",
   "switchScanningMethodDwell": "Zadržanje z enim stikalom",
@@ -165,8 +151,5 @@
   "errorGoHome": "Pojdi domov",
   "errorBoardNotFound": "Table ni mogoče najti",
   "errorBoardSetNotFound": "Table ni mogoče najti",
-  "boardUrlReplaceConfirmTitle": "Zamenjam »{name}«?",
-  "boardUrlReplaceConfirmDescription": "Uvoz s {host} bo zamenjal to tablo in vse v njej. Tega dejanja ni mogoče razveljaviti.",
-  "boardUrlReplace": "Zamenjaj",
   "boardUrlImportFailed": "Table ni bilo mogoče uvoziti s povezave"
 }

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "Ändra",
   "switchScanningNextItemSwitch": "Kontakt för nästa objekt",
   "switchScanningScanSwitch": "Skanningskontakt",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "Ignorera upprepade tryck",
   "switchScanningMinimumPressDuration": "Minsta trycktid",
   "switchScanningAssign": "Tryck på en kontakt för att tilldela den",
-  "switchScanningNextItem": "Nästa objekt",
   "switchScanningSelectSwitch": "Kontakt för val",
   "switchScanningMouseInput": "Musknapp {button}",
-  "switchScanningActions": "Åtgärder",
-  "switchScanningActionsExit": "Tillbaka från åtgärder",
   "switchScanningRow": "Rad {row}",
   "switchScanningRowExit": "Tillbaka från rad {row}",
   "loading": "Laddar...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "Tavla importerad",
         "countPlural=*": "Tavlor importerade"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Tavla ersatt",
-        "countPlural=*": "Tavlor ersatta"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "Kontaktstyrning",
   "switchScanningEnabled": "Aktivera kontaktskanning",
   "switchScanningMethod": "Skanningsmetod",
-  "switchScanningOneSwitch": "En kontakt",
-  "switchScanningTwoSwitches": "Två kontakter",
   "switchScanningMethodAuto": "Automatisk",
   "switchScanningMethodStep": "Steg med två kontakter",
   "switchScanningMethodDwell": "Väntetid med en kontakt",
@@ -165,8 +151,5 @@
   "errorGoHome": "Till startsidan",
   "errorBoardNotFound": "Tavlan hittades inte",
   "errorBoardSetNotFound": "Tavlan hittades inte",
-  "boardUrlReplaceConfirmTitle": "Ersätt ”{name}”?",
-  "boardUrlReplaceConfirmDescription": "Import från {host} ersätter den här tavlan och allt i den. Den här åtgärden kan inte ångras.",
-  "boardUrlReplace": "Ersätt",
   "boardUrlImportFailed": "Det gick inte att importera tavlan från länken"
 }

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "மாற்று",
   "switchScanningNextItemSwitch": "அடுத்த உருப்படிக்கான சுவிட்ச்",
   "switchScanningScanSwitch": "வருடல் சுவிட்ச்",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "மீண்டும் மீண்டும் அழுத்துவதைப் புறக்கணிக்கவும்",
   "switchScanningMinimumPressDuration": "குறைந்தபட்ச அழுத்த காலம்",
   "switchScanningAssign": "ஒதுக்க ஒரு சுவிட்சை அழுத்தவும்",
-  "switchScanningNextItem": "அடுத்த உருப்படி",
   "switchScanningSelectSwitch": "தேர்ந்தெடுக்கும் சுவிட்ச்",
   "switchScanningMouseInput": "சுட்டி பொத்தான் {button}",
-  "switchScanningActions": "செயல்கள்",
-  "switchScanningActionsExit": "செயல்களிலிருந்து பின்செல்",
   "switchScanningRow": "வரி {row}",
   "switchScanningRowExit": "{row} ஆம் வரியிலிருந்து பின்செல்",
   "loading": "ஏற்றப்படுகிறது…",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "பலகை இறக்குமதி செய்யப்பட்டது",
         "countPlural=*": "பலகைகள் இறக்குமதி செய்யப்பட்டன"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "பலகை மாற்றப்பட்டது",
-        "countPlural=*": "பலகைகள் மாற்றப்பட்டன"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "சுவிட்ச் அணுகல்",
   "switchScanningEnabled": "சுவிட்ச் ஸ்கேனிங்கை இயக்கு",
   "switchScanningMethod": "ஸ்கேன் முறை",
-  "switchScanningOneSwitch": "ஒரு சுவிட்ச்",
-  "switchScanningTwoSwitches": "இரண்டு சுவிட்ச்கள்",
   "switchScanningMethodAuto": "தானியங்கி",
   "switchScanningMethodStep": "இரண்டு-சுவிட்ச் படி",
   "switchScanningMethodDwell": "ஒற்றை-சுவிட்ச் காத்திருப்பு",
@@ -165,8 +151,5 @@
   "errorGoHome": "முகப்புக்குச் செல்",
   "errorBoardNotFound": "பலகை கிடைக்கவில்லை",
   "errorBoardSetNotFound": "பலகை கிடைக்கவில்லை",
-  "boardUrlReplaceConfirmTitle": "\"{name}\" என்பதை மாற்றவா?",
-  "boardUrlReplaceConfirmDescription": "{host} இலிருந்து இறக்குமதி செய்தால், இந்தப் பலகையும் அதில் உள்ள அனைத்தும் மாற்றப்படும். இந்தச் செயலைச் செயல்தவிர்க்க முடியாது.",
-  "boardUrlReplace": "மாற்று",
   "boardUrlImportFailed": "இணைப்பிலிருந்து பலகையை இறக்குமதி செய்ய முடியவில்லை"
 }

--- a/messages/te.json
+++ b/messages/te.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "మార్చు",
   "switchScanningNextItemSwitch": "తదుపరి అంశం స్విచ్",
   "switchScanningScanSwitch": "స్కాన్ స్విచ్",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "పదేపదే నొక్కడం విస్మరించండి",
   "switchScanningMinimumPressDuration": "కనీస నొక్కు వ్యవధి",
   "switchScanningAssign": "కేటాయించడానికి ఒక స్విచ్‌ను నొక్కండి",
-  "switchScanningNextItem": "తదుపరి అంశం",
   "switchScanningSelectSwitch": "ఎంచుకునే స్విచ్",
   "switchScanningMouseInput": "మౌస్ బటన్ {button}",
-  "switchScanningActions": "చర్యలు",
-  "switchScanningActionsExit": "చర్యల నుండి వెనక్కి",
   "switchScanningRow": "వరుస {row}",
   "switchScanningRowExit": "{row}వ వరుస నుండి వెనక్కి",
   "loading": "లోడ్ అవుతోంది…",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "బోర్డు దిగుమతి చేయబడింది",
         "countPlural=*": "బోర్డులు దిగుమతి చేయబడ్డాయి"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "బోర్డు భర్తీ చేయబడింది",
-        "countPlural=*": "బోర్డులు భర్తీ చేయబడ్డాయి"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "స్విచ్ యాక్సెస్",
   "switchScanningEnabled": "స్విచ్ స్కానింగ్‌ను ప్రారంభించండి",
   "switchScanningMethod": "స్కాన్ పద్ధతి",
-  "switchScanningOneSwitch": "ఒక స్విచ్",
-  "switchScanningTwoSwitches": "రెండు స్విచ్‌లు",
   "switchScanningMethodAuto": "స్వయంచాలక",
   "switchScanningMethodStep": "రెండు-స్విచ్ దశ",
   "switchScanningMethodDwell": "ఒక-స్విచ్ నిరీక్షణ",
@@ -165,8 +151,5 @@
   "errorGoHome": "హోమ్‌కు వెళ్లు",
   "errorBoardNotFound": "బోర్డు కనుగొనబడలేదు",
   "errorBoardSetNotFound": "బోర్డు కనుగొనబడలేదు",
-  "boardUrlReplaceConfirmTitle": "\"{name}\"ను భర్తీ చేయాలా?",
-  "boardUrlReplaceConfirmDescription": "{host} నుండి దిగుమతి చేస్తే ఈ బోర్డు మరియు అందులోని అన్నీ భర్తీ అవుతాయి. ఈ చర్యను రద్దు చేయడం సాధ్యం కాదు.",
-  "boardUrlReplace": "భర్తీ చేయి",
   "boardUrlImportFailed": "లింక్ నుండి బోర్డును దిగుమతి చేయలేకపోయాం"
 }

--- a/messages/th.json
+++ b/messages/th.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "เปลี่ยน",
   "switchScanningNextItemSwitch": "สวิตช์รายการถัดไป",
   "switchScanningScanSwitch": "สวิตช์สแกน",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "ละเว้นการกดซ้ำ",
   "switchScanningMinimumPressDuration": "ระยะเวลากดขั้นต่ำ",
   "switchScanningAssign": "กดสวิตช์เพื่อกำหนด",
-  "switchScanningNextItem": "รายการถัดไป",
   "switchScanningSelectSwitch": "สวิตช์เลือก",
   "switchScanningMouseInput": "ปุ่มเมาส์ {button}",
-  "switchScanningActions": "การดำเนินการ",
-  "switchScanningActionsExit": "ย้อนกลับจากการดำเนินการ",
   "switchScanningRow": "แถว {row}",
   "switchScanningRowExit": "ย้อนกลับจากแถว {row}",
   "loading": "กำลังโหลด...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "นำเข้าบอร์ดแล้ว",
         "countPlural=*": "นำเข้าบอร์ดแล้ว"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "แทนที่บอร์ดแล้ว",
-        "countPlural=*": "แทนที่บอร์ดแล้ว"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "การเข้าถึงด้วยสวิตช์",
   "switchScanningEnabled": "เปิดใช้การสแกนด้วยสวิตช์",
   "switchScanningMethod": "วิธีการสแกน",
-  "switchScanningOneSwitch": "หนึ่งสวิตช์",
-  "switchScanningTwoSwitches": "สองสวิตช์",
   "switchScanningMethodAuto": "อัตโนมัติ",
   "switchScanningMethodStep": "เลื่อนด้วยสองสวิตช์",
   "switchScanningMethodDwell": "ค้างด้วยสวิตช์เดียว",
@@ -165,8 +151,5 @@
   "errorGoHome": "ไปที่หน้าแรก",
   "errorBoardNotFound": "ไม่พบบอร์ด",
   "errorBoardSetNotFound": "ไม่พบบอร์ด",
-  "boardUrlReplaceConfirmTitle": "แทนที่ \"{name}\" ไหม",
-  "boardUrlReplaceConfirmDescription": "การนำเข้าจาก {host} จะแทนที่บอร์ดนี้และทุกอย่างในบอร์ด ไม่สามารถเลิกทำการกระทำนี้ได้",
-  "boardUrlReplace": "แทนที่",
   "boardUrlImportFailed": "นำเข้าบอร์ดจากลิงก์ไม่สำเร็จ"
 }

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "Değiştir",
   "switchScanningNextItemSwitch": "Sonraki öğe anahtarı",
   "switchScanningScanSwitch": "Tarama anahtarı",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "Yinelenen basışları yok say",
   "switchScanningMinimumPressDuration": "Minimum basma süresi",
   "switchScanningAssign": "Atamak için bir anahtara basın",
-  "switchScanningNextItem": "Sonraki öğe",
   "switchScanningSelectSwitch": "Seçim anahtarı",
   "switchScanningMouseInput": "Fare düğmesi {button}",
-  "switchScanningActions": "Eylemler",
-  "switchScanningActionsExit": "Eylemlerden geri dön",
   "switchScanningRow": "{row}. satır",
   "switchScanningRowExit": "{row}. satırdan geri dön",
   "loading": "Yükleniyor...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "Pano içe aktarıldı",
         "countPlural=*": "Panolar içe aktarıldı"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Pano değiştirildi",
-        "countPlural=*": "Panolar değiştirildi"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "Anahtar erişimi",
   "switchScanningEnabled": "Anahtarla taramayı etkinleştir",
   "switchScanningMethod": "Tarama yöntemi",
-  "switchScanningOneSwitch": "Tek anahtar",
-  "switchScanningTwoSwitches": "İki anahtar",
   "switchScanningMethodAuto": "Otomatik",
   "switchScanningMethodStep": "İki anahtarlı adım",
   "switchScanningMethodDwell": "Tek anahtarlı bekleme",
@@ -165,8 +151,5 @@
   "errorGoHome": "Ana sayfaya git",
   "errorBoardNotFound": "Pano bulunamadı",
   "errorBoardSetNotFound": "Pano bulunamadı",
-  "boardUrlReplaceConfirmTitle": "\"{name}\" değiştirilsin mi?",
-  "boardUrlReplaceConfirmDescription": "{host} adresinden içe aktarma bu panoyu ve içindeki her şeyi değiştirir. Bu işlem geri alınamaz.",
-  "boardUrlReplace": "Değiştir",
   "boardUrlImportFailed": "Pano bağlantıdan içe aktarılamadı"
 }

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "Змінити",
   "switchScanningNextItemSwitch": "Перемикач наступного елемента",
   "switchScanningScanSwitch": "Перемикач сканування",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "Ігнорувати повторні натискання",
   "switchScanningMinimumPressDuration": "Мінімальна тривалість натискання",
   "switchScanningAssign": "Натисніть перемикач, щоб призначити його",
-  "switchScanningNextItem": "Наступний елемент",
   "switchScanningSelectSwitch": "Перемикач вибору",
   "switchScanningMouseInput": "Кнопка миші {button}",
-  "switchScanningActions": "Дії",
-  "switchScanningActionsExit": "Назад із дій",
   "switchScanningRow": "Рядок {row}",
   "switchScanningRowExit": "Назад із рядка {row}",
   "loading": "Завантаження...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "Дошку імпортовано",
         "countPlural=*": "Дошки імпортовано"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Дошку замінено",
-        "countPlural=*": "Дошки замінено"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "Керування перемикачем",
   "switchScanningEnabled": "Увімкнути сканування перемикачем",
   "switchScanningMethod": "Метод сканування",
-  "switchScanningOneSwitch": "Один перемикач",
-  "switchScanningTwoSwitches": "Два перемикачі",
   "switchScanningMethodAuto": "Автоматичний",
   "switchScanningMethodStep": "Крок двома перемикачами",
   "switchScanningMethodDwell": "Затримка з одним перемикачем",
@@ -165,8 +151,5 @@
   "errorGoHome": "На головну",
   "errorBoardNotFound": "Дошку не знайдено",
   "errorBoardSetNotFound": "Дошку не знайдено",
-  "boardUrlReplaceConfirmTitle": "Замінити «{name}»?",
-  "boardUrlReplaceConfirmDescription": "Імпорт із сайту {host} замінить цю дошку та весь її вміст. Цю дію не можна скасувати.",
-  "boardUrlReplace": "Замінити",
   "boardUrlImportFailed": "Не вдалося імпортувати дошку за посиланням"
 }

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "Thay đổi",
   "switchScanningNextItemSwitch": "Công tắc mục tiếp theo",
   "switchScanningScanSwitch": "Công tắc quét",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "Bỏ qua các lần nhấn lặp lại",
   "switchScanningMinimumPressDuration": "Thời lượng nhấn tối thiểu",
   "switchScanningAssign": "Nhấn một công tắc để gán",
-  "switchScanningNextItem": "Mục tiếp theo",
   "switchScanningSelectSwitch": "Công tắc chọn",
   "switchScanningMouseInput": "Nút chuột {button}",
-  "switchScanningActions": "Thao tác",
-  "switchScanningActionsExit": "Quay lại từ thao tác",
   "switchScanningRow": "Hàng {row}",
   "switchScanningRowExit": "Quay lại từ hàng {row}",
   "loading": "Đang tải...",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "Đã nhập bảng",
         "countPlural=*": "Đã nhập các bảng"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "Đã thay thế bảng",
-        "countPlural=*": "Đã thay thế các bảng"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "Truy cập bằng công tắc",
   "switchScanningEnabled": "Bật quét bằng công tắc",
   "switchScanningMethod": "Phương thức quét",
-  "switchScanningOneSwitch": "Một công tắc",
-  "switchScanningTwoSwitches": "Hai công tắc",
   "switchScanningMethodAuto": "Tự động",
   "switchScanningMethodStep": "Bước bằng hai công tắc",
   "switchScanningMethodDwell": "Dừng bằng một công tắc",
@@ -165,8 +151,5 @@
   "errorGoHome": "Về trang chủ",
   "errorBoardNotFound": "Không tìm thấy bảng",
   "errorBoardSetNotFound": "Không tìm thấy bảng",
-  "boardUrlReplaceConfirmTitle": "Thay thế \"{name}\"?",
-  "boardUrlReplaceConfirmDescription": "Nhập từ {host} sẽ thay thế bảng này và mọi thứ trong đó. Không thể hoàn tác hành động này.",
-  "boardUrlReplace": "Thay thế",
   "boardUrlImportFailed": "Không thể nhập bảng từ liên kết"
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://inlang.com/schema/inlang-message-format",
+  "appName": "AAC Board AI",
   "switchScanningChange": "更改",
   "switchScanningNextItemSwitch": "下一项开关",
   "switchScanningScanSwitch": "扫描开关",
@@ -21,11 +22,8 @@
   "switchScanningIgnoreRepeatedPresses": "忽略重复按压",
   "switchScanningMinimumPressDuration": "最短按压时长",
   "switchScanningAssign": "按下一个开关进行分配",
-  "switchScanningNextItem": "下一项",
   "switchScanningSelectSwitch": "选择开关",
   "switchScanningMouseInput": "鼠标按钮 {button}",
-  "switchScanningActions": "操作",
-  "switchScanningActionsExit": "从操作返回",
   "switchScanningRow": "第 {row} 行",
   "switchScanningRowExit": "从第 {row} 行返回",
   "loading": "正在加载……",
@@ -55,16 +53,6 @@
       "match": {
         "countPlural=one": "已导入沟通板",
         "countPlural=*": "已导入沟通板"
-      }
-    }
-  ],
-  "libraryReplacedBoards": [
-    {
-      "declarations": ["input count", "local countPlural = count: plural"],
-      "selectors": ["countPlural"],
-      "match": {
-        "countPlural=one": "已替换沟通板",
-        "countPlural=*": "已替换沟通板"
       }
     }
   ],
@@ -111,8 +99,6 @@
   "settingsSectionSwitchAccess": "开关控制",
   "switchScanningEnabled": "启用开关扫描",
   "switchScanningMethod": "扫描方式",
-  "switchScanningOneSwitch": "单开关",
-  "switchScanningTwoSwitches": "双开关",
   "switchScanningMethodAuto": "自动",
   "switchScanningMethodStep": "双开关步进",
   "switchScanningMethodDwell": "单开关停留",
@@ -165,8 +151,5 @@
   "errorGoHome": "返回主页",
   "errorBoardNotFound": "未找到沟通板",
   "errorBoardSetNotFound": "未找到沟通板",
-  "boardUrlReplaceConfirmTitle": "替换“{name}”？",
-  "boardUrlReplaceConfirmDescription": "从 {host} 导入将替换此沟通板及其中的所有内容。此操作无法撤消。",
-  "boardUrlReplace": "替换",
   "boardUrlImportFailed": "无法从链接导入沟通板"
 }

--- a/src/app/onboarding/onboarding-dialog.tsx
+++ b/src/app/onboarding/onboarding-dialog.tsx
@@ -16,8 +16,6 @@ import { m } from "@paraglide/messages.js";
 import { useTranslate } from "@shared/language/use-translate";
 import type { ReactNode } from "react";
 
-const APP_NAME = "AAC Board AI";
-
 interface OnboardingDialogProps {
   open: boolean;
   onClose: () => void;
@@ -92,7 +90,7 @@ export function OnboardingDialog({ open, onClose }: OnboardingDialogProps) {
           textAlign: "center",
         }}
       >
-        {APP_NAME}
+        {t(m.appName)}
       </DialogTitle>
 
       <DialogContent>

--- a/src/app/routing/app-routes.tsx
+++ b/src/app/routing/app-routes.tsx
@@ -5,6 +5,7 @@ import { rootIndexLoader } from "@app/routing/loaders/root-index-loader";
 import { NotFound } from "@app/routing/not-found";
 import { RouteErrorBoundary } from "@app/routing/route-error-boundary";
 import { BOARD_SEGMENT, BOARD_SET_SEGMENT } from "@features/board";
+import { BoardPage } from "@pages/board-page";
 import { LoadingState } from "@shared/components/loading-state";
 import type { RouteObject } from "react-router";
 
@@ -29,7 +30,7 @@ export const appRoutes: RouteObject[] = [
               {
                 path: BOARD_SEGMENT,
                 loader: boardLoader,
-                lazy: () => import("@pages/board-page"),
+                Component: BoardPage,
               },
             ],
           },

--- a/src/pages/board-page.tsx
+++ b/src/pages/board-page.tsx
@@ -1,7 +1,7 @@
 import { BoardViewer, type Board } from "@features/board";
 import { useLoaderData } from "react-router";
 
-export const Component = function BoardPage() {
+export function BoardPage() {
   const board = useLoaderData<Board>();
 
   return (
@@ -10,4 +10,4 @@ export const Component = function BoardPage() {
       <BoardViewer board={board} />
     </>
   );
-};
+}


### PR DESCRIPTION
## What changed

- remove stale, unused translation keys across every locale
- move the AAC Board AI app name into Paraglide messages
- make the board route use the same explicit component-export convention as the rest of the app
- correct README and architecture documentation inconsistencies

## Why

The codebase had accumulated small mismatches between implementation, localization resources, routing conventions, and documentation. Keeping these aligned reduces maintenance overhead and makes the project invariants more accurate.

## Impact

No intended user-facing behavior changes. The onboarding title remains the same, unused locale entries are removed, and the active board route keeps its existing behavior.

## Validation

- `npm run lint`
- `npm test` — 78 files, 559 tests passed
- `npm run build`
