### PR TITLE
chore: bump version to 1.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aac-board-ai",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aac-board-ai",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aac-board-ai",
   "private": true,
-  "version": "1.15.0",
+  "version": "1.16.0",
   "license": "MIT",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## What changed

- bump the application version from `1.15.0` to `1.16.0`
- keep the npm lockfile metadata aligned

## Why

The changes merged since `v1.15.0` include substantial user-facing improvements to switch access, language selection, suggestions, imports, playback, navigation, and responsive layout. A minor release reflects that expanded functionality.

## User impact

This prepares the repository for the `v1.16.0` tag and GitHub Release. It does not add behavior beyond the changes already merged on `main`.

## Validation

- `npm run lint`
- `npm test` — 79 files, 568 tests passed
- `npm run build`
