### PR TITLE
Clarify README offline behavior and demo alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 </div>
 
-**AAC Board AI** is a local-first Augmentative and Alternative Communication (AAC) board for people who cannot rely on speech. Its core communication features work offline in modern browsers, while optional browser-native **Built-in AI** improves grammar, adjusts tone, and translates boards on-device.
+**AAC Board AI** is a local-first Augmentative and Alternative Communication (AAC) board for people who cannot rely on speech. Core board features work offline after the app and a board have been loaded, while optional browser-native **Built-in AI** improves grammar, adjusts tone, and translates boards on-device.
 
-![Demo: selecting “want,” go,” and “my room” accepting “I'm heading to my room now.” and playing the message aloud](demo.gif)
+![Demo: selecting “want,” “go,” and “my room,” accepting “I’m heading to my room now,” and playing the message aloud](demo.gif)
 
 _Built-in AI is a progressive enhancement; availability depends on the browser, device, language, and downloaded models._
 

--- a/src/features/board/storage/board-hydration.ts
+++ b/src/features/board/storage/board-hydration.ts
@@ -13,7 +13,7 @@ import { BoardNotFoundError, getAssetBlob, getBoard } from "./boards-db";
 // board's URLs. Each call builds URLs in its own registry, checks the abort
 // signal after every await, and swaps into `previousRegistry` synchronously
 // only if it wins; a superseded call throws first and revokes only its own
-// registry. Single concurrent caller assumed — the only consumer is boardLoader.
+// registry. The only production call site is boardLoader.
 let previousRegistry: ObjectUrlRegistry | null = null;
 
 export async function hydrateBoard(


### PR DESCRIPTION
## Summary

- clarify that core board features work offline after the app and a board are loaded
- correct malformed punctuation in the demo image alt text
- clarify the production call-site assumption in the board hydration comment

## Why

The previous offline claim could imply that speech output is always local, even though speech behavior depends on the platform. The demo alt text also contained malformed quotation marks that reduced readability for assistive technology users.

## Impact

Documentation now describes offline behavior more precisely and provides clearer demo alt text. Runtime behavior is unchanged.

## Validation

- `npm run lint`
- `npm test` (568 tests)
- `npm run build`
