### PR TITLE
Fix board media URL lifetime

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,12 +89,15 @@ of board use.
 React Router loaders prepare the active board before its route renders:
 
 1. Navigate to `/sets/:setId/boards/:boardId`.
-2. `hydrateBoard` reads raw OBF and asset blobs, creates media object URLs, and
-   maps the result through `obfToBoard` into the in-memory `Board`.
+2. `hydrateBoard` reads raw OBF and asset blobs, creates provisional media
+   object URLs, and maps the result through `obfToBoard` into the in-memory
+   `Board`.
 3. `resolveTranslatedBoard` uses an existing translation or attempts an optional
    translation. Success is applied immediately and cached with a best-effort,
    asynchronous IndexedDB write; failure returns the untranslated board.
-4. Render the grid with a ready `Board`.
+4. Render the grid with a ready `Board`; the route-lifetime observer commits its
+   media and releases the prior board. An aborted load releases only its own
+   provisional media.
 
 ### Activate a tile
 
@@ -178,8 +181,10 @@ rerender only subscribers to the changed slice.
   the in-memory model on every read so its shape can evolve without rewriting
   imported records.
 - **The active board is loader-owned.** Hydration and optional translation finish
-  before the new route renders. Ancillary board summaries may load through the
-  storage API without becoming another active-board path.
+  before the new route renders. Its media remains provisional until the route
+  commits, and leaving the route releases the committed media. Ancillary board
+  summaries may load through the storage API without becoming another
+  active-board path.
 - **Optional AI is capability-detected and failure-tolerant.** Consumers use
   `@shayc/react-built-in-ai`, never User-Agent checks. Suggestions disappear when
   unavailable; translation returns the untranslated board.
@@ -240,12 +245,6 @@ rise with meaningful coverage gains and are not lowered to admit a regression.
   locales remain selectable even when the browser exposes no matching voice. The
   app does not require `SpeechSynthesisVoice.localService`, so a selected voice's
   offline and privacy behavior remains platform-dependent.
-- **Media object-URL lifetime is coupled to hydration.** `hydrateBoard` replaces
-  the module-level URL registry and revokes the previous registry when hydration
-  completes, before optional translation and route commit finish. A pending
-  navigation can therefore revoke media still used by the visible board. The
-  ownership transition should move to route commit or another render-aware
-  lifecycle.
 - **Deployment configuration is host-specific.** The static SPA is portable, but
   the current deployment configuration is Netlify-only (`netlify.toml`).
 

--- a/src/app/layouts/app-shell.tsx
+++ b/src/app/layouts/app-shell.tsx
@@ -3,6 +3,7 @@ import { ContentColumn } from "@app/layouts/content-column";
 import { LibraryDrawer } from "@app/library/library-drawer";
 import { OnboardingDialog } from "@app/onboarding/onboarding-dialog";
 import { useOnboarding } from "@app/onboarding/use-onboarding";
+import { useBoardMediaLifetime } from "@app/routing/use-board-media-lifetime";
 import { useRevalidateOnLanguageChange } from "@app/routing/use-revalidate-on-language-change";
 import { SettingsDrawer } from "@app/settings/settings-drawer";
 import {
@@ -27,6 +28,7 @@ export function AppShell() {
   const isLibraryPushingContent = isPersistentLibrary && isLibraryOpen;
 
   useFileHandlerLaunch();
+  useBoardMediaLifetime();
   useRevalidateOnLanguageChange();
 
   return (

--- a/src/app/routing/app-routes.tsx
+++ b/src/app/routing/app-routes.tsx
@@ -4,6 +4,7 @@ import { boardSetIndexLoader } from "@app/routing/loaders/board-set-index-loader
 import { rootIndexLoader } from "@app/routing/loaders/root-index-loader";
 import { NotFound } from "@app/routing/not-found";
 import { RouteErrorBoundary } from "@app/routing/route-error-boundary";
+import { BOARD_ROUTE_ID } from "@app/routing/use-board-media-lifetime";
 import { BOARD_SEGMENT, BOARD_SET_SEGMENT } from "@features/board";
 import { BoardPage } from "@pages/board-page";
 import { LoadingState } from "@shared/components/loading-state";
@@ -28,6 +29,7 @@ export const appRoutes: RouteObject[] = [
             children: [
               { index: true, loader: boardSetIndexLoader },
               {
+                id: BOARD_ROUTE_ID,
                 path: BOARD_SEGMENT,
                 loader: boardLoader,
                 Component: BoardPage,

--- a/src/app/routing/loaders/board-loader.test.ts
+++ b/src/app/routing/loaders/board-loader.test.ts
@@ -3,6 +3,7 @@ import {
   resetBoardsDB,
   seedBoardSets,
 } from "@features/board/testing";
+import type { HydratedBoard } from "@features/board";
 import type { LoaderFunctionArgs } from "react-router";
 import { beforeEach, describe, expect, test } from "vitest";
 import { boardLoader } from "./board-loader";
@@ -10,7 +11,7 @@ import { boardLoader } from "./board-loader";
 function callLoader(
   setId: string | undefined,
   boardId: string | undefined,
-): Promise<unknown> {
+): Promise<HydratedBoard> {
   const args = {
     request: new Request("http://localhost/"),
     params: { setId, boardId },
@@ -57,8 +58,10 @@ describe("boardLoader", () => {
       },
     ]);
 
-    const board = await callLoader("set-1", "root-1");
+    const loadedBoard = await callLoader("set-1", "root-1");
 
-    expect(board).toMatchObject({ id: "root-1", name: "Home" });
+    expect(loadedBoard.board).toMatchObject({ id: "root-1", name: "Home" });
+
+    loadedBoard.media.dispose();
   });
 });

--- a/src/app/routing/loaders/board-loader.ts
+++ b/src/app/routing/loaders/board-loader.ts
@@ -3,7 +3,8 @@ import {
   hydrateBoard,
   InvalidIdError,
   resolveTranslatedBoard,
-  type Board,
+  type BoardMediaResource,
+  type HydratedBoard,
 } from "@features/board";
 import { getStoredLanguage } from "@shared/language/language-store";
 import { data, type LoaderFunctionArgs } from "react-router";
@@ -12,7 +13,7 @@ import { createLocalizedRouteError, routeErrorCodes } from "../route-error";
 export async function boardLoader({
   params,
   request,
-}: LoaderFunctionArgs): Promise<Board> {
+}: LoaderFunctionArgs): Promise<HydratedBoard> {
   const { setId, boardId } = params;
   if (!setId || !boardId) {
     throw data(createLocalizedRouteError(routeErrorCodes.boardNotFound), {
@@ -20,12 +21,24 @@ export async function boardLoader({
     });
   }
 
+  let media: BoardMediaResource | undefined;
   try {
-    const board = await hydrateBoard(setId, boardId, request.signal);
+    const hydrated = await hydrateBoard(setId, boardId, request.signal);
+    media = hydrated.media;
     const language = getStoredLanguage();
+    const board = await resolveTranslatedBoard(
+      setId,
+      hydrated.board,
+      language,
+      request.signal,
+    );
 
-    return await resolveTranslatedBoard(setId, board, language, request.signal);
+    request.signal.throwIfAborted();
+
+    return { board, media };
   } catch (error) {
+    media?.dispose();
+
     if (
       error instanceof BoardNotFoundError ||
       error instanceof InvalidIdError

--- a/src/app/routing/use-board-media-lifetime.test.tsx
+++ b/src/app/routing/use-board-media-lifetime.test.tsx
@@ -1,0 +1,243 @@
+import { hydrateBoard, type HydratedBoard } from "@features/board";
+import { makeOBFBoard, seedBoardSets } from "@features/board/testing";
+import { StrictMode } from "react";
+import {
+  createMemoryRouter,
+  Outlet,
+  type LoaderFunctionArgs,
+  useLoaderData,
+} from "react-router";
+import { RouterProvider } from "react-router/dom";
+import { expect, test, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { assertDefined } from "@shared/testing/assert-defined";
+import {
+  BOARD_ROUTE_ID,
+  useBoardMediaLifetime,
+} from "./use-board-media-lifetime";
+
+const SET_ID = "media-lifetime-set";
+const IMAGE_PATH = "images/test.png";
+const REAL_PNG_URL = "/pwa-192x192.png";
+
+interface Gate {
+  promise: Promise<void>;
+  open(): void;
+}
+
+function createGate(): Gate {
+  let open: () => void = () => undefined;
+  const promise = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+
+  return { promise, open };
+}
+
+function getAbortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new DOMException("The operation was aborted", "AbortError");
+}
+
+async function waitForGate(gate: Gate, signal: AbortSignal): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    function handleAbort() {
+      signal.removeEventListener("abort", handleAbort);
+      reject(getAbortError(signal));
+    }
+
+    if (signal.aborted) {
+      handleAbort();
+      return;
+    }
+
+    signal.addEventListener("abort", handleAbort, { once: true });
+    void gate.promise.then(() => {
+      signal.removeEventListener("abort", handleAbort);
+      resolve();
+    });
+  });
+}
+
+function TestShell() {
+  useBoardMediaLifetime();
+
+  return <Outlet />;
+}
+
+function TestHydrateFallback() {
+  return null;
+}
+
+function TestBoard() {
+  const { board } = useLoaderData<HydratedBoard>();
+  const imageUrl = board.buttons[0].imageSrc;
+  assertDefined(imageUrl);
+
+  return <img src={imageUrl} alt={board.name} />;
+}
+
+function isObjectUrlAlive(url: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const image = new Image();
+    const settle = (result: boolean) => {
+      image.onload = null;
+      image.onerror = null;
+      resolve(result);
+    };
+
+    image.onload = () => settle(true);
+    image.onerror = () => settle(false);
+    image.src = url;
+  });
+}
+
+function getImageUrl(loadedBoard: HydratedBoard): string {
+  const imageUrl = loadedBoard.board.buttons[0].imageSrc;
+  assertDefined(imageUrl);
+
+  return imageUrl;
+}
+
+function makeBoard(boardId: string, name: string) {
+  const obf = makeOBFBoard({
+    id: boardId,
+    name,
+    grid: { rows: 1, columns: 1, order: [["button-1"]] },
+    buttons: [{ id: "button-1", label: name, image_id: "image-1" }],
+    images: [{ id: "image-1", path: IMAGE_PATH, content_type: "image/png" }],
+  });
+
+  return { boardId, name, obf };
+}
+
+async function seedBoards(): Promise<void> {
+  const pngResponse = await fetch(REAL_PNG_URL);
+  if (!pngResponse.ok) {
+    throw new Error(`Could not fetch ${REAL_PNG_URL} for fixture image`);
+  }
+
+  await seedBoardSets([
+    {
+      setId: SET_ID,
+      name: "Media Lifetime",
+      rootBoardId: "first",
+      boards: [
+        makeBoard("first", "First Board"),
+        makeBoard("second", "Second Board"),
+        makeBoard("third", "Third Board"),
+      ],
+      assets: [{ path: IMAGE_PATH, blob: await pngResponse.blob() }],
+    },
+  ]);
+}
+
+test("owns media according to the committed board route", async () => {
+  await seedBoards();
+
+  const loadedBoards = new Map<string, HydratedBoard>();
+  const gates = new Map([
+    ["second", createGate()],
+    ["third", createGate()],
+  ]);
+
+  async function loader({
+    params,
+    request,
+  }: LoaderFunctionArgs): Promise<HydratedBoard> {
+    const boardId = params.boardId;
+    assertDefined(boardId);
+
+    const loadedBoard = await hydrateBoard(SET_ID, boardId, request.signal);
+    loadedBoards.set(boardId, loadedBoard);
+
+    const gate = gates.get(boardId);
+    if (gate) {
+      await waitForGate(gate, request.signal);
+    }
+
+    request.signal.throwIfAborted();
+
+    return loadedBoard;
+  }
+
+  const router = createMemoryRouter(
+    [
+      {
+        path: "/",
+        Component: TestShell,
+        HydrateFallback: TestHydrateFallback,
+        children: [
+          { index: true, element: <p>Outside board route</p> },
+          {
+            id: BOARD_ROUTE_ID,
+            path: "boards/:boardId",
+            loader,
+            Component: TestBoard,
+          },
+        ],
+      },
+    ],
+    { initialEntries: ["/boards/first"] },
+  );
+
+  const screen = await render(
+    <StrictMode>
+      <RouterProvider router={router} />
+    </StrictMode>,
+  );
+
+  await expect
+    .element(screen.getByRole("img", { name: "First Board" }))
+    .toBeVisible();
+
+  const first = loadedBoards.get("first");
+  assertDefined(first);
+  const firstUrl = getImageUrl(first);
+  expect(await isObjectUrlAlive(firstUrl)).toBe(true);
+
+  const secondNavigation = router.navigate("/boards/second");
+  await vi.waitFor(() => expect(loadedBoards.has("second")).toBe(true));
+
+  const second = loadedBoards.get("second");
+  assertDefined(second);
+  const secondUrl = getImageUrl(second);
+
+  await expect
+    .element(screen.getByRole("img", { name: "First Board" }))
+    .toBeVisible();
+  expect(await isObjectUrlAlive(firstUrl)).toBe(true);
+  expect(await isObjectUrlAlive(secondUrl)).toBe(true);
+
+  const thirdNavigation = router.navigate("/boards/third");
+  await secondNavigation;
+  gates.get("second")?.open();
+  await vi.waitFor(() => expect(loadedBoards.has("third")).toBe(true));
+
+  const third = loadedBoards.get("third");
+  assertDefined(third);
+  const thirdUrl = getImageUrl(third);
+
+  await vi.waitFor(async () => {
+    expect(await isObjectUrlAlive(secondUrl)).toBe(false);
+  });
+  expect(await isObjectUrlAlive(firstUrl)).toBe(true);
+  expect(await isObjectUrlAlive(thirdUrl)).toBe(true);
+
+  gates.get("third")?.open();
+  await thirdNavigation;
+  await expect
+    .element(screen.getByRole("img", { name: "Third Board" }))
+    .toBeVisible();
+  await vi.waitFor(async () => {
+    expect(await isObjectUrlAlive(firstUrl)).toBe(false);
+  });
+  expect(await isObjectUrlAlive(thirdUrl)).toBe(true);
+
+  await router.navigate("/");
+  await expect.element(screen.getByText("Outside board route")).toBeVisible();
+  await vi.waitFor(async () => {
+    expect(await isObjectUrlAlive(thirdUrl)).toBe(false);
+  });
+});

--- a/src/app/routing/use-board-media-lifetime.ts
+++ b/src/app/routing/use-board-media-lifetime.ts
@@ -1,0 +1,28 @@
+import type { BoardMediaResource, HydratedBoard } from "@features/board";
+import { useEffect } from "react";
+import { useRouteLoaderData } from "react-router";
+
+export const BOARD_ROUTE_ID = "board";
+
+let committedMedia: BoardMediaResource | undefined;
+
+export function useBoardMediaLifetime(): void {
+  const loadedBoard = useRouteLoaderData<HydratedBoard>(BOARD_ROUTE_ID);
+  const media = loadedBoard?.media;
+
+  // Route data becoming undefined is the unmount signal. Effect cleanup would
+  // revoke live media during Strict Mode's development replay.
+  useEffect(() => replaceCommittedMedia(media), [media]);
+}
+
+function replaceCommittedMedia(next: BoardMediaResource | undefined): void {
+  if (next === committedMedia) {
+    return;
+  }
+
+  next?.commit();
+
+  const previous = committedMedia;
+  committedMedia = next;
+  previous?.dispose();
+}

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -12,6 +12,10 @@ export {
 } from "./navigation/board-paths";
 export { BoardSelector } from "./navigation/board-selector";
 export { hydrateBoard } from "./storage/board-hydration";
+export type {
+  BoardMediaResource,
+  HydratedBoard,
+} from "./storage/board-hydration";
 export {
   BoardNotFoundError,
   getBoardSet,

--- a/src/features/board/storage/board-hydration.test.ts
+++ b/src/features/board/storage/board-hydration.test.ts
@@ -2,7 +2,7 @@ import type { OBFBoard } from "@shayc/open-board-format";
 import { beforeEach, describe, expect, test } from "vitest";
 import { assertDefined } from "@shared/testing/assert-defined";
 import { refreshBoardSets } from "../board-sets/board-sets-store";
-import { hydrateBoard } from "./board-hydration";
+import { hydrateBoard, type HydratedBoard } from "./board-hydration";
 import { BoardNotFoundError, replaceBoardSet } from "./boards-db";
 import { resetBoardsDB } from "../testing";
 
@@ -62,6 +62,13 @@ function isObjectUrlAlive(url: string): Promise<boolean> {
   });
 }
 
+function getImageUrl(loadedBoard: HydratedBoard): string {
+  const imageUrl = loadedBoard.board.buttons[0].imageSrc;
+  assertDefined(imageUrl);
+
+  return imageUrl;
+}
+
 describe("hydrateBoard", () => {
   beforeEach(async () => {
     await resetBoardsDB();
@@ -71,14 +78,15 @@ describe("hydrateBoard", () => {
   test("returns a hydrated board on the happy path", async () => {
     await seedTestBoard();
 
-    const board = await hydrateBoard(SET_ID, BOARD_ID);
+    const loadedBoard = await hydrateBoard(SET_ID, BOARD_ID);
 
-    expect(board.id).toBe(BOARD_ID);
+    expect(loadedBoard.board.id).toBe(BOARD_ID);
 
-    const imageSrc = board.buttons[0].imageSrc;
-    assertDefined(imageSrc);
+    const imageSrc = getImageUrl(loadedBoard);
     expect(imageSrc.startsWith("blob:")).toBe(true);
     expect(await isObjectUrlAlive(imageSrc)).toBe(true);
+
+    loadedBoard.media.dispose();
   });
 
   test("throws BoardNotFoundError when the board is not in IDB", async () => {
@@ -89,40 +97,43 @@ describe("hydrateBoard", () => {
     expect(error).toBeInstanceOf(BoardNotFoundError);
   });
 
-  test("revokes the previous registry on the next hydrateBoard call", async () => {
+  test("keeps concurrent hydration resources independent", async () => {
     await seedTestBoard();
 
     const first = await hydrateBoard(SET_ID, BOARD_ID);
-    const firstUrl = first.buttons[0].imageSrc;
-    assertDefined(firstUrl);
-    expect(await isObjectUrlAlive(firstUrl)).toBe(true);
-
     const second = await hydrateBoard(SET_ID, BOARD_ID);
-    const secondUrl = second.buttons[0].imageSrc;
-    assertDefined(secondUrl);
+    const firstUrl = getImageUrl(first);
+    const secondUrl = getImageUrl(second);
+
+    expect(await isObjectUrlAlive(firstUrl)).toBe(true);
+    expect(await isObjectUrlAlive(secondUrl)).toBe(true);
+
+    first.media.dispose();
 
     expect(await isObjectUrlAlive(firstUrl)).toBe(false);
     expect(await isObjectUrlAlive(secondUrl)).toBe(true);
+
+    second.media.dispose();
   });
 
-  test("a missing-board error does not poison module state for a later success", async () => {
+  test("a missing-board error does not affect a later success", async () => {
     await seedTestBoard();
 
     await expectThrown(hydrateBoard(SET_ID, "missing-board"));
 
-    const board = await hydrateBoard(SET_ID, BOARD_ID);
-    const url = board.buttons[0].imageSrc;
+    const loadedBoard = await hydrateBoard(SET_ID, BOARD_ID);
+    const url = getImageUrl(loadedBoard);
 
-    assertDefined(url);
     expect(await isObjectUrlAlive(url)).toBe(true);
+
+    loadedBoard.media.dispose();
   });
 
-  test("self-destructs without promoting when the signal is already aborted", async () => {
+  test("an already-aborted load does not disturb another resource", async () => {
     await seedTestBoard();
 
     const live = await hydrateBoard(SET_ID, BOARD_ID);
-    const liveUrl = live.buttons[0].imageSrc;
-    assertDefined(liveUrl);
+    const liveUrl = getImageUrl(live);
     expect(await isObjectUrlAlive(liveUrl)).toBe(true);
 
     const aborted = new AbortController();
@@ -132,9 +143,43 @@ describe("hydrateBoard", () => {
     );
 
     expect((error as Error).name).toBe("AbortError");
-    // A superseded load self-destructs instead of promoting, so the live load's
-    // URLs aren't orphaned.
     expect(await isObjectUrlAlive(liveUrl)).toBe(true);
+
+    live.media.dispose();
+  });
+
+  test("disposes provisional media when its signal aborts", async () => {
+    await seedTestBoard();
+
+    const controller = new AbortController();
+    const loadedBoard = await hydrateBoard(SET_ID, BOARD_ID, controller.signal);
+    const url = getImageUrl(loadedBoard);
+    expect(await isObjectUrlAlive(url)).toBe(true);
+
+    controller.abort();
+
+    expect(await isObjectUrlAlive(url)).toBe(false);
+    loadedBoard.media.dispose();
+    expect(() => loadedBoard.media.commit()).toThrow(
+      "Cannot commit disposed board media",
+    );
+  });
+
+  test("a committed resource survives its loader signal", async () => {
+    await seedTestBoard();
+
+    const controller = new AbortController();
+    const loadedBoard = await hydrateBoard(SET_ID, BOARD_ID, controller.signal);
+    const url = getImageUrl(loadedBoard);
+
+    loadedBoard.media.commit();
+    controller.abort();
+
+    expect(await isObjectUrlAlive(url)).toBe(true);
+
+    loadedBoard.media.dispose();
+
+    expect(await isObjectUrlAlive(url)).toBe(false);
   });
 
   test("a later load still hydrates after an aborted one", async () => {
@@ -144,10 +189,11 @@ describe("hydrateBoard", () => {
     aborted.abort();
     await expectThrown(hydrateBoard(SET_ID, BOARD_ID, aborted.signal));
 
-    const board = await hydrateBoard(SET_ID, BOARD_ID);
-    const url = board.buttons[0].imageSrc;
+    const loadedBoard = await hydrateBoard(SET_ID, BOARD_ID);
+    const url = getImageUrl(loadedBoard);
 
-    assertDefined(url);
     expect(await isObjectUrlAlive(url)).toBe(true);
+
+    loadedBoard.media.dispose();
   });
 });

--- a/src/features/board/storage/board-hydration.ts
+++ b/src/features/board/storage/board-hydration.ts
@@ -7,20 +7,21 @@ import { obfToBoard } from "../obf/obf-to-board";
 import type { Board } from "../types";
 import { BoardNotFoundError, getAssetBlob, getBoard } from "./boards-db";
 
-// Module-level because data-mode loaders have no unmount to hook into. Loader
-// calls are not serialized — a new navigation can start hydrating before the
-// previous one settles — and a superseded call must never revoke the live
-// board's URLs. Each call builds URLs in its own registry, checks the abort
-// signal after every await, and swaps into `previousRegistry` synchronously
-// only if it wins; a superseded call throws first and revokes only its own
-// registry. The only production call site is boardLoader.
-let previousRegistry: ObjectUrlRegistry | null = null;
+export interface BoardMediaResource {
+  commit(): void;
+  dispose(): void;
+}
+
+export interface HydratedBoard {
+  board: Board;
+  media: BoardMediaResource;
+}
 
 export async function hydrateBoard(
   setId: string,
   boardId: string,
   signal?: AbortSignal,
-): Promise<Board> {
+): Promise<HydratedBoard> {
   const registry = createObjectUrlRegistry();
   try {
     const obf = await readOBFBoard(setId, boardId);
@@ -32,15 +33,55 @@ export async function hydrateBoard(
 
     signal?.throwIfAborted();
 
-    const previous = previousRegistry;
-    previousRegistry = registry;
-    previous?.revokeAll();
-
-    return board;
+    return { board, media: createBoardMediaResource(registry, signal) };
   } catch (error) {
     registry.revokeAll();
     throw error;
   }
+}
+
+function createBoardMediaResource(
+  registry: ObjectUrlRegistry,
+  signal?: AbortSignal,
+): BoardMediaResource {
+  let state: "provisional" | "committed" | "disposed" = "provisional";
+
+  function removeAbortListener() {
+    signal?.removeEventListener("abort", disposeProvisional);
+  }
+
+  function dispose() {
+    if (state === "disposed") {
+      return;
+    }
+
+    state = "disposed";
+    removeAbortListener();
+    registry.revokeAll();
+  }
+
+  function disposeProvisional() {
+    if (state === "provisional") {
+      dispose();
+    }
+  }
+
+  signal?.addEventListener("abort", disposeProvisional, { once: true });
+
+  return {
+    commit() {
+      if (state === "disposed") {
+        throw new Error("Cannot commit disposed board media");
+      }
+      if (state === "committed") {
+        return;
+      }
+
+      state = "committed";
+      removeAbortListener();
+    },
+    dispose,
+  };
 }
 
 async function readOBFBoard(setId: string, boardId: string): Promise<OBFBoard> {

--- a/src/features/board/testing/db.ts
+++ b/src/features/board/testing/db.ts
@@ -3,6 +3,7 @@ import { refreshBoardSets } from "../board-sets/board-sets-store";
 import {
   getBoardsDB,
   replaceBoardSet,
+  type AssetInput,
   type BoardRecord,
   type BoardSetRecord,
 } from "../storage/boards-db";
@@ -13,6 +14,7 @@ interface SeedBoardSet extends Partial<BoardSetRecord> {
   setId: string;
   rootBoardId: string;
   boards?: Omit<BoardRecord, "setId">[];
+  assets?: AssetInput[];
 }
 
 export function makeOBFBoard(overrides: Partial<OBFBoard> = {}): OBFBoard {
@@ -46,11 +48,11 @@ export async function resetBoardsDB(): Promise<void> {
 
 export async function seedBoardSets(records: SeedBoardSet[]): Promise<void> {
   await clearBoardsDB();
-  for (const { boards = [], ...record } of records) {
+  for (const { boards = [], assets = [], ...record } of records) {
     await replaceBoardSet({
       boardSet: { name: record.setId, ...record },
       boards,
-      assets: [],
+      assets,
     });
   }
 

--- a/src/pages/board-page.tsx
+++ b/src/pages/board-page.tsx
@@ -1,8 +1,8 @@
-import { BoardViewer, type Board } from "@features/board";
+import { BoardViewer, type HydratedBoard } from "@features/board";
 import { useLoaderData } from "react-router";
 
 export function BoardPage() {
-  const board = useLoaderData<Board>();
+  const { board } = useLoaderData<HydratedBoard>();
 
   return (
     <>


### PR DESCRIPTION
## Summary

- Give each board hydration an isolated, abort-aware media resource.
- Commit object URLs only after the board route renders, then release the previous board on replacement or unmount.
- Cover abort, concurrency, Strict Mode, and route cleanup with real Chromium object-URL tests.

## Why

`hydrateBoard` previously replaced a module-level URL registry as soon as hydration completed. Translation and route commitment could still be pending, so an aborted or failed navigation could revoke media still used by the visible board and retain provisional URLs.

## Impact

The visible AAC board keeps its images and sounds until its successor commits. Abandoned or concurrent loads revoke only their own resources, and leaving the board route releases committed media.

## Validation

- `npm run lint`
- `npm test` — 571 tests passed
- `npm run test:coverage` — 92.31% statements, 83.59% branches
- `npm run build`
