### PR TITLE
Clarify architecture boundary levels

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -112,13 +112,30 @@ output:
    coordinator serializes speech and recorded audio and publishes progress for
    per-part highlighting.
 
-## Codemap and boundaries
+## Codemap and ownership seams
 
-The table identifies the owner of each concern and the rule at its boundary.
-Names are symbol-searchable rather than hyperlinked so file moves do not break
-the map.
+The repository has three enforced module boundaries:
 
-| Concern                   | Owner                                                                                              | Boundary rule                                                                                                                                                                 |
+- `src/shared/` is the leaf layer. It does not import from the app, pages, or
+  features.
+- Each directory directly under `src/features/` is an isolated feature. A
+  feature imports shared code and its own relative modules, but not the app,
+  pages, or another feature.
+- `src/app/` and `src/pages/` compose features through their public entry points,
+  such as `src/features/board/index.ts`, rather than importing feature internals.
+
+Directories inside `src/features/board/` are cohesion areas within one feature,
+not independent modules. They group code that changes together and may
+collaborate through relative imports; they do not need individual barrels or
+enforced dependency rules. Some still carry important ownership invariants —
+for example, `storage/` exclusively owns IndexedDB access — but a folder alone
+does not imply an independently replaceable boundary.
+
+The table identifies the owner of each concern and the rule at its ownership
+seam. Names are symbol-searchable rather than hyperlinked so file moves do not
+break the map.
+
+| Concern                   | Owner                                                                                              | Ownership rule                                                                                                                                                                |
 | ------------------------- | -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Composition               | `src/main.tsx`, `src/app/`, `src/pages/`                                                           | `AppProviders` and the router assemble features; pages are route entry components.                                                                                            |
 | Active-board data         | `src/app/routing/loaders/`                                                                         | The active board enters the render tree through `boardLoader`; ancillary summaries may use feature hooks.                                                                     |


### PR DESCRIPTION
## Summary

- distinguish the repository's enforced module boundaries from softer ownership seams
- document board subfolders as cohesion areas within one feature
- preserve explicit ownership invariants such as centralized IndexedDB access
- rename the codemap language from boundary rules to ownership rules

## Why

The existing codemap described every listed concern as a boundary, which could imply that each folder under `src/features/board/` should have its own façade, barrel, or enforced dependency direction. The implementation intentionally enforces boundaries at the shared, feature, and app/page layers while allowing board internals to collaborate through relative imports.

This clarification keeps the current decomposition while making its architectural weight explicit.

## Impact

Documentation only. There are no runtime, dependency, schema, or public API changes.

## Validation

- `npm run lint`
- `npm test` — 80 files, 571 tests passed
- `npm run build`
