### PR TITLE
Use symbol terminology for AAC representations

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,8 +28,9 @@ Web Platform. AAC terms are defined in the [glossary](#glossary).
 ## Purpose and constraints
 
 The app gives someone who cannot rely on speech a fast way to compose and speak
-a message by selecting pictogram tiles. Optional on-device models can turn short,
-telegraphic input such as "want eat pizza later" into more natural language.
+a message by selecting tiles that contain communication symbols. Optional
+on-device models can turn short, telegraphic input such as "want eat pizza
+later" into more natural language.
 
 Two constraints shape the architecture:
 
@@ -273,10 +274,12 @@ rise with meaningful coverage gains and are not lowered to admit a regression.
   board set with assets (`.obz`). The current interchange contract is import-only.
 - **Board set** — a collection of linked boards with a root board, imported as a
   unit.
-- **Tile / pictogram** — one grid cell: an image plus a label that the user
-  activates.
+- **Symbol** — an AAC representation displayed on a tile or in the message bar:
+  an image, a written label, or both.
+- **Tile** — an interactive board button containing a communication symbol. It
+  adds to the message or navigates to a linked board when activated.
 - **Vocalization** — what a button speaks when it differs from the visible label.
-- **Message bar** — the selected tiles accumulated into the message to speak.
+- **Message bar** — the selected symbols accumulated into the message to speak.
 - **Built-in AI** — browser-provided on-device Proofreader, Rewriter, and
   Translator APIs used for grammar, tone, and translation.
 - **TTS** — text-to-speech through the browser's Web Speech API.

--- a/src/features/board/board-viewer.test.tsx
+++ b/src/features/board/board-viewer.test.tsx
@@ -29,9 +29,9 @@ const SPELL_THEN_SPEAK_BOARD: OBFBoard = {
   grid: { rows: 1, columns: 1, order: [["btn-1"]] },
 };
 
-const PICTOGRAM_BOARD: OBFBoard = {
+const SYMBOL_BOARD: OBFBoard = {
   format: "open-board-0.1",
-  id: "pictogram-board",
+  id: "symbol-board",
   locale: "en",
   buttons: [
     { id: "btn-1", label: "hello", image_id: "img-1" },
@@ -435,7 +435,7 @@ describe("BoardViewer", () => {
   });
 
   test("has no accessibility violations with a composed message", async () => {
-    const screen = await renderBoardViewer(PICTOGRAM_BOARD);
+    const screen = await renderBoardViewer(SYMBOL_BOARD);
 
     await screen.getByRole("button", { name: "hello" }).click();
     await screen.getByRole("button", { name: "world" }).click();

--- a/src/features/board/communication-symbol/communication-symbol.test.tsx
+++ b/src/features/board/communication-symbol/communication-symbol.test.tsx
@@ -1,25 +1,27 @@
 import { describe, expect, test } from "vitest";
 import { render } from "vitest-browser-react";
 import { TEST_IMAGE_SRC } from "../testing";
-import { Pictogram } from "./pictogram";
+import { CommunicationSymbol } from "./communication-symbol";
 
-describe("Pictogram", () => {
-  test("renders no content when no src or label is provided", async () => {
-    const screen = await render(<Pictogram label="" />);
+describe("CommunicationSymbol", () => {
+  test("renders no content when no image source or label is provided", async () => {
+    const screen = await render(<CommunicationSymbol label="" />);
 
     expect(screen.container.textContent).toBe("");
     expect(screen.container.querySelector("img")).toBeNull();
   });
 
   test("renders label when provided", async () => {
-    const screen = await render(<Pictogram label="Hello" />);
+    const screen = await render(<CommunicationSymbol label="Hello" />);
 
     await expect.element(screen.getByText("Hello")).toBeVisible();
     expect(screen.container.querySelector("img")).toBeNull();
   });
 
-  test("renders image when src is provided", async () => {
-    const screen = await render(<Pictogram src={TEST_IMAGE_SRC} label="" />);
+  test("renders image when imageSrc is provided", async () => {
+    const screen = await render(
+      <CommunicationSymbol imageSrc={TEST_IMAGE_SRC} label="" />,
+    );
 
     const img = screen.container.querySelector("img");
     expect(img).not.toBeNull();
@@ -29,7 +31,7 @@ describe("Pictogram", () => {
 
   test("renders both image and label when both are provided", async () => {
     const screen = await render(
-      <Pictogram src={TEST_IMAGE_SRC} label="Action" />,
+      <CommunicationSymbol imageSrc={TEST_IMAGE_SRC} label="Action" />,
     );
 
     await expect.element(screen.getByText("Action")).toBeVisible();
@@ -38,19 +40,27 @@ describe("Pictogram", () => {
 
   test("places the label above the image when labelPlacement is top", async () => {
     const screen = await render(
-      <Pictogram src={TEST_IMAGE_SRC} label="Action" labelPlacement="top" />,
+      <CommunicationSymbol
+        imageSrc={TEST_IMAGE_SRC}
+        label="Action"
+        labelPlacement="top"
+      />,
     );
 
     const container = screen.getByText("Action").element().parentElement;
     if (!container) {
-      throw new Error("Pictogram container not found");
+      throw new Error("Communication symbol container not found");
     }
     expect(getComputedStyle(container).flexDirection).toBe("column-reverse");
   });
 
   test("keeps the label accessible when labelPlacement is hidden", async () => {
     const screen = await render(
-      <Pictogram src={TEST_IMAGE_SRC} label="Action" labelPlacement="hidden" />,
+      <CommunicationSymbol
+        imageSrc={TEST_IMAGE_SRC}
+        label="Action"
+        labelPlacement="hidden"
+      />,
     );
 
     await expect.element(screen.getByText("Action")).toBeInTheDocument();
@@ -58,7 +68,11 @@ describe("Pictogram", () => {
 
   test("takes no layout space for the label when labelPlacement is hidden", async () => {
     const screen = await render(
-      <Pictogram src={TEST_IMAGE_SRC} label="Action" labelPlacement="hidden" />,
+      <CommunicationSymbol
+        imageSrc={TEST_IMAGE_SRC}
+        label="Action"
+        labelPlacement="hidden"
+      />,
     );
 
     const label = screen.getByText("Action").element();

--- a/src/features/board/communication-symbol/communication-symbol.tsx
+++ b/src/features/board/communication-symbol/communication-symbol.tsx
@@ -2,17 +2,17 @@ import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import visuallyHidden from "@mui/utils/visuallyHidden";
 
-interface PictogramProps {
-  src?: string;
+interface CommunicationSymbolProps {
+  imageSrc?: string;
   label: string;
   labelPlacement?: "top" | "bottom" | "hidden";
 }
 
-export function Pictogram({
-  src,
+export function CommunicationSymbol({
+  imageSrc,
   label,
   labelPlacement = "bottom",
-}: PictogramProps) {
+}: CommunicationSymbolProps) {
   return (
     <Box
       sx={{
@@ -24,7 +24,7 @@ export function Pictogram({
         overflow: "hidden",
       }}
     >
-      {src && (
+      {imageSrc && (
         <Box
           sx={{
             height: "54px",
@@ -35,7 +35,7 @@ export function Pictogram({
         >
           <Box
             component="img"
-            src={src}
+            src={imageSrc}
             alt=""
             sx={{
               width: "100%",
@@ -53,7 +53,7 @@ export function Pictogram({
       <Typography
         noWrap
         component="span"
-        variant={src ? "body2" : "h5"}
+        variant={imageSrc ? "body2" : "h5"}
         sx={labelPlacement === "hidden" ? visuallyHidden : { lineHeight: 1 }}
       >
         {label}

--- a/src/features/board/message/message-bar.tsx
+++ b/src/features/board/message/message-bar.tsx
@@ -1,8 +1,8 @@
 import Stack from "@mui/material/Stack";
 import { useEffect, useRef } from "react";
-import { Pictogram } from "../pictogram/pictogram";
-import { PlayButton, type PlayButtonRootProps } from "./play-button";
+import { CommunicationSymbol } from "../communication-symbol/communication-symbol";
 import type { MessagePart } from "./message-types";
+import { PlayButton, type PlayButtonRootProps } from "./play-button";
 
 interface MessageBarSlotProps {
   playButton?: PlayButtonRootProps;
@@ -92,7 +92,10 @@ export function MessageBar({
                     : "none",
                 })}
               >
-                <Pictogram label={part.label ?? ""} src={part.imageSrc} />
+                <CommunicationSymbol
+                  label={part.label ?? ""}
+                  imageSrc={part.imageSrc}
+                />
               </Stack>
             );
           })}

--- a/src/features/board/tile/tile.tsx
+++ b/src/features/board/tile/tile.tsx
@@ -1,7 +1,7 @@
 import Button, { buttonClasses, type ButtonProps } from "@mui/material/Button";
 import { alpha } from "@mui/material/styles";
 import { mergeSx } from "@shared/theme/merge-sx";
-import { Pictogram } from "../pictogram/pictogram";
+import { CommunicationSymbol } from "../communication-symbol/communication-symbol";
 
 interface TileOwnProps {
   label: string;
@@ -120,7 +120,7 @@ export function Tile({
         sx,
       )}
     >
-      <Pictogram label={label} src={imageSrc} />
+      <CommunicationSymbol label={label} imageSrc={imageSrc} />
     </Button>
   );
 }

--- a/src/features/board/translation/resolve-translated-board.ts
+++ b/src/features/board/translation/resolve-translated-board.ts
@@ -42,7 +42,7 @@ export async function resolveTranslatedBoard(
     }
   } catch {
     // Total by design: translation is an enhancement, not a requirement —
-    // pictograms carry the meaning, so a failure must never block the board.
+    // symbols carry the meaning, so a failure must never block the board.
     return board;
   }
 }


### PR DESCRIPTION
## Summary

- rename the `Pictogram` component and module to `CommunicationSymbol`
- rename its `src` prop to `imageSrc` and update all consumers and tests
- replace remaining pictogram terminology and define symbols and tiles separately in the architecture glossary

## Why

“Symbol” is the correct AAC umbrella term for photographs, drawings, and written orthography. The component can also render a written label without an image, so “pictogram” was narrower than its actual responsibility.

## Impact

This is a terminology-only refactor with no intended user-facing behavior change. `Tile` remains reserved for the interactive board button, while `CommunicationSymbol` represents the image, written label, or both.

## Validation

- `npm run lint`
- `npm test` — 82 files, 573 tests
- `npm run build`
