### PR TITLE
Clarify board set terminology

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(يفتح في علامة تبويب جديدة)",
   "boardGridLabel": "لوحة تواصل",
   "board": "لوحة",
-  "libraryLoading": "جارٍ تحميل اللوحات...",
+  "libraryLoading": "جارٍ تحميل مجموعات اللوحات...",
   "libraryEmptyTitle": "المكتبة فارغة",
-  "libraryEmptyDescription": "استورد لوحات تواصل للبدء.",
-  "libraryImportBoards": "استيراد لوحات",
-  "libraryBoards": "لوحات",
+  "libraryEmptyDescription": "استورد ملفات اللوحات للبدء.",
+  "libraryImportBoards": "استيراد ملفات اللوحات",
+  "libraryBoards": "مجموعات اللوحات",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "جارٍ استيراد اللوحة...",
-        "countPlural=*": "جارٍ استيراد اللوحات..."
+        "countPlural=one": "جارٍ استيراد ملف لوحة...",
+        "countPlural=*": "جارٍ استيراد ملفات لوحات..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "تم استيراد اللوحة",
-        "countPlural=*": "تم استيراد اللوحات"
+        "countPlural=one": "تم استيراد مجموعة اللوحات",
+        "countPlural=*": "تم استيراد مجموعات اللوحات"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "تعذّر استيراد اللوحة",
-        "countPlural=*": "تعذّر استيراد اللوحات"
+        "countPlural=one": "تعذّر استيراد ملف اللوحة",
+        "countPlural=*": "تعذّر استيراد ملفات اللوحات"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "اللوحة كبيرة جدًا بحيث يتعذّر استيرادها",
-        "countPlural=*": "اللوحات كبيرة جدًا بحيث يتعذّر استيرادها"
+        "countPlural=one": "ملف اللوحة كبير جدًا بحيث يتعذّر استيراده",
+        "countPlural=*": "ملفات اللوحات كبيرة جدًا بحيث يتعذّر استيرادها"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "خيارات إضافية لـ {name}",
   "libraryByAuthor": "بقلم {author}",
   "libraryGridDimensions": "شبكة {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "حذف \"{name}\"؟",
-  "libraryDeleteIrreversible": "لا يمكن التراجع عن هذا الإجراء.",
-  "libraryDeleted": "تم حذف \"{name}\"",
-  "libraryDeleteFailed": "تعذّر حذف \"{name}\"",
+  "libraryDeleteConfirmTitle": "حذف مجموعة اللوحات \"{name}\"؟",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "سيتم حذف اللوحة الموجودة في هذه المجموعة. لا يمكن التراجع عن ذلك.",
+        "countPlural=*": "سيتم حذف جميع اللوحات البالغ عددها {count} في هذه المجموعة. لا يمكن التراجع عن ذلك."
+      }
+    }
+  ],
+  "libraryDeleted": "تم حذف مجموعة اللوحات \"{name}\"",
+  "libraryDeleteFailed": "تعذّر حذف مجموعة اللوحات \"{name}\"",
   "libraryTitle": "المكتبة",
   "libraryOpen": "فتح المكتبة",
   "aboutSourceCode": "الكود المصدري",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "الصفحة غير موجودة",
   "errorGoHome": "الانتقال إلى الرئيسية",
   "errorBoardNotFound": "اللوحة غير موجودة",
-  "errorBoardSetNotFound": "اللوحة غير موجودة",
-  "boardUrlImportFailed": "تعذّر استيراد اللوحة من الرابط"
+  "errorBoardSetNotFound": "مجموعة اللوحات غير موجودة",
+  "boardUrlImportFailed": "تعذّر استيراد ملف اللوحة من الرابط"
 }

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(отваря се в нов раздел)",
   "boardGridLabel": "Комуникационна дъска",
   "board": "Дъска",
-  "libraryLoading": "Зареждане на дъските...",
+  "libraryLoading": "Зареждане на наборите от дъски...",
   "libraryEmptyTitle": "Библиотеката е празна",
-  "libraryEmptyDescription": "Импортирайте комуникационни дъски, за да започнете.",
-  "libraryImportBoards": "Импортиране на дъски",
-  "libraryBoards": "Дъски",
+  "libraryEmptyDescription": "Импортирайте файлове с дъски, за да започнете.",
+  "libraryImportBoards": "Импортиране на файлове с дъски",
+  "libraryBoards": "Набори от дъски",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Импортиране на дъската...",
-        "countPlural=*": "Импортиране на дъските..."
+        "countPlural=one": "Импортиране на файл с дъска...",
+        "countPlural=*": "Импортиране на файлове с дъски..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Дъската е импортирана",
-        "countPlural=*": "Дъските са импортирани"
+        "countPlural=one": "Наборът от дъски е импортиран",
+        "countPlural=*": "Наборите от дъски са импортирани"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Дъската не може да бъде импортирана",
-        "countPlural=*": "Дъските не могат да бъдат импортирани"
+        "countPlural=one": "Файлът с дъска не може да бъде импортиран",
+        "countPlural=*": "Файловете с дъски не могат да бъдат импортирани"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Дъската е твърде голяма за импортиране",
-        "countPlural=*": "Дъските са твърде големи за импортиране"
+        "countPlural=one": "Файлът с дъска е твърде голям за импортиране",
+        "countPlural=*": "Файловете с дъски са твърде големи за импортиране"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "Още опции за {name}",
   "libraryByAuthor": "От {author}",
   "libraryGridDimensions": "Мрежа {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "Да се изтрие ли „{name}“?",
-  "libraryDeleteIrreversible": "Това действие не може да бъде отменено.",
-  "libraryDeleted": "„{name}“ е изтрита",
-  "libraryDeleteFailed": "„{name}“ не може да бъде изтрита",
+  "libraryDeleteConfirmTitle": "Да се изтрие ли наборът от дъски „{name}“?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Дъската в този набор ще бъде изтрита. Това не може да бъде отменено.",
+        "countPlural=*": "Всички {count} дъски в този набор ще бъдат изтрити. Това не може да бъде отменено."
+      }
+    }
+  ],
+  "libraryDeleted": "Наборът от дъски „{name}“ е изтрит",
+  "libraryDeleteFailed": "Наборът от дъски „{name}“ не може да бъде изтрит",
   "libraryTitle": "Библиотека",
   "libraryOpen": "Отваряне на библиотеката",
   "aboutSourceCode": "Изходен код",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Страницата не е намерена",
   "errorGoHome": "Към началото",
   "errorBoardNotFound": "Дъската не е намерена",
-  "errorBoardSetNotFound": "Дъската не е намерена",
-  "boardUrlImportFailed": "Дъската не може да бъде импортирана от връзката"
+  "errorBoardSetNotFound": "Наборът от дъски не е намерен",
+  "boardUrlImportFailed": "Файлът с дъска не може да бъде импортиран от връзката"
 }

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(নতুন ট্যাবে খোলে)",
   "boardGridLabel": "যোগাযোগ বোর্ড",
   "board": "বোর্ড",
-  "libraryLoading": "বোর্ড লোড হচ্ছে…",
+  "libraryLoading": "বোর্ড সেট লোড হচ্ছে…",
   "libraryEmptyTitle": "লাইব্রেরি খালি",
-  "libraryEmptyDescription": "শুরু করতে যোগাযোগ বোর্ড আমদানি করুন।",
-  "libraryImportBoards": "বোর্ড আমদানি করুন",
-  "libraryBoards": "বোর্ড",
+  "libraryEmptyDescription": "শুরু করতে বোর্ড ফাইল আমদানি করুন।",
+  "libraryImportBoards": "বোর্ড ফাইল আমদানি করুন",
+  "libraryBoards": "বোর্ড সেট",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "বোর্ড আমদানি করা হচ্ছে…",
-        "countPlural=*": "বোর্ড আমদানি করা হচ্ছে…"
+        "countPlural=one": "বোর্ড ফাইল আমদানি করা হচ্ছে…",
+        "countPlural=*": "বোর্ড ফাইল আমদানি করা হচ্ছে…"
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "বোর্ড আমদানি করা হয়েছে",
-        "countPlural=*": "বোর্ড আমদানি করা হয়েছে"
+        "countPlural=one": "বোর্ড সেট আমদানি করা হয়েছে",
+        "countPlural=*": "বোর্ড সেট আমদানি করা হয়েছে"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "বোর্ড আমদানি করা যায়নি",
-        "countPlural=*": "বোর্ড আমদানি করা যায়নি"
+        "countPlural=one": "বোর্ড ফাইল আমদানি করা যায়নি",
+        "countPlural=*": "বোর্ড ফাইল আমদানি করা যায়নি"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "বোর্ডটি আমদানি করার জন্য খুব বড়",
-        "countPlural=*": "বোর্ডগুলি আমদানি করার জন্য খুব বড়"
+        "countPlural=one": "বোর্ড ফাইলটি আমদানি করার জন্য খুব বড়",
+        "countPlural=*": "বোর্ড ফাইলগুলি আমদানি করার জন্য খুব বড়"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "{name}-এর জন্য আরও বিকল্প",
   "libraryByAuthor": "লিখেছেন {author}",
   "libraryGridDimensions": "{rows}×{columns} গ্রিড",
-  "libraryDeleteConfirmTitle": "\"{name}\" মুছবেন?",
-  "libraryDeleteIrreversible": "এই ক্রিয়াটি পূর্বাবস্থায় ফেরানো যাবে না।",
-  "libraryDeleted": "\"{name}\" মুছে ফেলা হয়েছে",
-  "libraryDeleteFailed": "\"{name}\" মোছা যায়নি",
+  "libraryDeleteConfirmTitle": "বোর্ড সেট \"{name}\" মুছবেন?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "এই সেটের বোর্ডটি মুছে ফেলা হবে। এটি পূর্বাবস্থায় ফেরানো যাবে না।",
+        "countPlural=*": "এই সেটের সব {count}টি বোর্ড মুছে ফেলা হবে। এটি পূর্বাবস্থায় ফেরানো যাবে না।"
+      }
+    }
+  ],
+  "libraryDeleted": "বোর্ড সেট \"{name}\" মুছে ফেলা হয়েছে",
+  "libraryDeleteFailed": "বোর্ড সেট \"{name}\" মোছা যায়নি",
   "libraryTitle": "লাইব্রেরি",
   "libraryOpen": "লাইব্রেরি খুলুন",
   "aboutSourceCode": "সোর্স কোড",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "পৃষ্ঠাটি পাওয়া যায়নি",
   "errorGoHome": "হোমে যান",
   "errorBoardNotFound": "বোর্ড পাওয়া যায়নি",
-  "errorBoardSetNotFound": "বোর্ড পাওয়া যায়নি",
-  "boardUrlImportFailed": "লিঙ্ক থেকে বোর্ড আমদানি করা যায়নি"
+  "errorBoardSetNotFound": "বোর্ড সেট পাওয়া যায়নি",
+  "boardUrlImportFailed": "লিঙ্ক থেকে বোর্ড ফাইল আমদানি করা যায়নি"
 }

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(otevře se na nové kartě)",
   "boardGridLabel": "Komunikační tabulka",
   "board": "Tabulka",
-  "libraryLoading": "Načítání tabulek...",
+  "libraryLoading": "Načítání sad tabulek...",
   "libraryEmptyTitle": "Knihovna je prázdná",
-  "libraryEmptyDescription": "Začněte importem komunikačních tabulek.",
-  "libraryImportBoards": "Importovat tabulky",
-  "libraryBoards": "Tabulky",
+  "libraryEmptyDescription": "Začněte importem souborů tabulek.",
+  "libraryImportBoards": "Importovat soubory tabulek",
+  "libraryBoards": "Sady tabulek",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Importování tabulky...",
-        "countPlural=*": "Importování tabulek..."
+        "countPlural=one": "Importování souboru tabulky...",
+        "countPlural=*": "Importování souborů tabulek..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tabulka importována",
-        "countPlural=*": "Tabulky importovány"
+        "countPlural=one": "Sada tabulek importována",
+        "countPlural=*": "Sady tabulek importovány"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tabulku se nepodařilo importovat",
-        "countPlural=*": "Tabulky se nepodařilo importovat"
+        "countPlural=one": "Soubor tabulky se nepodařilo importovat",
+        "countPlural=*": "Soubory tabulek se nepodařilo importovat"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tabulka je příliš velká na import",
-        "countPlural=*": "Tabulky jsou příliš velké na import"
+        "countPlural=one": "Soubor tabulky je příliš velký na import",
+        "countPlural=*": "Soubory tabulek jsou příliš velké na import"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "Další možnosti pro {name}",
   "libraryByAuthor": "Autor: {author}",
   "libraryGridDimensions": "Mřížka {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "Smazat „{name}“?",
-  "libraryDeleteIrreversible": "Tuto akci nelze vrátit zpět.",
-  "libraryDeleted": "„{name}“ smazáno",
-  "libraryDeleteFailed": "„{name}“ se nepodařilo smazat",
+  "libraryDeleteConfirmTitle": "Smazat sadu tabulek „{name}“?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tabulka v této sadě bude smazána. Tuto akci nelze vrátit zpět.",
+        "countPlural=*": "Všech {count} tabulek v této sadě bude smazáno. Tuto akci nelze vrátit zpět."
+      }
+    }
+  ],
+  "libraryDeleted": "Sada tabulek „{name}“ smazána",
+  "libraryDeleteFailed": "Sadu tabulek „{name}“ se nepodařilo smazat",
   "libraryTitle": "Knihovna",
   "libraryOpen": "Otevřít knihovnu",
   "aboutSourceCode": "Zdrojový kód",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Stránka nebyla nalezena",
   "errorGoHome": "Přejít domů",
   "errorBoardNotFound": "Tabulka nebyla nalezena",
-  "errorBoardSetNotFound": "Tabulka nebyla nalezena",
-  "boardUrlImportFailed": "Tabulku se nepodařilo importovat z odkazu"
+  "errorBoardSetNotFound": "Sada tabulek nebyla nalezena",
+  "boardUrlImportFailed": "Soubor tabulky se nepodařilo importovat z odkazu"
 }

--- a/messages/da.json
+++ b/messages/da.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(åbner i nyt faneblad)",
   "boardGridLabel": "Kommunikationstavle",
   "board": "Tavle",
-  "libraryLoading": "Indlæser tavler...",
+  "libraryLoading": "Indlæser tavlesæt...",
   "libraryEmptyTitle": "Biblioteket er tomt",
-  "libraryEmptyDescription": "Importér kommunikationstavler for at komme i gang.",
-  "libraryImportBoards": "Importér tavler",
-  "libraryBoards": "Tavler",
+  "libraryEmptyDescription": "Importér tavlefiler for at komme i gang.",
+  "libraryImportBoards": "Importér tavlefiler",
+  "libraryBoards": "Tavlesæt",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Importerer tavle...",
-        "countPlural=*": "Importerer tavler..."
+        "countPlural=one": "Importerer tavlefil...",
+        "countPlural=*": "Importerer tavlefiler..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tavle importeret",
-        "countPlural=*": "Tavler importeret"
+        "countPlural=one": "Tavlesæt importeret",
+        "countPlural=*": "Tavlesæt importeret"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tavlen kunne ikke importeres",
-        "countPlural=*": "Tavlerne kunne ikke importeres"
+        "countPlural=one": "Tavlefilen kunne ikke importeres",
+        "countPlural=*": "Tavlefilerne kunne ikke importeres"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tavlen er for stor til at blive importeret",
-        "countPlural=*": "Tavlerne er for store til at blive importeret"
+        "countPlural=one": "Tavlefilen er for stor til at blive importeret",
+        "countPlural=*": "Tavlefilerne er for store til at blive importeret"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "Flere indstillinger for {name}",
   "libraryByAuthor": "Af {author}",
   "libraryGridDimensions": "Gitter {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "Slet \"{name}\"?",
-  "libraryDeleteIrreversible": "Denne handling kan ikke fortrydes.",
-  "libraryDeleted": "\"{name}\" slettet",
-  "libraryDeleteFailed": "\"{name}\" kunne ikke slettes",
+  "libraryDeleteConfirmTitle": "Slet tavlesættet \"{name}\"?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tavlen i dette sæt vil blive slettet. Dette kan ikke fortrydes.",
+        "countPlural=*": "Alle {count} tavler i dette sæt vil blive slettet. Dette kan ikke fortrydes."
+      }
+    }
+  ],
+  "libraryDeleted": "Tavlesættet \"{name}\" er slettet",
+  "libraryDeleteFailed": "Tavlesættet \"{name}\" kunne ikke slettes",
   "libraryTitle": "Bibliotek",
   "libraryOpen": "Åbn biblioteket",
   "aboutSourceCode": "Kildekode",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Siden blev ikke fundet",
   "errorGoHome": "Gå til start",
   "errorBoardNotFound": "Tavlen blev ikke fundet",
-  "errorBoardSetNotFound": "Tavlen blev ikke fundet",
-  "boardUrlImportFailed": "Tavlen kunne ikke importeres fra linket"
+  "errorBoardSetNotFound": "Tavlesættet blev ikke fundet",
+  "boardUrlImportFailed": "Tavlefilen kunne ikke importeres fra linket"
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(öffnet in neuem Tab)",
   "boardGridLabel": "Kommunikationstafel",
   "board": "Tafel",
-  "libraryLoading": "Tafeln werden geladen...",
+  "libraryLoading": "Tafelsätze werden geladen...",
   "libraryEmptyTitle": "Die Bibliothek ist leer",
-  "libraryEmptyDescription": "Importiere Kommunikationstafeln, um loszulegen.",
-  "libraryImportBoards": "Tafeln importieren",
-  "libraryBoards": "Tafeln",
+  "libraryEmptyDescription": "Importiere Tafeldateien, um loszulegen.",
+  "libraryImportBoards": "Tafeldateien importieren",
+  "libraryBoards": "Tafelsätze",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tafel wird importiert...",
-        "countPlural=*": "Tafeln werden importiert..."
+        "countPlural=one": "Tafeldatei wird importiert...",
+        "countPlural=*": "Tafeldateien werden importiert..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tafel importiert",
-        "countPlural=*": "Tafeln importiert"
+        "countPlural=one": "Tafelsatz importiert",
+        "countPlural=*": "Tafelsätze importiert"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tafel konnte nicht importiert werden",
-        "countPlural=*": "Tafeln konnten nicht importiert werden"
+        "countPlural=one": "Tafeldatei konnte nicht importiert werden",
+        "countPlural=*": "Tafeldateien konnten nicht importiert werden"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Die Tafel ist zu groß zum Importieren",
-        "countPlural=*": "Die Tafeln sind zu groß zum Importieren"
+        "countPlural=one": "Die Tafeldatei ist zu groß zum Importieren",
+        "countPlural=*": "Die Tafeldateien sind zu groß zum Importieren"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "Weitere Optionen für {name}",
   "libraryByAuthor": "Von {author}",
   "libraryGridDimensions": "Raster {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "„{name}“ löschen?",
-  "libraryDeleteIrreversible": "Diese Aktion kann nicht rückgängig gemacht werden.",
-  "libraryDeleted": "„{name}“ gelöscht",
-  "libraryDeleteFailed": "„{name}“ konnte nicht gelöscht werden",
+  "libraryDeleteConfirmTitle": "Tafelsatz „{name}“ löschen?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Die Tafel in diesem Satz wird gelöscht. Dies kann nicht rückgängig gemacht werden.",
+        "countPlural=*": "Alle {count} Tafeln in diesem Satz werden gelöscht. Dies kann nicht rückgängig gemacht werden."
+      }
+    }
+  ],
+  "libraryDeleted": "Tafelsatz „{name}“ gelöscht",
+  "libraryDeleteFailed": "Tafelsatz „{name}“ konnte nicht gelöscht werden",
   "libraryTitle": "Bibliothek",
   "libraryOpen": "Bibliothek öffnen",
   "aboutSourceCode": "Quellcode",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Seite nicht gefunden",
   "errorGoHome": "Zur Startseite",
   "errorBoardNotFound": "Tafel nicht gefunden",
-  "errorBoardSetNotFound": "Tafel nicht gefunden",
-  "boardUrlImportFailed": "Tafel konnte nicht über den Link importiert werden"
+  "errorBoardSetNotFound": "Tafelsatz nicht gefunden",
+  "boardUrlImportFailed": "Tafeldatei konnte nicht über den Link importiert werden"
 }

--- a/messages/el.json
+++ b/messages/el.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(ανοίγει σε νέα καρτέλα)",
   "boardGridLabel": "Πίνακας επικοινωνίας",
   "board": "Πίνακας",
-  "libraryLoading": "Φόρτωση πινάκων...",
+  "libraryLoading": "Φόρτωση συνόλων πινάκων...",
   "libraryEmptyTitle": "Η βιβλιοθήκη είναι κενή",
-  "libraryEmptyDescription": "Εισαγάγετε πίνακες επικοινωνίας για να ξεκινήσετε.",
-  "libraryImportBoards": "Εισαγωγή πινάκων",
-  "libraryBoards": "Πίνακες",
+  "libraryEmptyDescription": "Εισαγάγετε αρχεία πινάκων για να ξεκινήσετε.",
+  "libraryImportBoards": "Εισαγωγή αρχείων πινάκων",
+  "libraryBoards": "Σύνολα πινάκων",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Εισαγωγή πίνακα...",
-        "countPlural=*": "Εισαγωγή πινάκων..."
+        "countPlural=one": "Εισαγωγή αρχείου πίνακα...",
+        "countPlural=*": "Εισαγωγή αρχείων πινάκων..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Ο πίνακας εισήχθη",
-        "countPlural=*": "Οι πίνακες εισήχθησαν"
+        "countPlural=one": "Το σύνολο πινάκων εισήχθη",
+        "countPlural=*": "Τα σύνολα πινάκων εισήχθησαν"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Δεν ήταν δυνατή η εισαγωγή του πίνακα",
-        "countPlural=*": "Δεν ήταν δυνατή η εισαγωγή των πινάκων"
+        "countPlural=one": "Δεν ήταν δυνατή η εισαγωγή του αρχείου πίνακα",
+        "countPlural=*": "Δεν ήταν δυνατή η εισαγωγή των αρχείων πινάκων"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Ο πίνακας είναι πολύ μεγάλος για εισαγωγή",
-        "countPlural=*": "Οι πίνακες είναι πολύ μεγάλοι για εισαγωγή"
+        "countPlural=one": "Το αρχείο πίνακα είναι πολύ μεγάλο για εισαγωγή",
+        "countPlural=*": "Τα αρχεία πινάκων είναι πολύ μεγάλα για εισαγωγή"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "Περισσότερες επιλογές για {name}",
   "libraryByAuthor": "Από {author}",
   "libraryGridDimensions": "Πλέγμα {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "Διαγραφή «{name}»;",
-  "libraryDeleteIrreversible": "Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.",
-  "libraryDeleted": "Το «{name}» διαγράφηκε",
-  "libraryDeleteFailed": "Δεν ήταν δυνατή η διαγραφή του «{name}»",
+  "libraryDeleteConfirmTitle": "Διαγραφή συνόλου πινάκων «{name}»;",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Ο πίνακας σε αυτό το σύνολο θα διαγραφεί. Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.",
+        "countPlural=*": "Και οι {count} πίνακες σε αυτό το σύνολο θα διαγραφούν. Αυτή η ενέργεια δεν μπορεί να αναιρεθεί."
+      }
+    }
+  ],
+  "libraryDeleted": "Το σύνολο πινάκων «{name}» διαγράφηκε",
+  "libraryDeleteFailed": "Δεν ήταν δυνατή η διαγραφή του συνόλου πινάκων «{name}»",
   "libraryTitle": "Βιβλιοθήκη",
   "libraryOpen": "Άνοιγμα βιβλιοθήκης",
   "aboutSourceCode": "Πηγαίος κώδικας",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Η σελίδα δεν βρέθηκε",
   "errorGoHome": "Μετάβαση στην αρχική",
   "errorBoardNotFound": "Ο πίνακας δεν βρέθηκε",
-  "errorBoardSetNotFound": "Ο πίνακας δεν βρέθηκε",
-  "boardUrlImportFailed": "Δεν ήταν δυνατή η εισαγωγή του πίνακα από τον σύνδεσμο"
+  "errorBoardSetNotFound": "Το σύνολο πινάκων δεν βρέθηκε",
+  "boardUrlImportFailed": "Δεν ήταν δυνατή η εισαγωγή του αρχείου πίνακα από τον σύνδεσμο"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -21,18 +21,18 @@
   "opensInNewTab": "(opens in new tab)",
   "boardGridLabel": "Communication board",
   "board": "Board",
-  "libraryLoading": "Loading boards...",
+  "libraryLoading": "Loading board sets...",
   "libraryEmptyTitle": "Library is empty",
-  "libraryEmptyDescription": "Import communication boards to get started.",
-  "libraryImportBoards": "Import boards",
-  "libraryBoards": "Boards",
+  "libraryEmptyDescription": "Import board files to get started.",
+  "libraryImportBoards": "Import board files",
+  "libraryBoards": "Board sets",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Importing board...",
-        "countPlural=*": "Importing boards..."
+        "countPlural=one": "Importing board file...",
+        "countPlural=*": "Importing board files..."
       }
     }
   ],
@@ -41,8 +41,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Board imported",
-        "countPlural=*": "Boards imported"
+        "countPlural=one": "Board set imported",
+        "countPlural=*": "Board sets imported"
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Couldn't import board",
-        "countPlural=*": "Couldn't import boards"
+        "countPlural=one": "Couldn't import board file",
+        "countPlural=*": "Couldn't import board files"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Board is too large to import",
-        "countPlural=*": "Boards are too large to import"
+        "countPlural=one": "Board file is too large to import",
+        "countPlural=*": "Board files are too large to import"
       }
     }
   ],
@@ -75,10 +75,19 @@
   "libraryMoreOptionsFor": "More options for {name}",
   "libraryByAuthor": "By {author}",
   "libraryGridDimensions": "{rows}×{columns} grid",
-  "libraryDeleteConfirmTitle": "Delete \"{name}\"?",
-  "libraryDeleteIrreversible": "This action cannot be undone.",
-  "libraryDeleted": "\"{name}\" deleted",
-  "libraryDeleteFailed": "Couldn't delete \"{name}\"",
+  "libraryDeleteConfirmTitle": "Delete board set \"{name}\"?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "The board in this set will be deleted. This cannot be undone.",
+        "countPlural=*": "All {count} boards in this set will be deleted. This cannot be undone."
+      }
+    }
+  ],
+  "libraryDeleted": "Board set \"{name}\" deleted",
+  "libraryDeleteFailed": "Couldn't delete board set \"{name}\"",
   "libraryTitle": "Library",
   "libraryOpen": "Open library",
   "aboutSourceCode": "Source code",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Page not found",
   "errorGoHome": "Go home",
   "errorBoardNotFound": "Board not found",
-  "errorBoardSetNotFound": "Board not found",
-  "boardUrlImportFailed": "Couldn't import board from link"
+  "errorBoardSetNotFound": "Board set not found",
+  "boardUrlImportFailed": "Couldn't import board file from link"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(se abre en una pestaña nueva)",
   "boardGridLabel": "Tablero de comunicación",
   "board": "Tablero",
-  "libraryLoading": "Cargando tableros...",
+  "libraryLoading": "Cargando conjuntos de tableros...",
   "libraryEmptyTitle": "La biblioteca está vacía",
-  "libraryEmptyDescription": "Importa tableros de comunicación para empezar.",
-  "libraryImportBoards": "Importar tableros",
-  "libraryBoards": "Tableros",
+  "libraryEmptyDescription": "Importa archivos de tableros para empezar.",
+  "libraryImportBoards": "Importar archivos de tableros",
+  "libraryBoards": "Conjuntos de tableros",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Importando tablero...",
-        "countPlural=*": "Importando tableros..."
+        "countPlural=one": "Importando archivo de tablero...",
+        "countPlural=*": "Importando archivos de tableros..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tablero importado",
-        "countPlural=*": "Tableros importados"
+        "countPlural=one": "Conjunto de tableros importado",
+        "countPlural=*": "Conjuntos de tableros importados"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "No se pudo importar el tablero",
-        "countPlural=*": "No se pudieron importar los tableros"
+        "countPlural=one": "No se pudo importar el archivo de tablero",
+        "countPlural=*": "No se pudieron importar los archivos de tableros"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "El tablero es demasiado grande para importarlo",
-        "countPlural=*": "Los tableros son demasiado grandes para importarlos"
+        "countPlural=one": "El archivo de tablero es demasiado grande para importarlo",
+        "countPlural=*": "Los archivos de tableros son demasiado grandes para importarlos"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "Más opciones para {name}",
   "libraryByAuthor": "Por {author}",
   "libraryGridDimensions": "Cuadrícula de {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "¿Eliminar \"{name}\"?",
-  "libraryDeleteIrreversible": "Esta acción no se puede deshacer.",
-  "libraryDeleted": "\"{name}\" eliminado",
-  "libraryDeleteFailed": "No se pudo eliminar \"{name}\"",
+  "libraryDeleteConfirmTitle": "¿Eliminar el conjunto de tableros \"{name}\"?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "El tablero de este conjunto se eliminará. Esta acción no se puede deshacer.",
+        "countPlural=*": "Los {count} tableros de este conjunto se eliminarán. Esta acción no se puede deshacer."
+      }
+    }
+  ],
+  "libraryDeleted": "Conjunto de tableros \"{name}\" eliminado",
+  "libraryDeleteFailed": "No se pudo eliminar el conjunto de tableros \"{name}\"",
   "libraryTitle": "Biblioteca",
   "libraryOpen": "Abrir biblioteca",
   "aboutSourceCode": "Código fuente",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Página no encontrada",
   "errorGoHome": "Ir al inicio",
   "errorBoardNotFound": "Tablero no encontrado",
-  "errorBoardSetNotFound": "Tablero no encontrado",
-  "boardUrlImportFailed": "No se pudo importar el tablero desde el enlace"
+  "errorBoardSetNotFound": "Conjunto de tableros no encontrado",
+  "boardUrlImportFailed": "No se pudo importar el archivo de tablero desde el enlace"
 }

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(avautuu uuteen välilehteen)",
   "boardGridLabel": "Kommunikointitaulu",
   "board": "Taulu",
-  "libraryLoading": "Ladataan tauluja...",
+  "libraryLoading": "Ladataan taulusarjoja...",
   "libraryEmptyTitle": "Kirjasto on tyhjä",
-  "libraryEmptyDescription": "Tuo kommunikointitauluja päästäksesi alkuun.",
-  "libraryImportBoards": "Tuo tauluja",
-  "libraryBoards": "Taulut",
+  "libraryEmptyDescription": "Tuo taulutiedostoja päästäksesi alkuun.",
+  "libraryImportBoards": "Tuo taulutiedostoja",
+  "libraryBoards": "Taulusarjat",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tuodaan taulua...",
-        "countPlural=*": "Tuodaan tauluja..."
+        "countPlural=one": "Tuodaan taulutiedostoa...",
+        "countPlural=*": "Tuodaan taulutiedostoja..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Taulu tuotu",
-        "countPlural=*": "Taulut tuotu"
+        "countPlural=one": "Taulusarja tuotu",
+        "countPlural=*": "Taulusarjat tuotu"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Taulun tuonti epäonnistui",
-        "countPlural=*": "Taulujen tuonti epäonnistui"
+        "countPlural=one": "Taulutiedoston tuonti epäonnistui",
+        "countPlural=*": "Taulutiedostojen tuonti epäonnistui"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Taulu on liian suuri tuotavaksi",
-        "countPlural=*": "Taulut ovat liian suuria tuotaviksi"
+        "countPlural=one": "Taulutiedosto on liian suuri tuotavaksi",
+        "countPlural=*": "Taulutiedostot ovat liian suuria tuotaviksi"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "Lisää vaihtoehtoja kohteelle {name}",
   "libraryByAuthor": "Tekijä: {author}",
   "libraryGridDimensions": "Ruudukko {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "Poistetaanko ”{name}”?",
-  "libraryDeleteIrreversible": "Tätä toimintoa ei voi kumota.",
-  "libraryDeleted": "”{name}” poistettu",
-  "libraryDeleteFailed": "Kohteen ”{name}” poisto epäonnistui",
+  "libraryDeleteConfirmTitle": "Poistetaanko taulusarja ”{name}”?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tämän sarjan taulu poistetaan. Tätä toimintoa ei voi kumota.",
+        "countPlural=*": "Kaikki tämän sarjan {count} taulua poistetaan. Tätä toimintoa ei voi kumota."
+      }
+    }
+  ],
+  "libraryDeleted": "Taulusarja ”{name}” poistettu",
+  "libraryDeleteFailed": "Taulusarjan ”{name}” poisto epäonnistui",
   "libraryTitle": "Kirjasto",
   "libraryOpen": "Avaa kirjasto",
   "aboutSourceCode": "Lähdekoodi",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Sivua ei löytynyt",
   "errorGoHome": "Siirry etusivulle",
   "errorBoardNotFound": "Taulua ei löytynyt",
-  "errorBoardSetNotFound": "Taulua ei löytynyt",
-  "boardUrlImportFailed": "Taulun tuonti linkistä epäonnistui"
+  "errorBoardSetNotFound": "Taulusarjaa ei löytynyt",
+  "boardUrlImportFailed": "Taulutiedoston tuonti linkistä epäonnistui"
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(s'ouvre dans un nouvel onglet)",
   "boardGridLabel": "Tableau de communication",
   "board": "Tableau",
-  "libraryLoading": "Chargement des tableaux...",
+  "libraryLoading": "Chargement des ensembles de tableaux...",
   "libraryEmptyTitle": "La bibliothèque est vide",
-  "libraryEmptyDescription": "Importez des tableaux de communication pour commencer.",
-  "libraryImportBoards": "Importer des tableaux",
-  "libraryBoards": "Tableaux",
+  "libraryEmptyDescription": "Importez des fichiers de tableaux pour commencer.",
+  "libraryImportBoards": "Importer des fichiers de tableaux",
+  "libraryBoards": "Ensembles de tableaux",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Importation du tableau...",
-        "countPlural=*": "Importation des tableaux..."
+        "countPlural=one": "Importation du fichier de tableau...",
+        "countPlural=*": "Importation des fichiers de tableaux..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tableau importé",
-        "countPlural=*": "Tableaux importés"
+        "countPlural=one": "Ensemble de tableaux importé",
+        "countPlural=*": "Ensembles de tableaux importés"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Impossible d'importer le tableau",
-        "countPlural=*": "Impossible d'importer les tableaux"
+        "countPlural=one": "Impossible d'importer le fichier de tableau",
+        "countPlural=*": "Impossible d'importer les fichiers de tableaux"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Le tableau est trop volumineux pour être importé",
-        "countPlural=*": "Les tableaux sont trop volumineux pour être importés"
+        "countPlural=one": "Le fichier de tableau est trop volumineux pour être importé",
+        "countPlural=*": "Les fichiers de tableaux sont trop volumineux pour être importés"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "Plus d'options pour {name}",
   "libraryByAuthor": "Par {author}",
   "libraryGridDimensions": "Grille {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "Supprimer « {name} » ?",
-  "libraryDeleteIrreversible": "Cette action est irréversible.",
-  "libraryDeleted": "« {name} » supprimé",
-  "libraryDeleteFailed": "Impossible de supprimer « {name} »",
+  "libraryDeleteConfirmTitle": "Supprimer l’ensemble de tableaux « {name} » ?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Le tableau de cet ensemble sera supprimé. Cette action est irréversible.",
+        "countPlural=*": "Les {count} tableaux de cet ensemble seront tous supprimés. Cette action est irréversible."
+      }
+    }
+  ],
+  "libraryDeleted": "Ensemble de tableaux « {name} » supprimé",
+  "libraryDeleteFailed": "Impossible de supprimer l’ensemble de tableaux « {name} »",
   "libraryTitle": "Bibliothèque",
   "libraryOpen": "Ouvrir la bibliothèque",
   "aboutSourceCode": "Code source",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Page introuvable",
   "errorGoHome": "Aller à l'accueil",
   "errorBoardNotFound": "Tableau introuvable",
-  "errorBoardSetNotFound": "Tableau introuvable",
-  "boardUrlImportFailed": "Impossible d'importer le tableau depuis le lien"
+  "errorBoardSetNotFound": "Ensemble de tableaux introuvable",
+  "boardUrlImportFailed": "Impossible d'importer le fichier de tableau depuis le lien"
 }

--- a/messages/he.json
+++ b/messages/he.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(נפתח בכרטיסייה חדשה)",
   "boardGridLabel": "לוח תקשורת",
   "board": "לוח",
-  "libraryLoading": "טעינת לוחות...",
+  "libraryLoading": "טעינת ערכות לוחות...",
   "libraryEmptyTitle": "הספרייה ריקה",
-  "libraryEmptyDescription": "כדי להתחיל, יש לייבא לוחות תקשורת.",
-  "libraryImportBoards": "ייבוא לוחות",
-  "libraryBoards": "לוחות",
+  "libraryEmptyDescription": "כדי להתחיל, יש לייבא קובצי לוחות.",
+  "libraryImportBoards": "ייבוא קובצי לוחות",
+  "libraryBoards": "ערכות לוחות",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "ייבוא לוח...",
-        "countPlural=*": "ייבוא לוחות..."
+        "countPlural=one": "ייבוא קובץ לוח...",
+        "countPlural=*": "ייבוא קובצי לוחות..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "הלוח יובא בהצלחה",
-        "countPlural=*": "הלוחות יובאו בהצלחה"
+        "countPlural=one": "ערכת הלוחות יובאה בהצלחה",
+        "countPlural=*": "ערכות הלוחות יובאו בהצלחה"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "ייבוא הלוח נכשל",
-        "countPlural=*": "ייבוא הלוחות נכשל"
+        "countPlural=one": "ייבוא קובץ הלוח נכשל",
+        "countPlural=*": "ייבוא קובצי הלוחות נכשל"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "הלוח גדול מדי לייבוא",
-        "countPlural=*": "הלוחות גדולים מדי לייבוא"
+        "countPlural=one": "קובץ הלוח גדול מדי לייבוא",
+        "countPlural=*": "קובצי הלוחות גדולים מדי לייבוא"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "אפשרויות נוספות עבור {name}",
   "libraryByAuthor": "מאת {author}",
   "libraryGridDimensions": "רשת {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "למחוק את \"{name}\"?",
-  "libraryDeleteIrreversible": "לא ניתן לבטל פעולה זו.",
-  "libraryDeleted": "\"{name}\" נמחק",
-  "libraryDeleteFailed": "מחיקת \"{name}\" נכשלה",
+  "libraryDeleteConfirmTitle": "למחוק את ערכת הלוחות \"{name}\"?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "הלוח בערכה זו יימחק. לא ניתן לבטל זאת.",
+        "countPlural=*": "כל {count} הלוחות בערכה זו יימחקו. לא ניתן לבטל זאת."
+      }
+    }
+  ],
+  "libraryDeleted": "ערכת הלוחות \"{name}\" נמחקה",
+  "libraryDeleteFailed": "מחיקת ערכת הלוחות \"{name}\" נכשלה",
   "libraryTitle": "ספרייה",
   "libraryOpen": "פתיחת ספרייה",
   "aboutSourceCode": "קוד מקור",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "הדף לא נמצא",
   "errorGoHome": "חזרה לעמוד הבית",
   "errorBoardNotFound": "הלוח לא נמצא",
-  "errorBoardSetNotFound": "הלוח לא נמצא",
-  "boardUrlImportFailed": "ייבוא הלוח מהקישור נכשל"
+  "errorBoardSetNotFound": "ערכת הלוחות לא נמצאה",
+  "boardUrlImportFailed": "ייבוא קובץ הלוח מהקישור נכשל"
 }

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(नए टैब में खुलता है)",
   "boardGridLabel": "संचार बोर्ड",
   "board": "बोर्ड",
-  "libraryLoading": "बोर्ड लोड हो रहे हैं…",
+  "libraryLoading": "बोर्ड सेट लोड हो रहे हैं…",
   "libraryEmptyTitle": "लाइब्रेरी खाली है",
-  "libraryEmptyDescription": "शुरू करने के लिए संचार बोर्ड आयात करें।",
-  "libraryImportBoards": "बोर्ड आयात करें",
-  "libraryBoards": "बोर्ड",
+  "libraryEmptyDescription": "शुरू करने के लिए बोर्ड फ़ाइलें आयात करें।",
+  "libraryImportBoards": "बोर्ड फ़ाइलें आयात करें",
+  "libraryBoards": "बोर्ड सेट",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "बोर्ड आयात हो रहा है…",
-        "countPlural=*": "बोर्ड आयात हो रहे हैं…"
+        "countPlural=one": "बोर्ड फ़ाइल आयात हो रही है…",
+        "countPlural=*": "बोर्ड फ़ाइलें आयात हो रही हैं…"
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "बोर्ड आयात हो गया",
-        "countPlural=*": "बोर्ड आयात हो गए"
+        "countPlural=one": "बोर्ड सेट आयात हो गया",
+        "countPlural=*": "बोर्ड सेट आयात हो गए"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "बोर्ड आयात नहीं किया जा सका",
-        "countPlural=*": "बोर्ड आयात नहीं किए जा सके"
+        "countPlural=one": "बोर्ड फ़ाइल आयात नहीं की जा सकी",
+        "countPlural=*": "बोर्ड फ़ाइलें आयात नहीं की जा सकीं"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "बोर्ड आयात करने के लिए बहुत बड़ा है",
-        "countPlural=*": "बोर्ड आयात करने के लिए बहुत बड़े हैं"
+        "countPlural=one": "बोर्ड फ़ाइल आयात करने के लिए बहुत बड़ी है",
+        "countPlural=*": "बोर्ड फ़ाइलें आयात करने के लिए बहुत बड़ी हैं"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "{name} के लिए अधिक विकल्प",
   "libraryByAuthor": "{author} द्वारा",
   "libraryGridDimensions": "{rows}×{columns} ग्रिड",
-  "libraryDeleteConfirmTitle": "\"{name}\" को हटाएँ?",
-  "libraryDeleteIrreversible": "यह क्रिया पूर्ववत नहीं की जा सकती।",
-  "libraryDeleted": "\"{name}\" हटा दिया गया",
-  "libraryDeleteFailed": "\"{name}\" को हटाया नहीं जा सका",
+  "libraryDeleteConfirmTitle": "बोर्ड सेट \"{name}\" को हटाएँ?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "इस सेट का बोर्ड हटा दिया जाएगा। इसे पूर्ववत नहीं किया जा सकता।",
+        "countPlural=*": "इस सेट के सभी {count} बोर्ड हटा दिए जाएंगे। इसे पूर्ववत नहीं किया जा सकता।"
+      }
+    }
+  ],
+  "libraryDeleted": "बोर्ड सेट \"{name}\" हटा दिया गया",
+  "libraryDeleteFailed": "बोर्ड सेट \"{name}\" को हटाया नहीं जा सका",
   "libraryTitle": "लाइब्रेरी",
   "libraryOpen": "लाइब्रेरी खोलें",
   "aboutSourceCode": "सोर्स कोड",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "पृष्ठ नहीं मिला",
   "errorGoHome": "होम पर जाएँ",
   "errorBoardNotFound": "बोर्ड नहीं मिला",
-  "errorBoardSetNotFound": "बोर्ड नहीं मिला",
-  "boardUrlImportFailed": "लिंक से बोर्ड आयात नहीं किया जा सका"
+  "errorBoardSetNotFound": "बोर्ड सेट नहीं मिला",
+  "boardUrlImportFailed": "लिंक से बोर्ड फ़ाइल आयात नहीं की जा सकी"
 }

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(otvara se u novoj kartici)",
   "boardGridLabel": "Komunikacijska ploča",
   "board": "Ploča",
-  "libraryLoading": "Učitavanje ploča...",
+  "libraryLoading": "Učitavanje skupova ploča...",
   "libraryEmptyTitle": "Knjižnica je prazna",
-  "libraryEmptyDescription": "Za početak uvezite komunikacijske ploče.",
-  "libraryImportBoards": "Uvezi ploče",
-  "libraryBoards": "Ploče",
+  "libraryEmptyDescription": "Za početak uvezite datoteke ploča.",
+  "libraryImportBoards": "Uvezi datoteke ploča",
+  "libraryBoards": "Skupovi ploča",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Uvoz ploče...",
-        "countPlural=*": "Uvoz ploča..."
+        "countPlural=one": "Uvoz datoteke ploče...",
+        "countPlural=*": "Uvoz datoteka ploča..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Ploča uvezena",
-        "countPlural=*": "Ploče uvezene"
+        "countPlural=one": "Skup ploča uvezen",
+        "countPlural=*": "Skupovi ploča uvezeni"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Ploču nije moguće uvesti",
-        "countPlural=*": "Ploče nije moguće uvesti"
+        "countPlural=one": "Datoteku ploče nije moguće uvesti",
+        "countPlural=*": "Datoteke ploča nije moguće uvesti"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Ploča je prevelika za uvoz",
-        "countPlural=*": "Ploče su prevelike za uvoz"
+        "countPlural=one": "Datoteka ploče je prevelika za uvoz",
+        "countPlural=*": "Datoteke ploča su prevelike za uvoz"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "Više opcija za {name}",
   "libraryByAuthor": "Autor: {author}",
   "libraryGridDimensions": "Mreža {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "Izbrisati „{name}”?",
-  "libraryDeleteIrreversible": "Ovu radnju nije moguće poništiti.",
-  "libraryDeleted": "„{name}” izbrisana",
-  "libraryDeleteFailed": "„{name}” nije moguće izbrisati",
+  "libraryDeleteConfirmTitle": "Izbrisati skup ploča „{name}”?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Ploča u ovom skupu bit će izbrisana. Ovu radnju nije moguće poništiti.",
+        "countPlural=*": "Svih {count} ploča u ovom skupu bit će izbrisano. Ovu radnju nije moguće poništiti."
+      }
+    }
+  ],
+  "libraryDeleted": "Skup ploča „{name}” izbrisan",
+  "libraryDeleteFailed": "Skup ploča „{name}” nije moguće izbrisati",
   "libraryTitle": "Knjižnica",
   "libraryOpen": "Otvori knjižnicu",
   "aboutSourceCode": "Izvorni kod",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Stranica nije pronađena",
   "errorGoHome": "Idi na početnu",
   "errorBoardNotFound": "Ploča nije pronađena",
-  "errorBoardSetNotFound": "Ploča nije pronađena",
-  "boardUrlImportFailed": "Ploču nije moguće uvesti s poveznice"
+  "errorBoardSetNotFound": "Skup ploča nije pronađen",
+  "boardUrlImportFailed": "Datoteku ploče nije moguće uvesti s poveznice"
 }

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(új lapon nyílik meg)",
   "boardGridLabel": "Kommunikációs tábla",
   "board": "Tábla",
-  "libraryLoading": "Táblák betöltése...",
+  "libraryLoading": "Táblakészletek betöltése...",
   "libraryEmptyTitle": "A könyvtár üres",
-  "libraryEmptyDescription": "Az induláshoz importálj kommunikációs táblákat.",
-  "libraryImportBoards": "Táblák importálása",
-  "libraryBoards": "Táblák",
+  "libraryEmptyDescription": "Az induláshoz importálj táblafájlokat.",
+  "libraryImportBoards": "Táblafájlok importálása",
+  "libraryBoards": "Táblakészletek",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tábla importálása...",
-        "countPlural=*": "Táblák importálása..."
+        "countPlural=one": "Táblafájl importálása...",
+        "countPlural=*": "Táblafájlok importálása..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tábla importálva",
-        "countPlural=*": "Táblák importálva"
+        "countPlural=one": "Táblakészlet importálva",
+        "countPlural=*": "Táblakészletek importálva"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "A tábla importálása nem sikerült",
-        "countPlural=*": "A táblák importálása nem sikerült"
+        "countPlural=one": "A táblafájl importálása nem sikerült",
+        "countPlural=*": "A táblafájlok importálása nem sikerült"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "A tábla túl nagy az importáláshoz",
-        "countPlural=*": "A táblák túl nagyok az importáláshoz"
+        "countPlural=one": "A táblafájl túl nagy az importáláshoz",
+        "countPlural=*": "A táblafájlok túl nagyok az importáláshoz"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "További lehetőségek: {name}",
   "libraryByAuthor": "Szerző: {author}",
   "libraryGridDimensions": "{rows}×{columns} rács",
-  "libraryDeleteConfirmTitle": "Törlöd a(z) „{name}” elemet?",
-  "libraryDeleteIrreversible": "Ez a művelet nem vonható vissza.",
-  "libraryDeleted": "„{name}” törölve",
-  "libraryDeleteFailed": "A(z) „{name}” törlése nem sikerült",
+  "libraryDeleteConfirmTitle": "Törlöd a(z) „{name}” táblakészletet?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "A készletben lévő tábla törlődik. Ez a művelet nem vonható vissza.",
+        "countPlural=*": "A készlet mind a(z) {count} táblája törlődik. Ez a művelet nem vonható vissza."
+      }
+    }
+  ],
+  "libraryDeleted": "A(z) „{name}” táblakészlet törölve",
+  "libraryDeleteFailed": "A(z) „{name}” táblakészlet törlése nem sikerült",
   "libraryTitle": "Könyvtár",
   "libraryOpen": "Könyvtár megnyitása",
   "aboutSourceCode": "Forráskód",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Az oldal nem található",
   "errorGoHome": "Ugrás a kezdőlapra",
   "errorBoardNotFound": "A tábla nem található",
-  "errorBoardSetNotFound": "A tábla nem található",
-  "boardUrlImportFailed": "A tábla importálása a hivatkozásról nem sikerült"
+  "errorBoardSetNotFound": "A táblakészlet nem található",
+  "boardUrlImportFailed": "A táblafájl importálása a hivatkozásról nem sikerült"
 }

--- a/messages/id.json
+++ b/messages/id.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(dibuka di tab baru)",
   "boardGridLabel": "Papan komunikasi",
   "board": "Papan",
-  "libraryLoading": "Memuat papan...",
+  "libraryLoading": "Memuat set papan...",
   "libraryEmptyTitle": "Pustaka kosong",
-  "libraryEmptyDescription": "Impor papan komunikasi untuk memulai.",
-  "libraryImportBoards": "Impor papan",
-  "libraryBoards": "Papan",
+  "libraryEmptyDescription": "Impor berkas papan untuk memulai.",
+  "libraryImportBoards": "Impor berkas papan",
+  "libraryBoards": "Set papan",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Mengimpor papan...",
-        "countPlural=*": "Mengimpor papan..."
+        "countPlural=one": "Mengimpor berkas papan...",
+        "countPlural=*": "Mengimpor berkas papan..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Papan diimpor",
-        "countPlural=*": "Papan diimpor"
+        "countPlural=one": "Set papan diimpor",
+        "countPlural=*": "Set papan diimpor"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tidak dapat mengimpor papan",
-        "countPlural=*": "Tidak dapat mengimpor papan"
+        "countPlural=one": "Tidak dapat mengimpor berkas papan",
+        "countPlural=*": "Tidak dapat mengimpor berkas papan"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Papan terlalu besar untuk diimpor",
-        "countPlural=*": "Papan terlalu besar untuk diimpor"
+        "countPlural=one": "Berkas papan terlalu besar untuk diimpor",
+        "countPlural=*": "Berkas papan terlalu besar untuk diimpor"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "Opsi lainnya untuk {name}",
   "libraryByAuthor": "Oleh {author}",
   "libraryGridDimensions": "Kisi {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "Hapus \"{name}\"?",
-  "libraryDeleteIrreversible": "Tindakan ini tidak dapat dibatalkan.",
-  "libraryDeleted": "\"{name}\" dihapus",
-  "libraryDeleteFailed": "Tidak dapat menghapus \"{name}\"",
+  "libraryDeleteConfirmTitle": "Hapus set papan \"{name}\"?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Papan dalam set ini akan dihapus. Tindakan ini tidak dapat dibatalkan.",
+        "countPlural=*": "Semua {count} papan dalam set ini akan dihapus. Tindakan ini tidak dapat dibatalkan."
+      }
+    }
+  ],
+  "libraryDeleted": "Set papan \"{name}\" dihapus",
+  "libraryDeleteFailed": "Tidak dapat menghapus set papan \"{name}\"",
   "libraryTitle": "Pustaka",
   "libraryOpen": "Buka pustaka",
   "aboutSourceCode": "Kode sumber",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Halaman tidak ditemukan",
   "errorGoHome": "Ke beranda",
   "errorBoardNotFound": "Papan tidak ditemukan",
-  "errorBoardSetNotFound": "Papan tidak ditemukan",
-  "boardUrlImportFailed": "Tidak dapat mengimpor papan dari tautan"
+  "errorBoardSetNotFound": "Set papan tidak ditemukan",
+  "boardUrlImportFailed": "Tidak dapat mengimpor berkas papan dari tautan"
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(si apre in una nuova scheda)",
   "boardGridLabel": "Tabella di comunicazione",
   "board": "Tabella",
-  "libraryLoading": "Caricamento tabelle...",
+  "libraryLoading": "Caricamento set di tabelle...",
   "libraryEmptyTitle": "La libreria è vuota",
-  "libraryEmptyDescription": "Importa tabelle di comunicazione per iniziare.",
-  "libraryImportBoards": "Importa tabelle",
-  "libraryBoards": "Tabelle",
+  "libraryEmptyDescription": "Importa file di tabelle per iniziare.",
+  "libraryImportBoards": "Importa file di tabelle",
+  "libraryBoards": "Set di tabelle",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Importazione tabella...",
-        "countPlural=*": "Importazione tabelle..."
+        "countPlural=one": "Importazione file di tabella...",
+        "countPlural=*": "Importazione file di tabelle..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tabella importata",
-        "countPlural=*": "Tabelle importate"
+        "countPlural=one": "Set di tabelle importato",
+        "countPlural=*": "Set di tabelle importati"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Impossibile importare la tabella",
-        "countPlural=*": "Impossibile importare le tabelle"
+        "countPlural=one": "Impossibile importare il file di tabella",
+        "countPlural=*": "Impossibile importare i file di tabelle"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "La tabella è troppo grande per essere importata",
-        "countPlural=*": "Le tabelle sono troppo grandi per essere importate"
+        "countPlural=one": "Il file di tabella è troppo grande per essere importato",
+        "countPlural=*": "I file di tabelle sono troppo grandi per essere importati"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "Altre opzioni per {name}",
   "libraryByAuthor": "Di {author}",
   "libraryGridDimensions": "Griglia {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "Eliminare \"{name}\"?",
-  "libraryDeleteIrreversible": "Questa azione non può essere annullata.",
-  "libraryDeleted": "\"{name}\" eliminata",
-  "libraryDeleteFailed": "Impossibile eliminare \"{name}\"",
+  "libraryDeleteConfirmTitle": "Eliminare il set di tabelle \"{name}\"?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "La tabella in questo set verrà eliminata. Questa azione non può essere annullata.",
+        "countPlural=*": "Tutte le {count} tabelle in questo set verranno eliminate. Questa azione non può essere annullata."
+      }
+    }
+  ],
+  "libraryDeleted": "Set di tabelle \"{name}\" eliminato",
+  "libraryDeleteFailed": "Impossibile eliminare il set di tabelle \"{name}\"",
   "libraryTitle": "Libreria",
   "libraryOpen": "Apri libreria",
   "aboutSourceCode": "Codice sorgente",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Pagina non trovata",
   "errorGoHome": "Vai alla home",
   "errorBoardNotFound": "Tabella non trovata",
-  "errorBoardSetNotFound": "Tabella non trovata",
-  "boardUrlImportFailed": "Impossibile importare la tabella dal link"
+  "errorBoardSetNotFound": "Set di tabelle non trovato",
+  "boardUrlImportFailed": "Impossibile importare il file di tabella dal link"
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(新しいタブで開きます)",
   "boardGridLabel": "コミュニケーションボード",
   "board": "ボード",
-  "libraryLoading": "ボードを読み込んでいます…",
+  "libraryLoading": "ボードセットを読み込んでいます…",
   "libraryEmptyTitle": "ライブラリは空です",
-  "libraryEmptyDescription": "コミュニケーションボードをインポートして始めましょう。",
-  "libraryImportBoards": "ボードをインポート",
-  "libraryBoards": "ボード",
+  "libraryEmptyDescription": "ボードファイルをインポートして始めましょう。",
+  "libraryImportBoards": "ボードファイルをインポート",
+  "libraryBoards": "ボードセット",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "ボードをインポートしています…",
-        "countPlural=*": "ボードをインポートしています…"
+        "countPlural=one": "ボードファイルをインポートしています…",
+        "countPlural=*": "ボードファイルをインポートしています…"
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "ボードをインポートしました",
-        "countPlural=*": "ボードをインポートしました"
+        "countPlural=one": "ボードセットをインポートしました",
+        "countPlural=*": "ボードセットをインポートしました"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "ボードをインポートできませんでした",
-        "countPlural=*": "ボードをインポートできませんでした"
+        "countPlural=one": "ボードファイルをインポートできませんでした",
+        "countPlural=*": "ボードファイルをインポートできませんでした"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "ボードが大きすぎてインポートできません",
-        "countPlural=*": "ボードが大きすぎてインポートできません"
+        "countPlural=one": "ボードファイルが大きすぎてインポートできません",
+        "countPlural=*": "ボードファイルが大きすぎてインポートできません"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "{name} のその他のオプション",
   "libraryByAuthor": "作成者：{author}",
   "libraryGridDimensions": "{rows}×{columns} グリッド",
-  "libraryDeleteConfirmTitle": "「{name}」を削除しますか？",
-  "libraryDeleteIrreversible": "この操作は取り消せません。",
-  "libraryDeleted": "「{name}」を削除しました",
-  "libraryDeleteFailed": "「{name}」を削除できませんでした",
+  "libraryDeleteConfirmTitle": "ボードセット「{name}」を削除しますか？",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "このセットのボードが削除されます。この操作は取り消せません。",
+        "countPlural=*": "このセットの{count}個のボードがすべて削除されます。この操作は取り消せません。"
+      }
+    }
+  ],
+  "libraryDeleted": "ボードセット「{name}」を削除しました",
+  "libraryDeleteFailed": "ボードセット「{name}」を削除できませんでした",
   "libraryTitle": "ライブラリ",
   "libraryOpen": "ライブラリを開く",
   "aboutSourceCode": "ソースコード",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "ページが見つかりません",
   "errorGoHome": "ホームに戻る",
   "errorBoardNotFound": "ボードが見つかりません",
-  "errorBoardSetNotFound": "ボードが見つかりません",
-  "boardUrlImportFailed": "リンクからボードをインポートできませんでした"
+  "errorBoardSetNotFound": "ボードセットが見つかりません",
+  "boardUrlImportFailed": "リンクからボードファイルをインポートできませんでした"
 }

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(ಹೊಸ ಟ್ಯಾಬ್‌ನಲ್ಲಿ ತೆರೆಯುತ್ತದೆ)",
   "boardGridLabel": "ಸಂವಹನ ಬೋರ್ಡ್",
   "board": "ಬೋರ್ಡ್",
-  "libraryLoading": "ಬೋರ್ಡ್‌ಗಳು ಲೋಡ್ ಆಗುತ್ತಿವೆ…",
+  "libraryLoading": "ಬೋರ್ಡ್ ಸೆಟ್‌ಗಳು ಲೋಡ್ ಆಗುತ್ತಿವೆ…",
   "libraryEmptyTitle": "ಗ್ರಂಥಾಲಯ ಖಾಲಿಯಾಗಿದೆ",
-  "libraryEmptyDescription": "ಪ್ರಾರಂಭಿಸಲು ಸಂವಹನ ಬೋರ್ಡ್‌ಗಳನ್ನು ಆಮದು ಮಾಡಿ.",
-  "libraryImportBoards": "ಬೋರ್ಡ್‌ಗಳನ್ನು ಆಮದು ಮಾಡಿ",
-  "libraryBoards": "ಬೋರ್ಡ್‌ಗಳು",
+  "libraryEmptyDescription": "ಪ್ರಾರಂಭಿಸಲು ಬೋರ್ಡ್ ಫೈಲ್‌ಗಳನ್ನು ಆಮದು ಮಾಡಿ.",
+  "libraryImportBoards": "ಬೋರ್ಡ್ ಫೈಲ್‌ಗಳನ್ನು ಆಮದು ಮಾಡಿ",
+  "libraryBoards": "ಬೋರ್ಡ್ ಸೆಟ್‌ಗಳು",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "ಬೋರ್ಡ್ ಆಮದು ಆಗುತ್ತಿದೆ…",
-        "countPlural=*": "ಬೋರ್ಡ್‌ಗಳು ಆಮದು ಆಗುತ್ತಿವೆ…"
+        "countPlural=one": "ಬೋರ್ಡ್ ಫೈಲ್ ಆಮದು ಆಗುತ್ತಿದೆ…",
+        "countPlural=*": "ಬೋರ್ಡ್ ಫೈಲ್‌ಗಳು ಆಮದು ಆಗುತ್ತಿವೆ…"
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "ಬೋರ್ಡ್ ಆಮದಾಗಿದೆ",
-        "countPlural=*": "ಬೋರ್ಡ್‌ಗಳು ಆಮದಾಗಿವೆ"
+        "countPlural=one": "ಬೋರ್ಡ್ ಸೆಟ್ ಆಮದಾಗಿದೆ",
+        "countPlural=*": "ಬೋರ್ಡ್ ಸೆಟ್‌ಗಳು ಆಮದಾಗಿವೆ"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "ಬೋರ್ಡ್ ಆಮದು ಮಾಡಲಾಗಲಿಲ್ಲ",
-        "countPlural=*": "ಬೋರ್ಡ್‌ಗಳನ್ನು ಆಮದು ಮಾಡಲಾಗಲಿಲ್ಲ"
+        "countPlural=one": "ಬೋರ್ಡ್ ಫೈಲ್ ಆಮದು ಮಾಡಲಾಗಲಿಲ್ಲ",
+        "countPlural=*": "ಬೋರ್ಡ್ ಫೈಲ್‌ಗಳನ್ನು ಆಮದು ಮಾಡಲಾಗಲಿಲ್ಲ"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "ಬೋರ್ಡ್ ಆಮದು ಮಾಡಲು ತುಂಬಾ ದೊಡ್ಡದಾಗಿದೆ",
-        "countPlural=*": "ಬೋರ್ಡ್‌ಗಳು ಆಮದು ಮಾಡಲು ತುಂಬಾ ದೊಡ್ಡದಾಗಿವೆ"
+        "countPlural=one": "ಬೋರ್ಡ್ ಫೈಲ್ ಆಮದು ಮಾಡಲು ತುಂಬಾ ದೊಡ್ಡದಾಗಿದೆ",
+        "countPlural=*": "ಬೋರ್ಡ್ ಫೈಲ್‌ಗಳು ಆಮದು ಮಾಡಲು ತುಂಬಾ ದೊಡ್ಡದಾಗಿವೆ"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "{name} ಗಾಗಿ ಹೆಚ್ಚಿನ ಆಯ್ಕೆಗಳು",
   "libraryByAuthor": "ಲೇಖಕ: {author}",
   "libraryGridDimensions": "{rows}×{columns} ಗ್ರಿಡ್",
-  "libraryDeleteConfirmTitle": "\"{name}\" ಅನ್ನು ಅಳಿಸುವುದೇ?",
-  "libraryDeleteIrreversible": "ಈ ಕ್ರಿಯೆಯನ್ನು ರದ್ದುಗೊಳಿಸಲಾಗದು.",
-  "libraryDeleted": "\"{name}\" ಅಳಿಸಲಾಗಿದೆ",
-  "libraryDeleteFailed": "\"{name}\" ಅನ್ನು ಅಳಿಸಲಾಗಲಿಲ್ಲ",
+  "libraryDeleteConfirmTitle": "ಬೋರ್ಡ್ ಸೆಟ್ \"{name}\" ಅನ್ನು ಅಳಿಸುವುದೇ?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "ಈ ಸೆಟ್‌ನಲ್ಲಿರುವ ಬೋರ್ಡ್ ಅನ್ನು ಅಳಿಸಲಾಗುತ್ತದೆ. ಈ ಕ್ರಿಯೆಯನ್ನು ರದ್ದುಗೊಳಿಸಲಾಗದು.",
+        "countPlural=*": "ಈ ಸೆಟ್‌ನಲ್ಲಿರುವ ಎಲ್ಲಾ {count} ಬೋರ್ಡ್‌ಗಳನ್ನು ಅಳಿಸಲಾಗುತ್ತದೆ. ಈ ಕ್ರಿಯೆಯನ್ನು ರದ್ದುಗೊಳಿಸಲಾಗದು."
+      }
+    }
+  ],
+  "libraryDeleted": "ಬೋರ್ಡ್ ಸೆಟ್ \"{name}\" ಅಳಿಸಲಾಗಿದೆ",
+  "libraryDeleteFailed": "ಬೋರ್ಡ್ ಸೆಟ್ \"{name}\" ಅನ್ನು ಅಳಿಸಲಾಗಲಿಲ್ಲ",
   "libraryTitle": "ಗ್ರಂಥಾಲಯ",
   "libraryOpen": "ಗ್ರಂಥಾಲಯವನ್ನು ತೆರೆಯಿರಿ",
   "aboutSourceCode": "ಮೂಲ ಕೋಡ್",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "ಪುಟ ಕಂಡುಬಂದಿಲ್ಲ",
   "errorGoHome": "ಮುಖಪುಟಕ್ಕೆ ಹೋಗಿ",
   "errorBoardNotFound": "ಬೋರ್ಡ್ ಕಂಡುಬಂದಿಲ್ಲ",
-  "errorBoardSetNotFound": "ಬೋರ್ಡ್ ಕಂಡುಬಂದಿಲ್ಲ",
-  "boardUrlImportFailed": "ಲಿಂಕ್‌ನಿಂದ ಬೋರ್ಡ್ ಆಮದು ಮಾಡಲಾಗಲಿಲ್ಲ"
+  "errorBoardSetNotFound": "ಬೋರ್ಡ್ ಸೆಟ್ ಕಂಡುಬಂದಿಲ್ಲ",
+  "boardUrlImportFailed": "ಲಿಂಕ್‌ನಿಂದ ಬೋರ್ಡ್ ಫೈಲ್ ಆಮದು ಮಾಡಲಾಗಲಿಲ್ಲ"
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(새 탭에서 열림)",
   "boardGridLabel": "의사소통 보드",
   "board": "보드",
-  "libraryLoading": "보드를 불러오는 중…",
+  "libraryLoading": "보드 세트를 불러오는 중…",
   "libraryEmptyTitle": "라이브러리가 비어 있습니다",
-  "libraryEmptyDescription": "의사소통 보드를 가져와 시작하세요.",
-  "libraryImportBoards": "보드 가져오기",
-  "libraryBoards": "보드",
+  "libraryEmptyDescription": "보드 파일을 가져와 시작하세요.",
+  "libraryImportBoards": "보드 파일 가져오기",
+  "libraryBoards": "보드 세트",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "보드를 가져오는 중…",
-        "countPlural=*": "보드를 가져오는 중…"
+        "countPlural=one": "보드 파일을 가져오는 중…",
+        "countPlural=*": "보드 파일을 가져오는 중…"
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "보드를 가져왔습니다",
-        "countPlural=*": "보드를 가져왔습니다"
+        "countPlural=one": "보드 세트를 가져왔습니다",
+        "countPlural=*": "보드 세트를 가져왔습니다"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "보드를 가져올 수 없습니다",
-        "countPlural=*": "보드를 가져올 수 없습니다"
+        "countPlural=one": "보드 파일을 가져올 수 없습니다",
+        "countPlural=*": "보드 파일을 가져올 수 없습니다"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "보드가 너무 커서 가져올 수 없습니다",
-        "countPlural=*": "보드가 너무 커서 가져올 수 없습니다"
+        "countPlural=one": "보드 파일이 너무 커서 가져올 수 없습니다",
+        "countPlural=*": "보드 파일이 너무 커서 가져올 수 없습니다"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "{name}의 옵션 더 보기",
   "libraryByAuthor": "작성자: {author}",
   "libraryGridDimensions": "{rows}×{columns} 그리드",
-  "libraryDeleteConfirmTitle": "\"{name}\"을(를) 삭제하시겠어요?",
-  "libraryDeleteIrreversible": "이 작업은 되돌릴 수 없습니다.",
-  "libraryDeleted": "\"{name}\"이(가) 삭제됨",
-  "libraryDeleteFailed": "\"{name}\"을(를) 삭제할 수 없습니다",
+  "libraryDeleteConfirmTitle": "보드 세트 \"{name}\"을(를) 삭제하시겠어요?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "이 세트의 보드가 삭제됩니다. 이 작업은 되돌릴 수 없습니다.",
+        "countPlural=*": "이 세트의 보드 {count}개가 모두 삭제됩니다. 이 작업은 되돌릴 수 없습니다."
+      }
+    }
+  ],
+  "libraryDeleted": "보드 세트 \"{name}\"이(가) 삭제됨",
+  "libraryDeleteFailed": "보드 세트 \"{name}\"을(를) 삭제할 수 없습니다",
   "libraryTitle": "라이브러리",
   "libraryOpen": "라이브러리 열기",
   "aboutSourceCode": "소스 코드",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "페이지를 찾을 수 없음",
   "errorGoHome": "홈으로",
   "errorBoardNotFound": "보드를 찾을 수 없음",
-  "errorBoardSetNotFound": "보드를 찾을 수 없음",
-  "boardUrlImportFailed": "링크에서 보드를 가져올 수 없습니다"
+  "errorBoardSetNotFound": "보드 세트를 찾을 수 없음",
+  "boardUrlImportFailed": "링크에서 보드 파일을 가져올 수 없습니다"
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(opent in nieuw tabblad)",
   "boardGridLabel": "Communicatiebord",
   "board": "Bord",
-  "libraryLoading": "Borden laden...",
+  "libraryLoading": "Bordsets laden...",
   "libraryEmptyTitle": "De bibliotheek is leeg",
-  "libraryEmptyDescription": "Importeer communicatieborden om te beginnen.",
-  "libraryImportBoards": "Borden importeren",
-  "libraryBoards": "Borden",
+  "libraryEmptyDescription": "Importeer bordbestanden om te beginnen.",
+  "libraryImportBoards": "Bordbestanden importeren",
+  "libraryBoards": "Bordsets",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Bord importeren...",
-        "countPlural=*": "Borden importeren..."
+        "countPlural=one": "Bordbestand importeren...",
+        "countPlural=*": "Bordbestanden importeren..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Bord geïmporteerd",
-        "countPlural=*": "Borden geïmporteerd"
+        "countPlural=one": "Bordset geïmporteerd",
+        "countPlural=*": "Bordsets geïmporteerd"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Kan bord niet importeren",
-        "countPlural=*": "Kan borden niet importeren"
+        "countPlural=one": "Kan bordbestand niet importeren",
+        "countPlural=*": "Kan bordbestanden niet importeren"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Het bord is te groot om te importeren",
-        "countPlural=*": "De borden zijn te groot om te importeren"
+        "countPlural=one": "Het bordbestand is te groot om te importeren",
+        "countPlural=*": "De bordbestanden zijn te groot om te importeren"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "Meer opties voor {name}",
   "libraryByAuthor": "Door {author}",
   "libraryGridDimensions": "Raster {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "\"{name}\" verwijderen?",
-  "libraryDeleteIrreversible": "Deze actie kan niet ongedaan worden gemaakt.",
-  "libraryDeleted": "\"{name}\" verwijderd",
-  "libraryDeleteFailed": "Kan \"{name}\" niet verwijderen",
+  "libraryDeleteConfirmTitle": "Bordset \"{name}\" verwijderen?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Het bord in deze set wordt verwijderd. Deze actie kan niet ongedaan worden gemaakt.",
+        "countPlural=*": "Alle {count} borden in deze set worden verwijderd. Deze actie kan niet ongedaan worden gemaakt."
+      }
+    }
+  ],
+  "libraryDeleted": "Bordset \"{name}\" verwijderd",
+  "libraryDeleteFailed": "Kan bordset \"{name}\" niet verwijderen",
   "libraryTitle": "Bibliotheek",
   "libraryOpen": "Bibliotheek openen",
   "aboutSourceCode": "Broncode",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Pagina niet gevonden",
   "errorGoHome": "Naar start",
   "errorBoardNotFound": "Bord niet gevonden",
-  "errorBoardSetNotFound": "Bord niet gevonden",
-  "boardUrlImportFailed": "Kan bord niet importeren via de link"
+  "errorBoardSetNotFound": "Bordset niet gevonden",
+  "boardUrlImportFailed": "Kan bordbestand niet importeren via de link"
 }

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(otwiera się w nowej karcie)",
   "boardGridLabel": "Tablica komunikacyjna",
   "board": "Tablica",
-  "libraryLoading": "Ładowanie tablic...",
+  "libraryLoading": "Ładowanie zestawów tablic...",
   "libraryEmptyTitle": "Biblioteka jest pusta",
-  "libraryEmptyDescription": "Zaimportuj tablice komunikacyjne, aby rozpocząć.",
-  "libraryImportBoards": "Importuj tablice",
-  "libraryBoards": "Tablice",
+  "libraryEmptyDescription": "Zaimportuj pliki tablic, aby rozpocząć.",
+  "libraryImportBoards": "Importuj pliki tablic",
+  "libraryBoards": "Zestawy tablic",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Importowanie tablicy...",
-        "countPlural=*": "Importowanie tablic..."
+        "countPlural=one": "Importowanie pliku tablicy...",
+        "countPlural=*": "Importowanie plików tablic..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Zaimportowano tablicę",
-        "countPlural=*": "Zaimportowano tablice"
+        "countPlural=one": "Zaimportowano zestaw tablic",
+        "countPlural=*": "Zaimportowano zestawy tablic"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Nie udało się zaimportować tablicy",
-        "countPlural=*": "Nie udało się zaimportować tablic"
+        "countPlural=one": "Nie udało się zaimportować pliku tablicy",
+        "countPlural=*": "Nie udało się zaimportować plików tablic"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tablica jest zbyt duża, aby ją zaimportować",
-        "countPlural=*": "Tablice są zbyt duże, aby je zaimportować"
+        "countPlural=one": "Plik tablicy jest zbyt duży, aby go zaimportować",
+        "countPlural=*": "Pliki tablic są zbyt duże, aby je zaimportować"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "Więcej opcji dla {name}",
   "libraryByAuthor": "Autor: {author}",
   "libraryGridDimensions": "Siatka {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "Usunąć „{name}”?",
-  "libraryDeleteIrreversible": "Tej operacji nie można cofnąć.",
-  "libraryDeleted": "Usunięto „{name}”",
-  "libraryDeleteFailed": "Nie udało się usunąć „{name}”",
+  "libraryDeleteConfirmTitle": "Usunąć zestaw tablic „{name}”?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tablica z tego zestawu zostanie usunięta. Tej operacji nie można cofnąć.",
+        "countPlural=*": "Wszystkie tablice z tego zestawu ({count}) zostaną usunięte. Tej operacji nie można cofnąć."
+      }
+    }
+  ],
+  "libraryDeleted": "Zestaw tablic „{name}” usunięty",
+  "libraryDeleteFailed": "Nie udało się usunąć zestawu tablic „{name}”",
   "libraryTitle": "Biblioteka",
   "libraryOpen": "Otwórz bibliotekę",
   "aboutSourceCode": "Kod źródłowy",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Nie znaleziono strony",
   "errorGoHome": "Przejdź do strony głównej",
   "errorBoardNotFound": "Nie znaleziono tablicy",
-  "errorBoardSetNotFound": "Nie znaleziono tablicy",
-  "boardUrlImportFailed": "Nie udało się zaimportować tablicy z linku"
+  "errorBoardSetNotFound": "Nie znaleziono zestawu tablic",
+  "boardUrlImportFailed": "Nie udało się zaimportować pliku tablicy z linku"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(abre em uma nova aba)",
   "boardGridLabel": "Prancha de comunicação",
   "board": "Prancha",
-  "libraryLoading": "Carregando pranchas...",
+  "libraryLoading": "Carregando conjuntos de pranchas...",
   "libraryEmptyTitle": "A biblioteca está vazia",
-  "libraryEmptyDescription": "Importe pranchas de comunicação para começar.",
-  "libraryImportBoards": "Importar pranchas",
-  "libraryBoards": "Pranchas",
+  "libraryEmptyDescription": "Importe arquivos de pranchas para começar.",
+  "libraryImportBoards": "Importar arquivos de pranchas",
+  "libraryBoards": "Conjuntos de pranchas",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Importando prancha...",
-        "countPlural=*": "Importando pranchas..."
+        "countPlural=one": "Importando arquivo de prancha...",
+        "countPlural=*": "Importando arquivos de pranchas..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Prancha importada",
-        "countPlural=*": "Pranchas importadas"
+        "countPlural=one": "Conjunto de pranchas importado",
+        "countPlural=*": "Conjuntos de pranchas importados"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Não foi possível importar a prancha",
-        "countPlural=*": "Não foi possível importar as pranchas"
+        "countPlural=one": "Não foi possível importar o arquivo de prancha",
+        "countPlural=*": "Não foi possível importar os arquivos de pranchas"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "A prancha é grande demais para importar",
-        "countPlural=*": "As pranchas são grandes demais para importar"
+        "countPlural=one": "O arquivo de prancha é grande demais para importar",
+        "countPlural=*": "Os arquivos de pranchas são grandes demais para importar"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "Mais opções para {name}",
   "libraryByAuthor": "Por {author}",
   "libraryGridDimensions": "Grade {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "Excluir \"{name}\"?",
-  "libraryDeleteIrreversible": "Esta ação não pode ser desfeita.",
-  "libraryDeleted": "\"{name}\" excluída",
-  "libraryDeleteFailed": "Não foi possível excluir \"{name}\"",
+  "libraryDeleteConfirmTitle": "Excluir o conjunto de pranchas \"{name}\"?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "A prancha neste conjunto será excluída. Esta ação não pode ser desfeita.",
+        "countPlural=*": "Todas as {count} pranchas neste conjunto serão excluídas. Esta ação não pode ser desfeita."
+      }
+    }
+  ],
+  "libraryDeleted": "Conjunto de pranchas \"{name}\" excluído",
+  "libraryDeleteFailed": "Não foi possível excluir o conjunto de pranchas \"{name}\"",
   "libraryTitle": "Biblioteca",
   "libraryOpen": "Abrir biblioteca",
   "aboutSourceCode": "Código-fonte",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Página não encontrada",
   "errorGoHome": "Ir para o início",
   "errorBoardNotFound": "Prancha não encontrada",
-  "errorBoardSetNotFound": "Prancha não encontrada",
-  "boardUrlImportFailed": "Não foi possível importar a prancha do link"
+  "errorBoardSetNotFound": "Conjunto de pranchas não encontrado",
+  "boardUrlImportFailed": "Não foi possível importar o arquivo de prancha do link"
 }

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(se deschide într-o filă nouă)",
   "boardGridLabel": "Tablă de comunicare",
   "board": "Tablă",
-  "libraryLoading": "Se încarcă tablele...",
+  "libraryLoading": "Se încarcă seturile de table...",
   "libraryEmptyTitle": "Biblioteca este goală",
-  "libraryEmptyDescription": "Importă table de comunicare pentru a începe.",
-  "libraryImportBoards": "Importă table",
-  "libraryBoards": "Table",
+  "libraryEmptyDescription": "Importă fișiere de table pentru a începe.",
+  "libraryImportBoards": "Importă fișiere de table",
+  "libraryBoards": "Seturi de table",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Se importă tabla...",
-        "countPlural=*": "Se importă tablele..."
+        "countPlural=one": "Se importă fișierul tablei...",
+        "countPlural=*": "Se importă fișierele tablelor..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tablă importată",
-        "countPlural=*": "Table importate"
+        "countPlural=one": "Set de table importat",
+        "countPlural=*": "Seturi de table importate"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tabla nu a putut fi importată",
-        "countPlural=*": "Tablele nu au putut fi importate"
+        "countPlural=one": "Fișierul tablei nu a putut fi importat",
+        "countPlural=*": "Fișierele tablelor nu au putut fi importate"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tabla este prea mare pentru a fi importată",
-        "countPlural=*": "Tablele sunt prea mari pentru a fi importate"
+        "countPlural=one": "Fișierul tablei este prea mare pentru a fi importat",
+        "countPlural=*": "Fișierele tablelor sunt prea mari pentru a fi importate"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "Mai multe opțiuni pentru {name}",
   "libraryByAuthor": "De {author}",
   "libraryGridDimensions": "Grilă {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "Ștergi „{name}”?",
-  "libraryDeleteIrreversible": "Această acțiune nu poate fi anulată.",
-  "libraryDeleted": "„{name}” a fost ștearsă",
-  "libraryDeleteFailed": "„{name}” nu a putut fi ștearsă",
+  "libraryDeleteConfirmTitle": "Ștergi setul de table „{name}”?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tabla din acest set va fi ștearsă. Această acțiune nu poate fi anulată.",
+        "countPlural=*": "Toate cele {count} table din acest set vor fi șterse. Această acțiune nu poate fi anulată."
+      }
+    }
+  ],
+  "libraryDeleted": "Setul de table „{name}” a fost șters",
+  "libraryDeleteFailed": "Setul de table „{name}” nu a putut fi șters",
   "libraryTitle": "Bibliotecă",
   "libraryOpen": "Deschide biblioteca",
   "aboutSourceCode": "Cod sursă",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Pagina nu a fost găsită",
   "errorGoHome": "Mergi la pagina principală",
   "errorBoardNotFound": "Tabla nu a fost găsită",
-  "errorBoardSetNotFound": "Tabla nu a fost găsită",
-  "boardUrlImportFailed": "Tabla nu a putut fi importată din link"
+  "errorBoardSetNotFound": "Setul de table nu a fost găsit",
+  "boardUrlImportFailed": "Fișierul tablei nu a putut fi importat din link"
 }

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(открывается в новой вкладке)",
   "boardGridLabel": "Коммуникационная доска",
   "board": "Доска",
-  "libraryLoading": "Загрузка досок...",
+  "libraryLoading": "Загрузка наборов досок...",
   "libraryEmptyTitle": "Библиотека пуста",
-  "libraryEmptyDescription": "Импортируйте коммуникационные доски, чтобы начать.",
-  "libraryImportBoards": "Импортировать доски",
-  "libraryBoards": "Доски",
+  "libraryEmptyDescription": "Импортируйте файлы досок, чтобы начать.",
+  "libraryImportBoards": "Импортировать файлы досок",
+  "libraryBoards": "Наборы досок",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Импорт доски...",
-        "countPlural=*": "Импорт досок..."
+        "countPlural=one": "Импорт файла доски...",
+        "countPlural=*": "Импорт файлов досок..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Доска импортирована",
-        "countPlural=*": "Доски импортированы"
+        "countPlural=one": "Набор досок импортирован",
+        "countPlural=*": "Наборы досок импортированы"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Не удалось импортировать доску",
-        "countPlural=*": "Не удалось импортировать доски"
+        "countPlural=one": "Не удалось импортировать файл доски",
+        "countPlural=*": "Не удалось импортировать файлы досок"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Доска слишком большая для импорта",
-        "countPlural=*": "Доски слишком большие для импорта"
+        "countPlural=one": "Файл доски слишком большой для импорта",
+        "countPlural=*": "Файлы досок слишком большие для импорта"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "Дополнительные параметры для {name}",
   "libraryByAuthor": "Автор: {author}",
   "libraryGridDimensions": "Сетка {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "Удалить «{name}»?",
-  "libraryDeleteIrreversible": "Это действие нельзя отменить.",
-  "libraryDeleted": "«{name}» удалена",
-  "libraryDeleteFailed": "Не удалось удалить «{name}»",
+  "libraryDeleteConfirmTitle": "Удалить набор досок «{name}»?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Доска из этого набора будет удалена. Это действие нельзя отменить.",
+        "countPlural=*": "Все доски из этого набора ({count}) будут удалены. Это действие нельзя отменить."
+      }
+    }
+  ],
+  "libraryDeleted": "Набор досок «{name}» удалён",
+  "libraryDeleteFailed": "Не удалось удалить набор досок «{name}»",
   "libraryTitle": "Библиотека",
   "libraryOpen": "Открыть библиотеку",
   "aboutSourceCode": "Исходный код",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Страница не найдена",
   "errorGoHome": "На главную",
   "errorBoardNotFound": "Доска не найдена",
-  "errorBoardSetNotFound": "Доска не найдена",
-  "boardUrlImportFailed": "Не удалось импортировать доску по ссылке"
+  "errorBoardSetNotFound": "Набор досок не найден",
+  "boardUrlImportFailed": "Не удалось импортировать файл доски по ссылке"
 }

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(otvorí sa na novej karte)",
   "boardGridLabel": "Komunikačná tabuľka",
   "board": "Tabuľka",
-  "libraryLoading": "Načítavajú sa tabuľky...",
+  "libraryLoading": "Načítavajú sa súpravy tabuliek...",
   "libraryEmptyTitle": "Knižnica je prázdna",
-  "libraryEmptyDescription": "Začnite importovaním komunikačných tabuliek.",
-  "libraryImportBoards": "Importovať tabuľky",
-  "libraryBoards": "Tabuľky",
+  "libraryEmptyDescription": "Začnite importovaním súborov tabuliek.",
+  "libraryImportBoards": "Importovať súbory tabuliek",
+  "libraryBoards": "Súpravy tabuliek",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Importovanie tabuľky...",
-        "countPlural=*": "Importovanie tabuliek..."
+        "countPlural=one": "Importovanie súboru tabuľky...",
+        "countPlural=*": "Importovanie súborov tabuliek..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tabuľka importovaná",
-        "countPlural=*": "Tabuľky importované"
+        "countPlural=one": "Súprava tabuliek importovaná",
+        "countPlural=*": "Súpravy tabuliek importované"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tabuľku sa nepodarilo importovať",
-        "countPlural=*": "Tabuľky sa nepodarilo importovať"
+        "countPlural=one": "Súbor tabuľky sa nepodarilo importovať",
+        "countPlural=*": "Súbory tabuliek sa nepodarilo importovať"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tabuľka je príliš veľká na import",
-        "countPlural=*": "Tabuľky sú príliš veľké na import"
+        "countPlural=one": "Súbor tabuľky je príliš veľký na import",
+        "countPlural=*": "Súbory tabuliek sú príliš veľké na import"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "Ďalšie možnosti pre {name}",
   "libraryByAuthor": "Autor: {author}",
   "libraryGridDimensions": "Mriežka {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "Odstrániť „{name}“?",
-  "libraryDeleteIrreversible": "Túto akciu nie je možné vrátiť späť.",
-  "libraryDeleted": "„{name}“ odstránené",
-  "libraryDeleteFailed": "„{name}“ sa nepodarilo odstrániť",
+  "libraryDeleteConfirmTitle": "Odstrániť súpravu tabuliek „{name}“?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tabuľka v tejto súprave bude odstránená. Túto akciu nie je možné vrátiť späť.",
+        "countPlural=*": "Všetkých {count} tabuliek v tejto súprave bude odstránených. Túto akciu nie je možné vrátiť späť."
+      }
+    }
+  ],
+  "libraryDeleted": "Súprava tabuliek „{name}“ odstránená",
+  "libraryDeleteFailed": "Súpravu tabuliek „{name}“ sa nepodarilo odstrániť",
   "libraryTitle": "Knižnica",
   "libraryOpen": "Otvoriť knižnicu",
   "aboutSourceCode": "Zdrojový kód",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Stránka sa nenašla",
   "errorGoHome": "Prejsť domov",
   "errorBoardNotFound": "Tabuľka sa nenašla",
-  "errorBoardSetNotFound": "Tabuľka sa nenašla",
-  "boardUrlImportFailed": "Tabuľku sa nepodarilo importovať z odkazu"
+  "errorBoardSetNotFound": "Súprava tabuliek sa nenašla",
+  "boardUrlImportFailed": "Súbor tabuľky sa nepodarilo importovať z odkazu"
 }

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(odpre se v novem zavihku)",
   "boardGridLabel": "Komunikacijska tabla",
   "board": "Tabla",
-  "libraryLoading": "Nalaganje tabel...",
+  "libraryLoading": "Nalaganje kompletov tabel...",
   "libraryEmptyTitle": "Knjižnica je prazna",
-  "libraryEmptyDescription": "Za začetek uvozite komunikacijske table.",
-  "libraryImportBoards": "Uvozi table",
-  "libraryBoards": "Table",
+  "libraryEmptyDescription": "Za začetek uvozite datoteke tabel.",
+  "libraryImportBoards": "Uvozi datoteke tabel",
+  "libraryBoards": "Kompleti tabel",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Uvažanje table...",
-        "countPlural=*": "Uvažanje tabel..."
+        "countPlural=one": "Uvažanje datoteke tabele...",
+        "countPlural=*": "Uvažanje datotek tabel..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tabla uvožena",
-        "countPlural=*": "Table uvožene"
+        "countPlural=one": "Komplet tabel uvožen",
+        "countPlural=*": "Kompleti tabel uvoženi"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Table ni bilo mogoče uvoziti",
-        "countPlural=*": "Tabel ni bilo mogoče uvoziti"
+        "countPlural=one": "Datoteke tabele ni bilo mogoče uvoziti",
+        "countPlural=*": "Datotek tabel ni bilo mogoče uvoziti"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tabla je prevelika za uvoz",
-        "countPlural=*": "Table so prevelike za uvoz"
+        "countPlural=one": "Datoteka tabele je prevelika za uvoz",
+        "countPlural=*": "Datoteke tabel so prevelike za uvoz"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "Več možnosti za {name}",
   "libraryByAuthor": "Avtor: {author}",
   "libraryGridDimensions": "Mreža {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "Izbrišem »{name}«?",
-  "libraryDeleteIrreversible": "Tega dejanja ni mogoče razveljaviti.",
-  "libraryDeleted": "»{name}« izbrisana",
-  "libraryDeleteFailed": "»{name}« ni bilo mogoče izbrisati",
+  "libraryDeleteConfirmTitle": "Izbrišem komplet tabel »{name}«?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tabela v tem kompletu bo izbrisana. Tega dejanja ni mogoče razveljaviti.",
+        "countPlural=*": "Vseh {count} tabel v tem kompletu bo izbrisanih. Tega dejanja ni mogoče razveljaviti."
+      }
+    }
+  ],
+  "libraryDeleted": "Komplet tabel »{name}« izbrisan",
+  "libraryDeleteFailed": "Kompleta tabel »{name}« ni bilo mogoče izbrisati",
   "libraryTitle": "Knjižnica",
   "libraryOpen": "Odpri knjižnico",
   "aboutSourceCode": "Izvorna koda",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Strani ni mogoče najti",
   "errorGoHome": "Pojdi domov",
   "errorBoardNotFound": "Table ni mogoče najti",
-  "errorBoardSetNotFound": "Table ni mogoče najti",
-  "boardUrlImportFailed": "Table ni bilo mogoče uvoziti s povezave"
+  "errorBoardSetNotFound": "Kompleta tabel ni mogoče najti",
+  "boardUrlImportFailed": "Datoteke tabele ni bilo mogoče uvoziti s povezave"
 }

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(öppnas i en ny flik)",
   "boardGridLabel": "Kommunikationstavla",
   "board": "Tavla",
-  "libraryLoading": "Laddar tavlor...",
+  "libraryLoading": "Laddar taveluppsättningar...",
   "libraryEmptyTitle": "Biblioteket är tomt",
-  "libraryEmptyDescription": "Importera kommunikationstavlor för att komma igång.",
-  "libraryImportBoards": "Importera tavlor",
-  "libraryBoards": "Tavlor",
+  "libraryEmptyDescription": "Importera tavelfiler för att komma igång.",
+  "libraryImportBoards": "Importera tavelfiler",
+  "libraryBoards": "Taveluppsättningar",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Importerar tavla...",
-        "countPlural=*": "Importerar tavlor..."
+        "countPlural=one": "Importerar tavelfil...",
+        "countPlural=*": "Importerar tavelfiler..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tavla importerad",
-        "countPlural=*": "Tavlor importerade"
+        "countPlural=one": "Taveluppsättning importerad",
+        "countPlural=*": "Taveluppsättningar importerade"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Det gick inte att importera tavlan",
-        "countPlural=*": "Det gick inte att importera tavlorna"
+        "countPlural=one": "Det gick inte att importera tavelfilen",
+        "countPlural=*": "Det gick inte att importera tavelfilerna"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Tavlan är för stor för att importeras",
-        "countPlural=*": "Tavlorna är för stora för att importeras"
+        "countPlural=one": "Tavelfilen är för stor för att importeras",
+        "countPlural=*": "Tavelfilerna är för stora för att importeras"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "Fler alternativ för {name}",
   "libraryByAuthor": "Av {author}",
   "libraryGridDimensions": "Rutnät {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "Ta bort ”{name}”?",
-  "libraryDeleteIrreversible": "Den här åtgärden kan inte ångras.",
-  "libraryDeleted": "”{name}” borttagen",
-  "libraryDeleteFailed": "Det gick inte att ta bort ”{name}”",
+  "libraryDeleteConfirmTitle": "Ta bort taveluppsättningen ”{name}”?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Tavlan i den här uppsättningen kommer att tas bort. Den här åtgärden kan inte ångras.",
+        "countPlural=*": "Alla {count} tavlor i den här uppsättningen kommer att tas bort. Den här åtgärden kan inte ångras."
+      }
+    }
+  ],
+  "libraryDeleted": "Taveluppsättningen ”{name}” borttagen",
+  "libraryDeleteFailed": "Det gick inte att ta bort taveluppsättningen ”{name}”",
   "libraryTitle": "Bibliotek",
   "libraryOpen": "Öppna biblioteket",
   "aboutSourceCode": "Källkod",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Sidan hittades inte",
   "errorGoHome": "Till startsidan",
   "errorBoardNotFound": "Tavlan hittades inte",
-  "errorBoardSetNotFound": "Tavlan hittades inte",
-  "boardUrlImportFailed": "Det gick inte att importera tavlan från länken"
+  "errorBoardSetNotFound": "Taveluppsättningen hittades inte",
+  "boardUrlImportFailed": "Det gick inte att importera tavelfilen från länken"
 }

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(புதிய தாவலில் திறக்கும்)",
   "boardGridLabel": "தொடர்பு பலகை",
   "board": "பலகை",
-  "libraryLoading": "பலகைகள் ஏற்றப்படுகின்றன…",
+  "libraryLoading": "பலகைத் தொகுப்புகள் ஏற்றப்படுகின்றன…",
   "libraryEmptyTitle": "நூலகம் காலியாக உள்ளது",
-  "libraryEmptyDescription": "தொடங்க தொடர்பு பலகைகளை இறக்குமதி செய்யுங்கள்.",
-  "libraryImportBoards": "பலகைகளை இறக்குமதி செய்",
-  "libraryBoards": "பலகைகள்",
+  "libraryEmptyDescription": "தொடங்க பலகைக் கோப்புகளை இறக்குமதி செய்யுங்கள்.",
+  "libraryImportBoards": "பலகைக் கோப்புகளை இறக்குமதி செய்",
+  "libraryBoards": "பலகைத் தொகுப்புகள்",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "பலகை இறக்குமதி செய்யப்படுகிறது…",
-        "countPlural=*": "பலகைகள் இறக்குமதி செய்யப்படுகின்றன…"
+        "countPlural=one": "பலகைக் கோப்பு இறக்குமதி செய்யப்படுகிறது…",
+        "countPlural=*": "பலகைக் கோப்புகள் இறக்குமதி செய்யப்படுகின்றன…"
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "பலகை இறக்குமதி செய்யப்பட்டது",
-        "countPlural=*": "பலகைகள் இறக்குமதி செய்யப்பட்டன"
+        "countPlural=one": "பலகைத் தொகுப்பு இறக்குமதி செய்யப்பட்டது",
+        "countPlural=*": "பலகைத் தொகுப்புகள் இறக்குமதி செய்யப்பட்டன"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "பலகையை இறக்குமதி செய்ய முடியவில்லை",
-        "countPlural=*": "பலகைகளை இறக்குமதி செய்ய முடியவில்லை"
+        "countPlural=one": "பலகைக் கோப்பை இறக்குமதி செய்ய முடியவில்லை",
+        "countPlural=*": "பலகைக் கோப்புகளை இறக்குமதி செய்ய முடியவில்லை"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "பலகை இறக்குமதி செய்ய மிகப் பெரியது",
-        "countPlural=*": "பலகைகள் இறக்குமதி செய்ய மிகப் பெரியவை"
+        "countPlural=one": "பலகைக் கோப்பு இறக்குமதி செய்ய மிகப் பெரியது",
+        "countPlural=*": "பலகைக் கோப்புகள் இறக்குமதி செய்ய மிகப் பெரியவை"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "{name}க்கான மேலும் விருப்பங்கள்",
   "libraryByAuthor": "எழுதியவர்: {author}",
   "libraryGridDimensions": "{rows}×{columns} கட்டம்",
-  "libraryDeleteConfirmTitle": "\"{name}\" என்பதை நீக்கவா?",
-  "libraryDeleteIrreversible": "இந்தச் செயலைச் செயல்தவிர்க்க முடியாது.",
-  "libraryDeleted": "\"{name}\" நீக்கப்பட்டது",
-  "libraryDeleteFailed": "\"{name}\" என்பதை நீக்க முடியவில்லை",
+  "libraryDeleteConfirmTitle": "பலகைத் தொகுப்பு \"{name}\" என்பதை நீக்கவா?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "இந்தத் தொகுப்பில் உள்ள பலகை நீக்கப்படும். இதைச் செயல்தவிர்க்க முடியாது.",
+        "countPlural=*": "இந்தத் தொகுப்பில் உள்ள அனைத்து {count} பலகைகளும் நீக்கப்படும். இதைச் செயல்தவிர்க்க முடியாது."
+      }
+    }
+  ],
+  "libraryDeleted": "பலகைத் தொகுப்பு \"{name}\" நீக்கப்பட்டது",
+  "libraryDeleteFailed": "பலகைத் தொகுப்பு \"{name}\" என்பதை நீக்க முடியவில்லை",
   "libraryTitle": "நூலகம்",
   "libraryOpen": "நூலகத்தைத் திற",
   "aboutSourceCode": "மூலக் குறியீடு",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "பக்கம் கிடைக்கவில்லை",
   "errorGoHome": "முகப்புக்குச் செல்",
   "errorBoardNotFound": "பலகை கிடைக்கவில்லை",
-  "errorBoardSetNotFound": "பலகை கிடைக்கவில்லை",
-  "boardUrlImportFailed": "இணைப்பிலிருந்து பலகையை இறக்குமதி செய்ய முடியவில்லை"
+  "errorBoardSetNotFound": "பலகைத் தொகுப்பு கிடைக்கவில்லை",
+  "boardUrlImportFailed": "இணைப்பிலிருந்து பலகைக் கோப்பை இறக்குமதி செய்ய முடியவில்லை"
 }

--- a/messages/te.json
+++ b/messages/te.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(కొత్త ట్యాబ్‌లో తెరుచుకుంటుంది)",
   "boardGridLabel": "సంభాషణ బోర్డు",
   "board": "బోర్డు",
-  "libraryLoading": "బోర్డులు లోడ్ అవుతున్నాయి…",
+  "libraryLoading": "బోర్డు సెట్లు లోడ్ అవుతున్నాయి…",
   "libraryEmptyTitle": "లైబ్రరీ ఖాళీగా ఉంది",
-  "libraryEmptyDescription": "ప్రారంభించడానికి సంభాషణ బోర్డులను దిగుమతి చేయండి.",
-  "libraryImportBoards": "బోర్డులను దిగుమతి చేయి",
-  "libraryBoards": "బోర్డులు",
+  "libraryEmptyDescription": "ప్రారంభించడానికి బోర్డు ఫైళ్లను దిగుమతి చేయండి.",
+  "libraryImportBoards": "బోర్డు ఫైళ్లను దిగుమతి చేయి",
+  "libraryBoards": "బోర్డు సెట్లు",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "బోర్డు దిగుమతి అవుతోంది…",
-        "countPlural=*": "బోర్డులు దిగుమతి అవుతున్నాయి…"
+        "countPlural=one": "బోర్డు ఫైల్ దిగుమతి అవుతోంది…",
+        "countPlural=*": "బోర్డు ఫైళ్లు దిగుమతి అవుతున్నాయి…"
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "బోర్డు దిగుమతి చేయబడింది",
-        "countPlural=*": "బోర్డులు దిగుమతి చేయబడ్డాయి"
+        "countPlural=one": "బోర్డు సెట్ దిగుమతి చేయబడింది",
+        "countPlural=*": "బోర్డు సెట్లు దిగుమతి చేయబడ్డాయి"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "బోర్డును దిగుమతి చేయలేకపోయాం",
-        "countPlural=*": "బోర్డులను దిగుమతి చేయలేకపోయాం"
+        "countPlural=one": "బోర్డు ఫైల్‌ను దిగుమతి చేయలేకపోయాం",
+        "countPlural=*": "బోర్డు ఫైళ్లను దిగుమతి చేయలేకపోయాం"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "బోర్డు దిగుమతి చేయడానికి చాలా పెద్దది",
-        "countPlural=*": "బోర్డులు దిగుమతి చేయడానికి చాలా పెద్దవి"
+        "countPlural=one": "బోర్డు ఫైల్ దిగుమతి చేయడానికి చాలా పెద్దది",
+        "countPlural=*": "బోర్డు ఫైళ్లు దిగుమతి చేయడానికి చాలా పెద్దవి"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "{name} కోసం మరిన్ని ఎంపికలు",
   "libraryByAuthor": "రచయిత: {author}",
   "libraryGridDimensions": "{rows}×{columns} గ్రిడ్",
-  "libraryDeleteConfirmTitle": "\"{name}\"ను తొలగించాలా?",
-  "libraryDeleteIrreversible": "ఈ చర్యను రద్దు చేయడం సాధ్యం కాదు.",
-  "libraryDeleted": "\"{name}\" తొలగించబడింది",
-  "libraryDeleteFailed": "\"{name}\"ను తొలగించలేకపోయాం",
+  "libraryDeleteConfirmTitle": "బోర్డు సెట్ \"{name}\"ను తొలగించాలా?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "ఈ సెట్‌లోని బోర్డు తొలగించబడుతుంది. ఈ చర్యను రద్దు చేయడం సాధ్యం కాదు.",
+        "countPlural=*": "ఈ సెట్‌లోని మొత్తం {count} బోర్డులు తొలగించబడతాయి. ఈ చర్యను రద్దు చేయడం సాధ్యం కాదు."
+      }
+    }
+  ],
+  "libraryDeleted": "బోర్డు సెట్ \"{name}\" తొలగించబడింది",
+  "libraryDeleteFailed": "బోర్డు సెట్ \"{name}\"ను తొలగించలేకపోయాం",
   "libraryTitle": "లైబ్రరీ",
   "libraryOpen": "లైబ్రరీని తెరువు",
   "aboutSourceCode": "సోర్స్ కోడ్",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "పేజీ కనుగొనబడలేదు",
   "errorGoHome": "హోమ్‌కు వెళ్లు",
   "errorBoardNotFound": "బోర్డు కనుగొనబడలేదు",
-  "errorBoardSetNotFound": "బోర్డు కనుగొనబడలేదు",
-  "boardUrlImportFailed": "లింక్ నుండి బోర్డును దిగుమతి చేయలేకపోయాం"
+  "errorBoardSetNotFound": "బోర్డు సెట్ కనుగొనబడలేదు",
+  "boardUrlImportFailed": "లింక్ నుండి బోర్డు ఫైల్‌ను దిగుమతి చేయలేకపోయాం"
 }

--- a/messages/th.json
+++ b/messages/th.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(เปิดในแท็บใหม่)",
   "boardGridLabel": "บอร์ดสื่อสาร",
   "board": "บอร์ด",
-  "libraryLoading": "กำลังโหลดบอร์ด...",
+  "libraryLoading": "กำลังโหลดชุดบอร์ด...",
   "libraryEmptyTitle": "คลังว่างเปล่า",
-  "libraryEmptyDescription": "นำเข้าบอร์ดสื่อสารเพื่อเริ่มต้น",
-  "libraryImportBoards": "นำเข้าบอร์ด",
-  "libraryBoards": "บอร์ด",
+  "libraryEmptyDescription": "นำเข้าไฟล์บอร์ดเพื่อเริ่มต้น",
+  "libraryImportBoards": "นำเข้าไฟล์บอร์ด",
+  "libraryBoards": "ชุดบอร์ด",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "กำลังนำเข้าบอร์ด...",
-        "countPlural=*": "กำลังนำเข้าบอร์ด..."
+        "countPlural=one": "กำลังนำเข้าไฟล์บอร์ด...",
+        "countPlural=*": "กำลังนำเข้าไฟล์บอร์ด..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "นำเข้าบอร์ดแล้ว",
-        "countPlural=*": "นำเข้าบอร์ดแล้ว"
+        "countPlural=one": "นำเข้าชุดบอร์ดแล้ว",
+        "countPlural=*": "นำเข้าชุดบอร์ดแล้ว"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "นำเข้าบอร์ดไม่สำเร็จ",
-        "countPlural=*": "นำเข้าบอร์ดไม่สำเร็จ"
+        "countPlural=one": "นำเข้าไฟล์บอร์ดไม่สำเร็จ",
+        "countPlural=*": "นำเข้าไฟล์บอร์ดไม่สำเร็จ"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "บอร์ดมีขนาดใหญ่เกินไปที่จะนำเข้า",
-        "countPlural=*": "บอร์ดมีขนาดใหญ่เกินไปที่จะนำเข้า"
+        "countPlural=one": "ไฟล์บอร์ดมีขนาดใหญ่เกินไปที่จะนำเข้า",
+        "countPlural=*": "ไฟล์บอร์ดมีขนาดใหญ่เกินไปที่จะนำเข้า"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "ตัวเลือกเพิ่มเติมสำหรับ {name}",
   "libraryByAuthor": "โดย {author}",
   "libraryGridDimensions": "ตาราง {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "ลบ \"{name}\" ไหม",
-  "libraryDeleteIrreversible": "ไม่สามารถเลิกทำการกระทำนี้ได้",
-  "libraryDeleted": "ลบ \"{name}\" แล้ว",
-  "libraryDeleteFailed": "ลบ \"{name}\" ไม่สำเร็จ",
+  "libraryDeleteConfirmTitle": "ลบชุดบอร์ด \"{name}\" ไหม",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "บอร์ดในชุดนี้จะถูกลบ การดำเนินการนี้ไม่สามารถเลิกทำได้",
+        "countPlural=*": "บอร์ดทั้ง {count} รายการในชุดนี้จะถูกลบ การดำเนินการนี้ไม่สามารถเลิกทำได้"
+      }
+    }
+  ],
+  "libraryDeleted": "ลบชุดบอร์ด \"{name}\" แล้ว",
+  "libraryDeleteFailed": "ลบชุดบอร์ด \"{name}\" ไม่สำเร็จ",
   "libraryTitle": "คลัง",
   "libraryOpen": "เปิดคลัง",
   "aboutSourceCode": "ซอร์สโค้ด",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "ไม่พบหน้านี้",
   "errorGoHome": "ไปที่หน้าแรก",
   "errorBoardNotFound": "ไม่พบบอร์ด",
-  "errorBoardSetNotFound": "ไม่พบบอร์ด",
-  "boardUrlImportFailed": "นำเข้าบอร์ดจากลิงก์ไม่สำเร็จ"
+  "errorBoardSetNotFound": "ไม่พบชุดบอร์ด",
+  "boardUrlImportFailed": "นำเข้าไฟล์บอร์ดจากลิงก์ไม่สำเร็จ"
 }

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(yeni sekmede açılır)",
   "boardGridLabel": "İletişim panosu",
   "board": "Pano",
-  "libraryLoading": "Panolar yükleniyor...",
+  "libraryLoading": "Pano setleri yükleniyor...",
   "libraryEmptyTitle": "Kitaplık boş",
-  "libraryEmptyDescription": "Başlamak için iletişim panoları içe aktarın.",
-  "libraryImportBoards": "Panoları içe aktar",
-  "libraryBoards": "Panolar",
+  "libraryEmptyDescription": "Başlamak için pano dosyalarını içe aktarın.",
+  "libraryImportBoards": "Pano dosyalarını içe aktar",
+  "libraryBoards": "Pano setleri",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Pano içe aktarılıyor...",
-        "countPlural=*": "Panolar içe aktarılıyor..."
+        "countPlural=one": "Pano dosyası içe aktarılıyor...",
+        "countPlural=*": "Pano dosyaları içe aktarılıyor..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Pano içe aktarıldı",
-        "countPlural=*": "Panolar içe aktarıldı"
+        "countPlural=one": "Pano seti içe aktarıldı",
+        "countPlural=*": "Pano setleri içe aktarıldı"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Pano içe aktarılamadı",
-        "countPlural=*": "Panolar içe aktarılamadı"
+        "countPlural=one": "Pano dosyası içe aktarılamadı",
+        "countPlural=*": "Pano dosyaları içe aktarılamadı"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Pano içe aktarılamayacak kadar büyük",
-        "countPlural=*": "Panolar içe aktarılamayacak kadar büyük"
+        "countPlural=one": "Pano dosyası içe aktarılamayacak kadar büyük",
+        "countPlural=*": "Pano dosyaları içe aktarılamayacak kadar büyük"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "{name} için diğer seçenekler",
   "libraryByAuthor": "{author} tarafından",
   "libraryGridDimensions": "{rows}×{columns} ızgara",
-  "libraryDeleteConfirmTitle": "\"{name}\" silinsin mi?",
-  "libraryDeleteIrreversible": "Bu işlem geri alınamaz.",
-  "libraryDeleted": "\"{name}\" silindi",
-  "libraryDeleteFailed": "\"{name}\" silinemedi",
+  "libraryDeleteConfirmTitle": "\"{name}\" pano seti silinsin mi?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Bu setteki pano silinecek. Bu işlem geri alınamaz.",
+        "countPlural=*": "Bu setteki {count} panonun tümü silinecek. Bu işlem geri alınamaz."
+      }
+    }
+  ],
+  "libraryDeleted": "\"{name}\" pano seti silindi",
+  "libraryDeleteFailed": "\"{name}\" pano seti silinemedi",
   "libraryTitle": "Kitaplık",
   "libraryOpen": "Kitaplığı aç",
   "aboutSourceCode": "Kaynak kodu",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Sayfa bulunamadı",
   "errorGoHome": "Ana sayfaya git",
   "errorBoardNotFound": "Pano bulunamadı",
-  "errorBoardSetNotFound": "Pano bulunamadı",
-  "boardUrlImportFailed": "Pano bağlantıdan içe aktarılamadı"
+  "errorBoardSetNotFound": "Pano seti bulunamadı",
+  "boardUrlImportFailed": "Pano dosyası bağlantıdan içe aktarılamadı"
 }

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(відкривається в новій вкладці)",
   "boardGridLabel": "Комунікаційна дошка",
   "board": "Дошка",
-  "libraryLoading": "Завантаження дошок...",
+  "libraryLoading": "Завантаження наборів дошок...",
   "libraryEmptyTitle": "Бібліотека порожня",
-  "libraryEmptyDescription": "Імпортуйте комунікаційні дошки, щоб почати.",
-  "libraryImportBoards": "Імпортувати дошки",
-  "libraryBoards": "Дошки",
+  "libraryEmptyDescription": "Імпортуйте файли дошок, щоб почати.",
+  "libraryImportBoards": "Імпортувати файли дошок",
+  "libraryBoards": "Набори дошок",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Імпортування дошки...",
-        "countPlural=*": "Імпортування дошок..."
+        "countPlural=one": "Імпортування файла дошки...",
+        "countPlural=*": "Імпортування файлів дошок..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Дошку імпортовано",
-        "countPlural=*": "Дошки імпортовано"
+        "countPlural=one": "Набір дошок імпортовано",
+        "countPlural=*": "Набори дошок імпортовано"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Не вдалося імпортувати дошку",
-        "countPlural=*": "Не вдалося імпортувати дошки"
+        "countPlural=one": "Не вдалося імпортувати файл дошки",
+        "countPlural=*": "Не вдалося імпортувати файли дошок"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Дошка занадто велика для імпортування",
-        "countPlural=*": "Дошки занадто великі для імпортування"
+        "countPlural=one": "Файл дошки занадто великий для імпортування",
+        "countPlural=*": "Файли дошок занадто великі для імпортування"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "Більше параметрів для {name}",
   "libraryByAuthor": "Автор: {author}",
   "libraryGridDimensions": "Сітка {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "Видалити «{name}»?",
-  "libraryDeleteIrreversible": "Цю дію не можна скасувати.",
-  "libraryDeleted": "«{name}» видалено",
-  "libraryDeleteFailed": "Не вдалося видалити «{name}»",
+  "libraryDeleteConfirmTitle": "Видалити набір дошок «{name}»?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Дошку з цього набору буде видалено. Цю дію не можна скасувати.",
+        "countPlural=*": "Усі дошки з цього набору ({count}) буде видалено. Цю дію не можна скасувати."
+      }
+    }
+  ],
+  "libraryDeleted": "Набір дошок «{name}» видалено",
+  "libraryDeleteFailed": "Не вдалося видалити набір дошок «{name}»",
   "libraryTitle": "Бібліотека",
   "libraryOpen": "Відкрити бібліотеку",
   "aboutSourceCode": "Вихідний код",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Сторінку не знайдено",
   "errorGoHome": "На головну",
   "errorBoardNotFound": "Дошку не знайдено",
-  "errorBoardSetNotFound": "Дошку не знайдено",
-  "boardUrlImportFailed": "Не вдалося імпортувати дошку за посиланням"
+  "errorBoardSetNotFound": "Набір дошок не знайдено",
+  "boardUrlImportFailed": "Не вдалося імпортувати файл дошки за посиланням"
 }

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(mở trong tab mới)",
   "boardGridLabel": "Bảng giao tiếp",
   "board": "Bảng",
-  "libraryLoading": "Đang tải các bảng...",
+  "libraryLoading": "Đang tải các bộ bảng...",
   "libraryEmptyTitle": "Thư viện trống",
-  "libraryEmptyDescription": "Nhập các bảng giao tiếp để bắt đầu.",
-  "libraryImportBoards": "Nhập bảng",
-  "libraryBoards": "Bảng",
+  "libraryEmptyDescription": "Nhập tệp bảng để bắt đầu.",
+  "libraryImportBoards": "Nhập tệp bảng",
+  "libraryBoards": "Bộ bảng",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Đang nhập bảng...",
-        "countPlural=*": "Đang nhập các bảng..."
+        "countPlural=one": "Đang nhập tệp bảng...",
+        "countPlural=*": "Đang nhập các tệp bảng..."
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Đã nhập bảng",
-        "countPlural=*": "Đã nhập các bảng"
+        "countPlural=one": "Đã nhập bộ bảng",
+        "countPlural=*": "Đã nhập các bộ bảng"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Không thể nhập bảng",
-        "countPlural=*": "Không thể nhập các bảng"
+        "countPlural=one": "Không thể nhập tệp bảng",
+        "countPlural=*": "Không thể nhập các tệp bảng"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "Bảng quá lớn để nhập",
-        "countPlural=*": "Các bảng quá lớn để nhập"
+        "countPlural=one": "Tệp bảng quá lớn để nhập",
+        "countPlural=*": "Các tệp bảng quá lớn để nhập"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "Tùy chọn khác cho {name}",
   "libraryByAuthor": "Bởi {author}",
   "libraryGridDimensions": "Lưới {rows}×{columns}",
-  "libraryDeleteConfirmTitle": "Xóa \"{name}\"?",
-  "libraryDeleteIrreversible": "Không thể hoàn tác hành động này.",
-  "libraryDeleted": "Đã xóa \"{name}\"",
-  "libraryDeleteFailed": "Không thể xóa \"{name}\"",
+  "libraryDeleteConfirmTitle": "Xóa bộ bảng \"{name}\"?",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "Bảng trong bộ này sẽ bị xóa. Không thể hoàn tác hành động này.",
+        "countPlural=*": "Tất cả {count} bảng trong bộ này sẽ bị xóa. Không thể hoàn tác hành động này."
+      }
+    }
+  ],
+  "libraryDeleted": "Đã xóa bộ bảng \"{name}\"",
+  "libraryDeleteFailed": "Không thể xóa bộ bảng \"{name}\"",
   "libraryTitle": "Thư viện",
   "libraryOpen": "Mở thư viện",
   "aboutSourceCode": "Mã nguồn",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "Không tìm thấy trang",
   "errorGoHome": "Về trang chủ",
   "errorBoardNotFound": "Không tìm thấy bảng",
-  "errorBoardSetNotFound": "Không tìm thấy bảng",
-  "boardUrlImportFailed": "Không thể nhập bảng từ liên kết"
+  "errorBoardSetNotFound": "Không tìm thấy bộ bảng",
+  "boardUrlImportFailed": "Không thể nhập tệp bảng từ liên kết"
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -31,18 +31,18 @@
   "opensInNewTab": "(在新标签页中打开)",
   "boardGridLabel": "沟通板",
   "board": "沟通板",
-  "libraryLoading": "正在加载沟通板……",
+  "libraryLoading": "正在加载沟通板集……",
   "libraryEmptyTitle": "板库为空",
-  "libraryEmptyDescription": "导入沟通板即可开始。",
-  "libraryImportBoards": "导入沟通板",
-  "libraryBoards": "沟通板",
+  "libraryEmptyDescription": "导入沟通板文件即可开始。",
+  "libraryImportBoards": "导入沟通板文件",
+  "libraryBoards": "沟通板集",
   "libraryImportingBoards": [
     {
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "正在导入沟通板……",
-        "countPlural=*": "正在导入沟通板……"
+        "countPlural=one": "正在导入沟通板文件……",
+        "countPlural=*": "正在导入沟通板文件……"
       }
     }
   ],
@@ -51,8 +51,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "已导入沟通板",
-        "countPlural=*": "已导入沟通板"
+        "countPlural=one": "已导入沟通板集",
+        "countPlural=*": "已导入沟通板集"
       }
     }
   ],
@@ -61,8 +61,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "无法导入沟通板",
-        "countPlural=*": "无法导入沟通板"
+        "countPlural=one": "无法导入沟通板文件",
+        "countPlural=*": "无法导入沟通板文件"
       }
     }
   ],
@@ -71,8 +71,8 @@
       "declarations": ["input count", "local countPlural = count: plural"],
       "selectors": ["countPlural"],
       "match": {
-        "countPlural=one": "沟通板过大，无法导入",
-        "countPlural=*": "沟通板过大，无法导入"
+        "countPlural=one": "沟通板文件过大，无法导入",
+        "countPlural=*": "沟通板文件过大，无法导入"
       }
     }
   ],
@@ -85,10 +85,19 @@
   "libraryMoreOptionsFor": "{name} 的更多选项",
   "libraryByAuthor": "作者：{author}",
   "libraryGridDimensions": "{rows}×{columns} 网格",
-  "libraryDeleteConfirmTitle": "删除“{name}”？",
-  "libraryDeleteIrreversible": "此操作无法撤消。",
-  "libraryDeleted": "已删除“{name}”",
-  "libraryDeleteFailed": "无法删除“{name}”",
+  "libraryDeleteConfirmTitle": "删除沟通板集“{name}”？",
+  "libraryDeleteIrreversible": [
+    {
+      "declarations": ["input count", "local countPlural = count: plural"],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "此板集中的沟通板将被删除。此操作无法撤消。",
+        "countPlural=*": "此板集中的全部 {count} 个沟通板将被删除。此操作无法撤消。"
+      }
+    }
+  ],
+  "libraryDeleted": "已删除沟通板集“{name}”",
+  "libraryDeleteFailed": "无法删除沟通板集“{name}”",
   "libraryTitle": "板库",
   "libraryOpen": "打开板库",
   "aboutSourceCode": "源代码",
@@ -147,6 +156,6 @@
   "errorPageNotFound": "页面未找到",
   "errorGoHome": "返回主页",
   "errorBoardNotFound": "未找到沟通板",
-  "errorBoardSetNotFound": "未找到沟通板",
-  "boardUrlImportFailed": "无法从链接导入沟通板"
+  "errorBoardSetNotFound": "未找到沟通板集",
+  "boardUrlImportFailed": "无法从链接导入沟通板文件"
 }

--- a/src/app/routing/route-error-boundary.test.tsx
+++ b/src/app/routing/route-error-boundary.test.tsx
@@ -75,4 +75,17 @@ describe("RouteErrorBoundary", () => {
     await screen.getByRole("button", { name: "switch-to-hebrew" }).click();
     await expect.element(screen.getByText("הלוח לא נמצא")).toBeVisible();
   });
+
+  test("distinguishes a missing board set from a missing board", async () => {
+    const screen = await renderWithLoader(() =>
+      throwDataResponse(
+        createLocalizedRouteError(routeErrorCodes.boardSetNotFound),
+      ),
+    );
+
+    await expect.element(screen.getByText("Board set not found")).toBeVisible();
+    await expect
+      .element(screen.getByText("Board not found"))
+      .not.toBeInTheDocument();
+  });
 });

--- a/src/features/board/board-sets/board-set-delete-dialog.test.tsx
+++ b/src/features/board/board-sets/board-set-delete-dialog.test.tsx
@@ -24,20 +24,42 @@ describe("BoardSetDeleteDialog", () => {
     await expectNoA11yViolations(document.body);
   });
 
-  test("shows the board set name and an irreversible warning when open", async () => {
+  test("shows the board set name and the single-board warning", async () => {
     const screen = await renderWithProviders(
       <BoardSetDeleteDialog
-        boardSet={makeBoardSet({ name: "Core Words" })}
+        boardSet={makeBoardSet({ name: "Core Words", boardCount: 1 })}
         onConfirm={vi.fn()}
         onClose={vi.fn()}
       />,
     );
 
     await expect
-      .element(screen.getByText('Delete "Core Words"?'))
+      .element(screen.getByText('Delete board set "Core Words"?'))
       .toBeInTheDocument();
     await expect
-      .element(screen.getByText("This action cannot be undone."))
+      .element(
+        screen.getByText(
+          "The board in this set will be deleted. This cannot be undone.",
+        ),
+      )
+      .toBeInTheDocument();
+  });
+
+  test("shows the board count in the multiple-board warning", async () => {
+    const screen = await renderWithProviders(
+      <BoardSetDeleteDialog
+        boardSet={makeBoardSet({ boardCount: 5 })}
+        onConfirm={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await expect
+      .element(
+        screen.getByText(
+          "All 5 boards in this set will be deleted. This cannot be undone.",
+        ),
+      )
       .toBeInTheDocument();
   });
 
@@ -51,7 +73,11 @@ describe("BoardSetDeleteDialog", () => {
     );
 
     await expect
-      .element(screen.getByText("This action cannot be undone."))
+      .element(
+        screen.getByText(
+          "The board in this set will be deleted. This cannot be undone.",
+        ),
+      )
       .not.toBeInTheDocument();
   });
 

--- a/src/features/board/board-sets/board-set-delete-dialog.tsx
+++ b/src/features/board/board-sets/board-set-delete-dialog.tsx
@@ -36,7 +36,9 @@ export function BoardSetDeleteDialog({
 
       <DialogContent>
         <DialogContentText id="delete-dialog-description">
-          {t(m.libraryDeleteIrreversible)}
+          {boardSet
+            ? t(m.libraryDeleteIrreversible, { count: boardSet.boardCount })
+            : null}
         </DialogContentText>
       </DialogContent>
 

--- a/src/features/board/board-sets/board-set-library.test.tsx
+++ b/src/features/board/board-sets/board-set-library.test.tsx
@@ -28,7 +28,7 @@ describe("BoardSetLibrary", () => {
       .element(screen.getByText("Library is empty"))
       .toBeInTheDocument();
     await expect
-      .element(screen.getByRole("button", { name: "Import boards" }))
+      .element(screen.getByRole("button", { name: "Import board files" }))
       .toBeInTheDocument();
   });
 
@@ -59,13 +59,13 @@ describe("BoardSetLibrary", () => {
     await screen.getByRole("menuitem", { name: "Delete" }).click();
 
     await expect
-      .element(screen.getByText('Delete "Animals"?'))
+      .element(screen.getByText('Delete board set "Animals"?'))
       .toBeInTheDocument();
     await screen.getByRole("button", { name: "Delete" }).click();
 
     await expect
       .element(screen.getByRole("alert"))
-      .toHaveTextContent('"Animals" deleted');
+      .toHaveTextContent('Board set "Animals" deleted');
     await expect
       .element(screen.getByText("Library is empty"))
       .toBeInTheDocument();
@@ -86,7 +86,7 @@ describe("BoardSetLibrary", () => {
 
     await expect.element(screen.getByText("Animals")).toBeInTheDocument();
     await expect
-      .element(screen.getByText('Delete "Animals"?'))
+      .element(screen.getByText('Delete board set "Animals"?'))
       .not.toBeInTheDocument();
   });
 
@@ -98,6 +98,7 @@ describe("BoardSetLibrary", () => {
 
     const screen = await renderBoardSetLibrary();
 
+    await expect.element(screen.getByText("Board sets")).toBeInTheDocument();
     await expect.element(screen.getByText("Animals")).toBeInTheDocument();
     await expect.element(screen.getByText("Core Words")).toBeInTheDocument();
 

--- a/src/features/board/import/use-import-board-files.test.tsx
+++ b/src/features/board/import/use-import-board-files.test.tsx
@@ -38,7 +38,19 @@ describe("useImportBoardFiles", () => {
 
     await expect
       .element(screen.getByRole("alert"))
-      .toHaveTextContent("Board imported");
+      .toHaveTextContent("Board set imported");
+  });
+
+  test("shows the plural imported message for multiple files", async () => {
+    const firstFile = await loadFixtureFile(OBF_FIXTURE);
+    const secondFile = await loadFixtureFile(OBF_FIXTURE);
+    const screen = await renderImport([firstFile, secondFile]);
+
+    await screen.getByRole("button", { name: "import" }).click();
+
+    await expect
+      .element(screen.getByRole("alert"))
+      .toHaveTextContent("Board sets imported");
   });
 
   test("shows the imported message and keeps both sets on a conflict", async () => {
@@ -50,7 +62,7 @@ describe("useImportBoardFiles", () => {
 
     await expect
       .element(screen.getByRole("alert"))
-      .toHaveTextContent("Board imported");
+      .toHaveTextContent("Board set imported");
   });
 
   test("shows the too-large message when an OBZ exceeds the decompression limit", async () => {
@@ -67,6 +79,6 @@ describe("useImportBoardFiles", () => {
 
     await expect
       .element(screen.getByRole("alert"))
-      .toHaveTextContent("Board is too large to import");
+      .toHaveTextContent("Board file is too large to import");
   });
 });

--- a/src/features/board/navigation/board-selector.test.tsx
+++ b/src/features/board/navigation/board-selector.test.tsx
@@ -63,7 +63,9 @@ describe("BoardSelector", () => {
   test("shows the current board name in the input", async () => {
     const { screen } = await renderSelector("/sets/set-1/boards/root");
 
-    await expect.element(screen.getByRole("combobox")).toHaveValue("Home");
+    await expect
+      .element(screen.getByRole("combobox", { name: "Board" }))
+      .toHaveValue("Home");
   });
 
   test("opens the popup with boards listed alphabetically and the current board selected", async () => {

--- a/src/shared/snackbar/snackbar-provider.test.tsx
+++ b/src/shared/snackbar/snackbar-provider.test.tsx
@@ -102,11 +102,11 @@ describe("SnackbarProvider", () => {
     await screen.getByRole("button", { name: "show-imported" }).click();
     await expect
       .element(screen.getByRole("alert"))
-      .toHaveTextContent("Board imported");
+      .toHaveTextContent("Board set imported");
 
     await screen.getByRole("button", { name: "switch-to-hebrew" }).click();
     await expect
       .element(screen.getByRole("alert"))
-      .toHaveTextContent("הלוח יובא בהצלחה");
+      .toHaveTextContent("ערכת הלוחות יובאה בהצלחה");
   });
 });


### PR DESCRIPTION
## Summary

- distinguish board sets, board files, and individual boards throughout the library UI
- make board-set deletion warnings singular/plural using the stored board count
- apply equivalent terminology across every locale and expand focused behavior coverage

## Why

The library stores imported .obf and .obz files as board sets, while some user-facing copy described those sets as individual boards. This made imports, library navigation, deletion, and route errors ambiguous.

## User impact

Users now see consistent terminology: files are imported, imports create board sets, and boards remain the individual boards inside a set. Deletion warnings state exactly how many boards will be removed.

## Validation

- npm run lint
- npm test (82 files, 576 tests)
- npm run build