### PR TITLE
Clarify unsupported suggestions message

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -137,7 +137,7 @@
   "aiCustomInstructions": "Custom instructions",
   "aiCustomInstructionsPlaceholder": "e.g., make suggestions playful and sarcastic",
   "aiCustomInstructionsHelper": "Shape suggestions in your own words.",
-  "suggestionsUnsupported": "Custom instructions require desktop Chrome or Edge with built-in AI enabled.",
+  "suggestionsUnsupported": "Suggestions require desktop Chrome or Edge with built-in AI enabled.",
   "suggestionsEnable": "Enable suggestions",
   "suggestionsDownloading": "Downloading AI model... {progress}%",
   "suggestionsDownloadingIndeterminate": "Downloading AI model...",

--- a/src/app/settings/suggestions-settings.test.tsx
+++ b/src/app/settings/suggestions-settings.test.tsx
@@ -25,9 +25,7 @@ describe("SuggestionsSettings", () => {
     const screen = await renderSuggestionsSettings();
 
     await expect
-      .element(
-        screen.getByText(/Custom instructions require desktop Chrome or Edge/i),
-      )
+      .element(screen.getByText(/Suggestions require desktop Chrome or Edge/i))
       .toBeVisible();
     await expect
       .element(screen.getByRole("textbox", { name: "Custom instructions" }))


### PR DESCRIPTION
## Summary

- describe the unsupported capability as suggestions rather than custom instructions
- update the settings test to assert the revised copy
- confirm existing non-English translations already refer to suggestions

## Why

The unsupported-state message described only custom instructions even though the browser requirement applies to the suggestions feature as a whole. The revised copy matches the actual feature scope and avoids misleading users.

## Impact

Users on unsupported browsers now see a clearer explanation that suggestions require desktop Chrome or Edge with built-in AI enabled. No behavior, API, or translation changes are involved.

## Validation

- `npm run lint`
- `npm test` — 82 files, 576 tests passed
- `npm run build`
- pre-commit ESLint and Prettier hooks
