### PR TITLE
Support Vite native config loading

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,7 @@ import {
   CONTENT_LIGHT,
   SHELL_DARK,
   SHELL_LIGHT,
-} from "./src/shared/theme/theme-colors";
+} from "./src/shared/theme/theme-colors.ts";
 
 // Share theme-colors.ts with index.html's static styles instead of duplicating hex.
 const themeColorHtmlPlugin: Plugin = {
@@ -78,11 +78,11 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@app": path.resolve(__dirname, "./src/app"),
-      "@features": path.resolve(__dirname, "./src/features"),
-      "@pages": path.resolve(__dirname, "./src/pages"),
-      "@paraglide": path.resolve(__dirname, "./src/paraglide"),
-      "@shared": path.resolve(__dirname, "./src/shared"),
+      "@app": path.resolve(import.meta.dirname, "./src/app"),
+      "@features": path.resolve(import.meta.dirname, "./src/features"),
+      "@pages": path.resolve(import.meta.dirname, "./src/pages"),
+      "@paraglide": path.resolve(import.meta.dirname, "./src/paraglide"),
+      "@shared": path.resolve(import.meta.dirname, "./src/shared"),
     },
   },
   optimizeDeps: {


### PR DESCRIPTION
## Summary

- use an explicit `.ts` extension for the theme-colors import in the Vite config
- replace the CommonJS `__dirname` global with ESM-native `import.meta.dirname` for path aliases

## Why

Vite's native config loader executes the TypeScript config with native module semantics. Extensionless relative imports and the CommonJS-only `__dirname` global are unsupported and currently emit warnings because native loading is planned to become the default in a future Vite major.

The project requires Node 24, which supports `import.meta.dirname`, and its TypeScript config already allows TypeScript import extensions. These changes preserve the existing alias paths and theme-color values while making the config compatible with native loading.

## Impact

The Vite native-config compatibility warnings no longer appear during tests or production builds. Application runtime behavior and browser output are unchanged.

## Validation

- `npm run lint`
- `npm test` — 82 files, 576 tests passed
- `npm run build`
- confirmed both native-config warnings are absent from test and build output
