### PR TITLE
Remove unused application code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@fontsource/roboto": "^5.3.0",
-        "@inlang/paraglide-js-react": "^1.0.2",
         "@mui/icons-material": "^9.2.0",
         "@mui/material": "^9.2.0",
         "@mui/stylis-plugin-rtl": "^9.1.1",
@@ -2111,6 +2110,7 @@
       "version": "2.23.1",
       "resolved": "https://registry.npmjs.org/@inlang/paraglide-js/-/paraglide-js-2.23.1.tgz",
       "integrity": "sha512-KEnJhvRLhB1zbGNmt2DHi4SuIbr7ZcZ0tftFYxQDDSpS1GqjJJ+b+ZaxVC2PElpgcQYNgD5Bt9hYUpV+et8IMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inlang/recommend-sherlock": "^0.2.1",
@@ -2137,20 +2137,11 @@
         }
       }
     },
-    "node_modules/@inlang/paraglide-js-react": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@inlang/paraglide-js-react/-/paraglide-js-react-1.0.2.tgz",
-      "integrity": "sha512-3cs1VNTY836qn0/oAk+sPyAmM8nT5BOV3NMGud89nQGYlOJUxR0nYyeBLzelXR7lmi9iBWcPkpfNzvH464EeAg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@inlang/paraglide-js": ">=2.11.0 <3",
-        "react": "^18.0.0 || ^19.0.0"
-      }
-    },
     "node_modules/@inlang/recommend-sherlock": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@inlang/recommend-sherlock/-/recommend-sherlock-0.2.1.tgz",
       "integrity": "sha512-ckv8HvHy/iTqaVAEKrr+gnl+p3XFNwe5D2+6w6wJk2ORV2XkcRkKOJ/XsTUJbPSiyi4PI+p+T3bqbmNx/rDUlg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "comment-json": "^4.2.3"
@@ -2160,6 +2151,7 @@
       "version": "2.10.2",
       "resolved": "https://registry.npmjs.org/@inlang/sdk/-/sdk-2.10.2.tgz",
       "integrity": "sha512-O1ki72SNK6LPagaGrvlioBb1mWKvump7cO7P85hfGZjdFTmDdn3icI0A6MvaBsB3P9KQHAjzyubnN1OslGufTw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lix-js/sdk": "0.4.10",
@@ -2223,6 +2215,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2242,7 +2235,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2269,6 +2262,7 @@
       "version": "0.4.10",
       "resolved": "https://registry.npmjs.org/@lix-js/sdk/-/sdk-0.4.10.tgz",
       "integrity": "sha512-0dMInAJK/67guTG5rRZaCEhvzC5cCXENOjaePA5AqMXrCE97kaY7SRor9e2vnoGsFIiGqXKlT0MCIoZj36G0gg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@lix-js/server-protocol-schema": "0.1.1",
@@ -2287,6 +2281,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@lix-js/server-protocol-schema/-/server-protocol-schema-0.1.1.tgz",
       "integrity": "sha512-jBeALB6prAbtr5q4vTuxnRZZv1M2rKe8iNqRQhFJ4Tv7150unEa0vKyz0hs8Gl3fUGsWaNJBh3J8++fpbrpRBQ==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@mui/core-downloads-tracker": {
@@ -2566,7 +2561,7 @@
       "version": "0.142.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
       "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -2605,6 +2600,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2621,6 +2617,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2637,6 +2634,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2653,6 +2651,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2669,6 +2668,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2685,6 +2685,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -2704,6 +2705,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -2723,6 +2725,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -2742,6 +2745,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -2761,6 +2765,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -2780,6 +2785,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -2799,6 +2805,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2815,6 +2822,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2831,6 +2839,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2875,7 +2884,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/plugin-babel": {
@@ -3442,12 +3451,14 @@
       "version": "0.31.30",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.31.30.tgz",
       "integrity": "sha512-MGsM7bVmHg3sUKCphlu3SGQ+T+5JTbygZWYArfKQCW5anJeACHeqLhcnf+R7XlCWZ+QR3C8JTBx3kCKJTN69ow==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sqlite.org/sqlite-wasm": {
       "version": "3.48.0-build4",
       "resolved": "https://registry.npmjs.org/@sqlite.org/sqlite-wasm/-/sqlite-wasm-3.48.0-build4.tgz",
       "integrity": "sha512-hI6twvUkzOmyGZhQMza1gpfqErZxXRw6JEsiVjUbo7tFanVD+8Oil0Ih3l2nGzHdxPI41zFmfUQG7GHqhciKZQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "sqlite-wasm": "bin/index.js"
@@ -3579,7 +3590,7 @@
       "version": "24.13.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
       "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -3930,7 +3941,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -4501,6 +4512,7 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -4569,6 +4581,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
       "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/arraybuffer.prototype.slice": {
@@ -4816,7 +4829,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/call-bind": {
@@ -4922,6 +4935,7 @@
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
       "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -4931,6 +4945,7 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.6.2.tgz",
       "integrity": "sha512-R2rze/hDX30uul4NZoIZ76ImSJLFxn/1/ZxtKC1L77y2X1k+yYu1joKbAtMA2Fg3hZrTOiw0I5mwVMo0cf250w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-timsort": "^1.0.3",
@@ -4961,6 +4976,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.0.tgz",
       "integrity": "sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
@@ -5133,6 +5149,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
       "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -5200,7 +5217,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5685,6 +5702,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -5815,7 +5833,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6347,6 +6365,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/human-id/-/human-id-4.2.0.tgz",
       "integrity": "sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "human-id": "dist/cli.js"
@@ -6959,6 +6978,7 @@
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.1.tgz",
       "integrity": "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-tokens": {
@@ -7010,6 +7030,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -7055,6 +7076,7 @@
       "version": "0.28.17",
       "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.17.tgz",
       "integrity": "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
@@ -7088,7 +7110,7 @@
       "version": "1.33.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
       "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -7121,6 +7143,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7141,6 +7164,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7161,6 +7185,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7181,6 +7206,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7201,6 +7227,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7221,6 +7248,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -7244,6 +7272,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -7267,6 +7296,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -7290,6 +7320,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -7313,6 +7344,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7333,6 +7365,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7527,7 +7560,7 @@
       "version": "3.3.17",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
       "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7811,6 +7844,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7877,7 +7911,7 @@
       "version": "8.5.25",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
       "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8216,7 +8250,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.2.tgz",
       "integrity": "sha512-opwpo1tQBAcpSUJDt94B7hhLNGOKjCdE//XXjeLrnx9b83bjnw45tXdg1b09yEw/VLFBJGZpwRULMmOZo7ol+A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@oxc-project/types": "=0.142.0",
@@ -8578,7 +8612,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -8588,7 +8622,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -8599,7 +8633,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -8609,6 +8643,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/sqlite-wasm-kysely/-/sqlite-wasm-kysely-0.3.0.tgz",
       "integrity": "sha512-TzjBNv7KwRw6E3pdKdlRyZiTmUIE0UttT/Sl56MVwVARl/u5gp978KepazCJZewFUnlWHz9i3NQd4kOtP/Afdg==",
+      "dev": true,
       "dependencies": {
         "@sqlite.org/sqlite-wasm": "^3.48.0-build2"
       },
@@ -8839,7 +8874,7 @@
       "version": "5.49.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.1.tgz",
       "integrity": "sha512-7A2xlQ5EnGT8KPA92dUh6RbRYTVw8hEaEN9L1K68l4UOXFuV511NnAqObGoRqGOQofQcMypisu1s3xawCEHrvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -8858,7 +8893,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinybench": {
@@ -8882,7 +8917,7 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -9050,7 +9085,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@typescript/typescript6/-/typescript6-6.0.2.tgz",
       "integrity": "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@typescript/old": "npm:typescript@^6"
@@ -9106,7 +9141,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -9180,6 +9215,7 @@
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
       "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
@@ -9247,6 +9283,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
       "integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/use-sync-external-store": {
@@ -9262,6 +9299,7 @@
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
       "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -9275,7 +9313,7 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
       "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.33.0",
@@ -9384,6 +9422,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9513,6 +9552,7 @@
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/which": {
@@ -9965,6 +10005,7 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "bin": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@fontsource/roboto": "^5.3.0",
-    "@inlang/paraglide-js-react": "^1.0.2",
     "@mui/icons-material": "^9.2.0",
     "@mui/material": "^9.2.0",
     "@mui/stylis-plugin-rtl": "^9.1.1",

--- a/src/features/board/navigation/board-selector.test.tsx
+++ b/src/features/board/navigation/board-selector.test.tsx
@@ -9,7 +9,7 @@ import { RouterProvider } from "react-router/dom";
 import { beforeEach, describe, expect, test } from "vitest";
 import { render } from "vitest-browser-react";
 import { userEvent } from "vitest/browser";
-import { replaceBoardSet } from "../storage/boards-db";
+import { createBoardSet } from "../storage/boards-db";
 import { makeOBFBoard, resetBoardsDB } from "../testing";
 import { BoardSelector } from "./board-selector";
 
@@ -36,7 +36,7 @@ async function renderSelector(initialPath: string) {
 beforeEach(async () => {
   setStoredLanguage(DEFAULT_LANGUAGE);
   await resetBoardsDB();
-  await replaceBoardSet({
+  await createBoardSet({
     boardSet: { setId: "set-1", name: "Set", rootBoardId: "root" },
     boards: [
       {
@@ -145,7 +145,7 @@ describe("BoardSelector", () => {
   });
 
   test("shows the cached translated name for the active language, falling back to the raw name otherwise", async () => {
-    await replaceBoardSet({
+    await createBoardSet({
       boardSet: { setId: "set-2", name: "Set", rootBoardId: "root" },
       boards: [
         {

--- a/src/features/board/storage/board-hydration.test.ts
+++ b/src/features/board/storage/board-hydration.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, test } from "vitest";
 import { assertDefined } from "@shared/testing/assert-defined";
 import { refreshBoardSets } from "../board-sets/board-sets-store";
 import { hydrateBoard, type HydratedBoard } from "./board-hydration";
-import { BoardNotFoundError, replaceBoardSet } from "./boards-db";
+import { BoardNotFoundError, createBoardSet } from "./boards-db";
 import { resetBoardsDB } from "../testing";
 
 const SET_ID = "loader-test-set";
@@ -28,7 +28,7 @@ async function seedTestBoard(): Promise<void> {
     images: [{ id: "img-1", path: IMAGE_PATH, content_type: "image/png" }],
   };
 
-  await replaceBoardSet({
+  await createBoardSet({
     boardSet: { setId: SET_ID, name: "Loader Test", rootBoardId: BOARD_ID },
     boards: [{ boardId: BOARD_ID, name: "Test Board", obf: obfBoard }],
     assets: [{ path: IMAGE_PATH, blob: pngBlob }],

--- a/src/features/board/storage/boards-db.test.ts
+++ b/src/features/board/storage/boards-db.test.ts
@@ -12,15 +12,14 @@ import {
   InvalidIdError,
   listBoards,
   listBoardSets,
-  replaceBoardSet,
   updateBoardStrings,
-  type BoardSetWriteInput,
+  type BoardSetCreateInput,
 } from "./boards-db";
 import { makeOBFBoard, resetBoardsDB } from "../testing";
 
-function makeReplaceInput(
-  overrides: Partial<BoardSetWriteInput> = {},
-): BoardSetWriteInput {
+function makeBoardSetInput(
+  overrides: Partial<BoardSetCreateInput> = {},
+): BoardSetCreateInput {
   return {
     boardSet: { setId: "set-1", name: "Set", rootBoardId: "root-1" },
     boards: [],
@@ -38,7 +37,7 @@ afterEach(closeBoardsDB);
 describe("createBoardSet", () => {
   test("rejects a conflicting ID without changing the existing set", async () => {
     await createBoardSet(
-      makeReplaceInput({
+      makeBoardSetInput({
         boardSet: { setId: "set-1", name: "Original", rootBoardId: "a" },
         boards: [{ boardId: "a", name: "A", obf: makeOBFBoard({ id: "a" }) }],
         assets: [{ path: "x.png", blob: new Blob(["x"]) }],
@@ -47,7 +46,7 @@ describe("createBoardSet", () => {
 
     await expect(
       createBoardSet(
-        makeReplaceInput({
+        makeBoardSetInput({
           boardSet: {
             setId: "set-1",
             name: "Replacement",
@@ -64,17 +63,13 @@ describe("createBoardSet", () => {
     expect(await getAssetBlob("set-1", "x.png")).toBeInstanceOf(Blob);
     expect((await listBoardSets())[0]?.name).toBe("Original");
   });
-});
 
-describe("replaceBoardSet", () => {
   test("inserts a new board set", async () => {
-    const { replacedExisting } = await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeBoardSetInput({
         boardSet: { setId: "set-1", name: "My Set", rootBoardId: "root-1" },
       }),
     );
-
-    expect(replacedExisting).toBe(false);
 
     const sets = await listBoardSets();
     expect(sets).toHaveLength(1);
@@ -90,7 +85,7 @@ describe("replaceBoardSet", () => {
       { boardId: "b3", name: "B3", obf: makeOBFBoard({ id: "b3" }) },
     ];
 
-    await replaceBoardSet(makeReplaceInput({ boards }));
+    await createBoardSet(makeBoardSetInput({ boards }));
 
     const sets = await listBoardSets();
     expect(sets[0].boardCount).toBe(3);
@@ -101,8 +96,8 @@ describe("replaceBoardSet", () => {
   });
 
   test("stores and retrieves asset blobs, normalizing paths", async () => {
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeBoardSetInput({
         assets: [
           { path: "images\\photo.png", blob: new Blob(["data"]) },
           { path: "/leading.png", blob: new Blob(["a"]) },
@@ -122,91 +117,30 @@ describe("replaceBoardSet", () => {
     );
   });
 
-  test("replaces an existing set wholesale: dropped boards, assets and metadata are gone", async () => {
-    await replaceBoardSet(
-      makeReplaceInput({
-        boardSet: {
-          setId: "set-1",
-          name: "Set v1",
-          rootBoardId: "a",
-          author: "Alice",
-        },
-        boards: [
-          { boardId: "a", name: "A", obf: makeOBFBoard({ id: "a" }) },
-          { boardId: "b", name: "B", obf: makeOBFBoard({ id: "b" }) },
-        ],
-        assets: [
-          { path: "x.png", blob: new Blob(["x"]) },
-          { path: "y.png", blob: new Blob(["y"]) },
-        ],
-      }),
-    );
-
-    const { replacedExisting } = await replaceBoardSet(
-      makeReplaceInput({
-        boardSet: { setId: "set-1", name: "Set v2", rootBoardId: "a" },
-        boards: [{ boardId: "a", name: "A", obf: makeOBFBoard({ id: "a" }) }],
-        assets: [{ path: "x.png", blob: new Blob(["x"]) }],
-      }),
-    );
-
-    expect(replacedExisting).toBe(true);
-
-    const sets = await listBoardSets();
-    expect(sets).toHaveLength(1);
-    expect(sets[0].boardCount).toBe(1);
-    expect(sets[0].author).toBeUndefined();
-    expect(sets[0].rootBoardId).toBe("a");
-
-    expect(await getBoard("set-1", "a")).toBeDefined();
-    expect(await getBoard("set-1", "b")).toBeUndefined();
-    expect(await getAssetBlob("set-1", "x.png")).toBeInstanceOf(Blob);
-    expect(await getAssetBlob("set-1", "y.png")).toBeUndefined();
-  });
-
-  test("aborts the entire transaction when a board fails to clone, leaving the prior set intact", async () => {
-    await replaceBoardSet(
-      makeReplaceInput({
-        boardSet: {
-          setId: "set-1",
-          name: "Set v1",
-          rootBoardId: "a",
-          author: "Alice",
-        },
-        boards: [{ boardId: "a", name: "A", obf: makeOBFBoard({ id: "a" }) }],
-        assets: [{ path: "x.png", blob: new Blob(["x"]) }],
-      }),
-    );
-
+  test("aborts the entire transaction when a board fails to clone", async () => {
     const uncloneableObf = {
       ...makeOBFBoard({ id: "b" }),
       onFail: () => "noop",
     } as unknown as OBFBoard;
 
     await expect(
-      replaceBoardSet(
-        makeReplaceInput({
-          boardSet: { setId: "set-1", name: "Set v2", rootBoardId: "b" },
+      createBoardSet(
+        makeBoardSetInput({
           boards: [{ boardId: "b", name: "B", obf: uncloneableObf }],
-          assets: [],
+          assets: [{ path: "x.png", blob: new Blob(["x"]) }],
         }),
       ),
     ).rejects.toThrow();
 
-    const sets = await listBoardSets();
-    expect(sets).toHaveLength(1);
-    expect(sets[0].author).toBe("Alice");
-    expect(sets[0].rootBoardId).toBe("a");
-    expect(sets[0].boardCount).toBe(1);
-
-    expect(await getBoard("set-1", "a")).toBeDefined();
-    expect(await getAssetBlob("set-1", "x.png")).toBeInstanceOf(Blob);
+    expect(await listBoardSets()).toEqual([]);
+    expect(await getBoard("set-1", "b")).toBeUndefined();
+    expect(await getAssetBlob("set-1", "x.png")).toBeUndefined();
   });
 
   test("rejects empty setId", async () => {
     await expect(
-      replaceBoardSet(
-        makeReplaceInput({
+      createBoardSet(
+        makeBoardSetInput({
           boardSet: { setId: "", name: "Bad", rootBoardId: "root-1" },
         }),
       ),
@@ -215,8 +149,8 @@ describe("replaceBoardSet", () => {
 
   test("rejects empty setId with a typed InvalidIdError", async () => {
     await expect(
-      replaceBoardSet(
-        makeReplaceInput({
+      createBoardSet(
+        makeBoardSetInput({
           boardSet: { setId: "", name: "Bad", rootBoardId: "root-1" },
         }),
       ),
@@ -225,8 +159,8 @@ describe("replaceBoardSet", () => {
 
   test("rejects setId longer than 255 characters", async () => {
     await expect(
-      replaceBoardSet(
-        makeReplaceInput({
+      createBoardSet(
+        makeBoardSetInput({
           boardSet: {
             setId: "x".repeat(256),
             name: "Bad",
@@ -239,8 +173,8 @@ describe("replaceBoardSet", () => {
 
   test("rejects empty rootBoardId", async () => {
     await expect(
-      replaceBoardSet(
-        makeReplaceInput({
+      createBoardSet(
+        makeBoardSetInput({
           boardSet: { setId: "set-1", name: "Bad", rootBoardId: "" },
         }),
       ),
@@ -249,8 +183,8 @@ describe("replaceBoardSet", () => {
 
   test("rejects empty boardId", async () => {
     await expect(
-      replaceBoardSet(
-        makeReplaceInput({
+      createBoardSet(
+        makeBoardSetInput({
           boards: [{ boardId: "", name: "B", obf: makeOBFBoard() }],
         }),
       ),
@@ -259,8 +193,8 @@ describe("replaceBoardSet", () => {
 
   test("rejects boardId longer than 255 characters", async () => {
     await expect(
-      replaceBoardSet(
-        makeReplaceInput({
+      createBoardSet(
+        makeBoardSetInput({
           boards: [
             { boardId: "x".repeat(256), name: "B", obf: makeOBFBoard() },
           ],
@@ -280,13 +214,13 @@ describe("listBoardSets", () => {
     let now = 1000;
     vi.spyOn(Date, "now").mockImplementation(() => (now += 1000));
 
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeBoardSetInput({
         boardSet: { setId: "old", name: "Old", rootBoardId: "root-1" },
       }),
     );
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeBoardSetInput({
         boardSet: { setId: "new", name: "New", rootBoardId: "root-1" },
       }),
     );
@@ -300,7 +234,7 @@ describe("listBoardSets", () => {
 
 describe("getBoard", () => {
   test("returns undefined for nonexistent board", async () => {
-    await replaceBoardSet(makeReplaceInput());
+    await createBoardSet(makeBoardSetInput());
 
     const board = await getBoard("set-1", "nonexistent");
     expect(board).toBeUndefined();
@@ -309,8 +243,8 @@ describe("getBoard", () => {
 
 describe("listBoards", () => {
   test("returns only the set's boards", async () => {
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeBoardSetInput({
         boardSet: { setId: "set-1", name: "Set 1", rootBoardId: "a" },
         boards: [
           { boardId: "a", name: "A", obf: makeOBFBoard({ id: "a" }) },
@@ -318,8 +252,8 @@ describe("listBoards", () => {
         ],
       }),
     );
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeBoardSetInput({
         boardSet: { setId: "set-2", name: "Set 2", rootBoardId: "c" },
         boards: [{ boardId: "c", name: "C", obf: makeOBFBoard({ id: "c" }) }],
       }),
@@ -331,7 +265,7 @@ describe("listBoards", () => {
   });
 
   test("returns empty array for a set with no boards", async () => {
-    await replaceBoardSet(makeReplaceInput());
+    await createBoardSet(makeBoardSetInput());
 
     const boards = await listBoards("set-1");
 
@@ -342,8 +276,8 @@ describe("listBoards", () => {
 describe("updateBoardStrings", () => {
   test("adds localized strings to a board", async () => {
     const obf = makeOBFBoard({ id: "b1" });
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeBoardSetInput({
         boards: [{ boardId: "b1", name: "B1", obf }],
       }),
     );
@@ -365,8 +299,8 @@ describe("updateBoardStrings", () => {
       id: "b1",
       strings: { fr: { hello: "bonjour" } },
     });
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeBoardSetInput({
         boards: [{ boardId: "b1", name: "B1", obf }],
       }),
     );
@@ -383,8 +317,8 @@ describe("updateBoardStrings", () => {
 
   test("replaces all strings when updating an existing locale", async () => {
     const obf = makeOBFBoard({ id: "b1" });
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeBoardSetInput({
         boards: [{ boardId: "b1", name: "B1", obf }],
       }),
     );
@@ -401,7 +335,7 @@ describe("updateBoardStrings", () => {
   });
 
   test("throws when board does not exist", async () => {
-    await replaceBoardSet(makeReplaceInput());
+    await createBoardSet(makeBoardSetInput());
 
     await expect(
       updateBoardStrings("set-1", "nonexistent", "es", {}),
@@ -411,7 +345,7 @@ describe("updateBoardStrings", () => {
 
 describe("deleteBoardSetRows", () => {
   test("removes the board set record", async () => {
-    await replaceBoardSet(makeReplaceInput());
+    await createBoardSet(makeBoardSetInput());
 
     await deleteBoardSetRows("set-1");
 
@@ -420,8 +354,8 @@ describe("deleteBoardSetRows", () => {
   });
 
   test("cascade-deletes all boards in the set", async () => {
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeBoardSetInput({
         boards: [
           { boardId: "b1", name: "B1", obf: makeOBFBoard({ id: "b1" }) },
           { boardId: "b2", name: "B2", obf: makeOBFBoard({ id: "b2" }) },
@@ -436,8 +370,8 @@ describe("deleteBoardSetRows", () => {
   });
 
   test("cascade-deletes all assets in the set", async () => {
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeBoardSetInput({
         assets: [
           { path: "img1.png", blob: new Blob(["a"]) },
           { path: "img2.png", blob: new Blob(["b"]) },
@@ -452,16 +386,16 @@ describe("deleteBoardSetRows", () => {
   });
 
   test("does not affect other board sets", async () => {
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeBoardSetInput({
         boardSet: { setId: "set-1", name: "Set 1", rootBoardId: "root-1" },
         boards: [
           { boardId: "b1", name: "B1", obf: makeOBFBoard({ id: "b1" }) },
         ],
       }),
     );
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeBoardSetInput({
         boardSet: { setId: "set-2", name: "Set 2", rootBoardId: "root-1" },
         boards: [
           { boardId: "b2", name: "B2", obf: makeOBFBoard({ id: "b2" }) },
@@ -498,8 +432,8 @@ describe("getBoardsDB", () => {
     const second = await getBoardsDB();
     expect(second).not.toBe(first);
 
-    await replaceBoardSet(
-      makeReplaceInput({
+    await createBoardSet(
+      makeBoardSetInput({
         boardSet: { setId: "set-1", name: "Persisted", rootBoardId: "root-1" },
       }),
     );

--- a/src/features/board/storage/boards-db.ts
+++ b/src/features/board/storage/boards-db.ts
@@ -208,28 +208,15 @@ export async function deleteBoardSetRows(setId: string): Promise<void> {
   ]);
 }
 
-export interface BoardSetWriteInput {
+export interface BoardSetCreateInput {
   boardSet: BoardSetInput;
   boards: BoardInput[];
   assets: AssetInput[];
 }
 
-export async function createBoardSet(input: BoardSetWriteInput): Promise<void> {
-  await writeBoardSet(input, "create");
-}
-
-export async function replaceBoardSet(
-  input: BoardSetWriteInput,
-): Promise<{ replacedExisting: boolean }> {
-  return { replacedExisting: await writeBoardSet(input, "replace") };
-}
-
-type BoardSetWriteMode = "create" | "replace";
-
-async function writeBoardSet(
-  input: BoardSetWriteInput,
-  mode: BoardSetWriteMode,
-): Promise<boolean> {
+export async function createBoardSet(
+  input: BoardSetCreateInput,
+): Promise<void> {
   const { boardSet, boards, assets } = input;
   validateId(boardSet.setId, "setId");
   validateId(boardSet.rootBoardId, "rootBoardId");
@@ -245,7 +232,7 @@ async function writeBoardSet(
   const assetStore = tx.objectStore("assets");
 
   const existing = await boardSetStore.get(setId);
-  if (mode === "create" && existing) {
+  if (existing) {
     await tx.done;
     throw new BoardSetAlreadyExistsError(setId);
   }
@@ -271,11 +258,6 @@ async function writeBoardSet(
   const requests: Promise<unknown>[] = [tx.done];
 
   try {
-    if (mode === "replace") {
-      const setRange = boardSetRange(setId);
-      requests.push(boardStore.delete(setRange), assetStore.delete(setRange));
-    }
-
     for (const board of boards) {
       requests.push(
         boardStore.put({
@@ -295,9 +277,7 @@ async function writeBoardSet(
         }),
       );
     }
-    requests.push(
-      mode === "create" ? boardSetStore.add(record) : boardSetStore.put(record),
-    );
+    requests.push(boardSetStore.add(record));
 
     await Promise.all(requests);
   } catch (error) {
@@ -309,8 +289,6 @@ async function writeBoardSet(
     await Promise.allSettled(requests);
     throw error;
   }
-
-  return existing !== undefined;
 }
 
 export async function getBoard(

--- a/src/features/board/testing/db.ts
+++ b/src/features/board/testing/db.ts
@@ -2,7 +2,7 @@ import type { OBFBoard } from "@shayc/open-board-format";
 import { refreshBoardSets } from "../board-sets/board-sets-store";
 import {
   getBoardsDB,
-  replaceBoardSet,
+  createBoardSet,
   type AssetInput,
   type BoardRecord,
   type BoardSetRecord,
@@ -49,7 +49,7 @@ export async function resetBoardsDB(): Promise<void> {
 export async function seedBoardSets(records: SeedBoardSet[]): Promise<void> {
   await clearBoardsDB();
   for (const { boards = [], assets = [], ...record } of records) {
-    await replaceBoardSet({
+    await createBoardSet({
       boardSet: { name: record.setId, ...record },
       boards,
       assets,

--- a/src/features/board/translation/resolve-translated-board.test.ts
+++ b/src/features/board/translation/resolve-translated-board.test.ts
@@ -3,7 +3,7 @@ import {
   stubTranslator,
 } from "@shared/testing/built-in-ai";
 import { beforeEach, describe, expect, test } from "vitest";
-import { getBoard, replaceBoardSet } from "../storage/boards-db";
+import { getBoard, createBoardSet } from "../storage/boards-db";
 import { resetBoardsDB } from "../testing";
 import type { Board } from "../types";
 import { resolveTranslatedBoard } from "./resolve-translated-board";
@@ -76,7 +76,7 @@ describe("resolveTranslatedBoard", () => {
   });
 
   test("persists a fresh translation so the next load hits the cache", async () => {
-    await replaceBoardSet({
+    await createBoardSet({
       boardSet: { setId: "set-1", name: "set-1", rootBoardId: "board-1" },
       boards: [
         {

--- a/src/shared/testing/built-in-ai.ts
+++ b/src/shared/testing/built-in-ai.ts
@@ -4,7 +4,7 @@ import { type Mock, vi } from "vitest";
 // @shayc/react-built-in-ai reads off globalThis. They're absent in CI Chromium,
 // so we fake them at the global boundary.
 
-type AINamespace = "Proofreader" | "Rewriter" | "Translator" | "LanguageModel";
+type AINamespace = "Proofreader" | "Rewriter" | "Translator";
 
 interface NamespaceSpies {
   create: Mock<(options?: Record<string, unknown>) => Promise<unknown>>;
@@ -25,10 +25,6 @@ interface RewriterStub extends NamespaceSpies {
 
 interface TranslatorStub extends NamespaceSpies {
   translate: Mock<(input: string) => string | Promise<string>>;
-}
-
-interface LanguageModelStub extends NamespaceSpies {
-  prompt: Mock<(input: string) => string | Promise<string>>;
 }
 
 function installNamespace(
@@ -79,22 +75,6 @@ export function stubTranslator(
   const spies = installNamespace("Translator", () => ({ translate: action }));
 
   return { translate: action, ...spies };
-}
-
-// The Prompt API session exposes the surface @shayc/react-built-in-ai reads:
-// `prompt`, the `contextoverflow` listener, and the live context-window numbers.
-export function stubLanguageModel(
-  prompt: (input: string) => string | Promise<string> = () => '{"words":[]}',
-): LanguageModelStub {
-  const action = vi.fn(prompt);
-  const spies = installNamespace("LanguageModel", () => ({
-    prompt: action,
-    addEventListener: () => undefined,
-    contextWindow: 4096,
-    contextUsage: 0,
-  }));
-
-  return { prompt: action, ...spies };
 }
 
 export function stubBuiltInAIUnsupported(...names: AINamespace[]): void {

--- a/src/shared/testing/global-setup.ts
+++ b/src/shared/testing/global-setup.ts
@@ -1,17 +1,10 @@
 import { resetPersistedStores } from "@shared/utils/persisted-store";
 import { afterEach, beforeEach, vi } from "vitest";
 
-// Built-in AI namespaces the app reads off globalThis. CI's Chromium exposes
-// some of these (e.g. a downloadable LanguageModel) while local Chromium does
-// not, so tests that don't stub them would otherwise pick up ambient state and
-// behave differently across environments. Default them all to absent; tests
-// opt in with the stub helpers in built-in-ai.ts.
-const BUILT_IN_AI_NAMESPACES = [
-  "Proofreader",
-  "Rewriter",
-  "Translator",
-  "LanguageModel",
-];
+// Built-in AI namespaces the app reads off globalThis. Their ambient state can
+// differ between local and CI Chromium, so default them to absent; tests opt in
+// with the stub helpers in built-in-ai.ts.
+const BUILT_IN_AI_NAMESPACES = ["Proofreader", "Rewriter", "Translator"];
 
 function clearStorage() {
   localStorage.clear();

--- a/src/shared/utils/locale.test.ts
+++ b/src/shared/utils/locale.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "vitest";
 import {
-  getEnglishLanguageName,
   getLanguageCode,
   getNativeLanguageName,
   getTextDirection,
@@ -56,16 +55,6 @@ describe("getTextDirection", () => {
 
   test("returns ltr when Intl.Locale rejects structurally invalid input", () => {
     expect(getTextDirection("!!!")).toBe("ltr");
-  });
-});
-
-describe("getEnglishLanguageName", () => {
-  test("uses dialect form for region-qualified locales", () => {
-    expect(getEnglishLanguageName("en-US")).toBe("American English");
-  });
-
-  test("returns plain language name when no region is given", () => {
-    expect(getEnglishLanguageName("es")).toBe("Spanish");
   });
 });
 

--- a/src/shared/utils/locale.ts
+++ b/src/shared/utils/locale.ts
@@ -1,8 +1,3 @@
-const englishLanguageNames = new Intl.DisplayNames(["en"], {
-  type: "language",
-  languageDisplay: "dialect",
-});
-
 function parseLocale(locale: string): Intl.Locale {
   return new Intl.Locale(locale.replace(/_/g, "-"));
 }
@@ -56,19 +51,6 @@ export function getTextDirection(locale: string): "ltr" | "rtl" {
     return parseLocale(locale).getTextInfo().direction ?? "ltr";
   } catch {
     return "ltr";
-  }
-}
-
-/**
- * English display name of a locale, dialect-aware
- * (e.g. "en-US" → "American English", "he-IL" → "Hebrew (Israel)").
- * Falls back to the original code if the locale is not recognized.
- */
-export function getEnglishLanguageName(locale: string): string {
-  try {
-    return englishLanguageNames.of(normalizeLocale(locale)) ?? locale;
-  } catch {
-    return locale;
   }
 }
 


### PR DESCRIPTION
## Summary

- remove the unused English locale-name helper and Prompt API test stub
- remove the unused `@inlang/paraglide-js-react` dependency
- remove the unplanned board-set replacement API and replace-only database branches
- update test fixtures and retain creation, validation, transaction rollback, hydration, translation, and navigation coverage

## Why

The removed paths had no application callers. The board-set replacement implementation was retained only for tests, and its shared mode branches still reached the production bundle.

## Impact

There is no intended user-facing behavior change. Board imports continue to create uniquely named sets, while existing-ID conflicts remain rejected.

## Validation

- `npm run lint`
- `npm test` — 82 files, 573 tests
- `npm run build`
