### PR TITLE
Release v1.16.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aac-board-ai",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aac-board-ai",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aac-board-ai",
   "private": true,
-  "version": "1.16.0",
+  "version": "1.16.1",
   "license": "MIT",
   "type": "module",
   "engines": {

--- a/src/features/board/tile/tile.test.tsx
+++ b/src/features/board/tile/tile.test.tsx
@@ -30,6 +30,10 @@ function resolveBackgroundColor(cssColor: string): string {
   return resolved;
 }
 
+function resolveColorInSrgb(cssColor: string): string {
+  return resolveColor(`color(srgb from ${cssColor} r g b)`);
+}
+
 function resolveBoxShadow(cssShadow: string): string {
   const probe = document.createElement("div");
   document.body.append(probe);
@@ -217,8 +221,8 @@ describe("Tile", () => {
     const button = screen.getByRole("button", { name: "Colored" });
     const styles = getComputedStyle(button.element());
 
-    expect(styles.backgroundColor).toBe(
-      resolveBackgroundColor("oklch(from #000000 l c h)"),
+    expect(resolveColorInSrgb(styles.backgroundColor)).toBe(
+      resolveColorInSrgb("oklch(from #000000 l c h)"),
     );
     expect(styles.color).toBe("rgb(255, 255, 255)");
   });


### PR DESCRIPTION
## Summary

- bump the application and lockfile version to 1.16.1
- compare rendered tile colors in a common sRGB space so the browser test accepts equivalent `oklab` and `oklch` serialization
- prepare the patch release for the 17 commits merged since v1.16.0

## Why

The post-v1.16.0 changes include a core reliability fix that keeps visible AAC board images and sounds alive until navigation commits, along with clearer board-set and suggestions messaging.

Chromium may serialize the same rendered black color as either `oklab(0 0 0)` or `oklch(0 0 0)` depending on the environment. The previous string comparison made an otherwise-correct test fail locally.

## Impact

The release metadata now matches v1.16.1. The test remains behavior-focused while becoming portable across Chromium serialization variants; application runtime behavior is unchanged by the test adjustment.

## Validation

- `npm run lint`
- `npm test` — 82 files, 573 tests passed
- `npm run test:coverage` — 92.32% statements, 83.53% branches
- `npm run build`
- `git diff --check`
