### PR TITLE
Clarify project documentation boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ After the first successful load, the app and loaded boards work offline. URL imp
 
 Boards can be imported and stored, but not edited, exported, or synchronized between devices. Prepare custom boards with an Open Board Format-compatible tool and import them on each device.
 
-## Compatibility
+## Built-in AI compatibility
 
 The app checks for Built-in AI support at runtime. Availability depends on the browser, operating system, hardware, language, and downloaded models; initial model or language-pack downloads may require an unmetered connection.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -153,11 +153,12 @@ seam. Search by path or symbol name to locate the code.
 | Shared state primitives   | `src/shared/utils/external-store.ts`, `src/shared/utils/persisted-store.ts`                                  | Cross-cutting stores build on these primitives instead of defining new subscription or localStorage machinery.                                                                |
 | UI messages               | `messages/*.json`, `project.inlang/`                                                                         | Message sources compile through Paraglide into generated `src/paraglide/`; generated files are never edited manually.                                                         |
 
-External packages carry three integration seams:
-`@shayc/open-board-format` parses OBF/OBZ,
-`@shayc/react-built-in-ai` wraps browser AI APIs, and
-`@shayc/switch-scanning` provides the scanning engine. App modules add product
-policy around those package interfaces.
+Two companion packages own reusable mechanics outside the application:
+[`@shayc/open-board-format`](https://github.com/shayc/open-board-format) parses
+and creates OBF/OBZ files, while
+[`@shayc/react-built-in-ai`](https://github.com/shayc/react-built-in-ai)
+manages browser AI availability, provisioning, and lifecycle. App modules add
+product policy around both interfaces.
 
 ## Data and state model
 


### PR DESCRIPTION
## Summary

- clarify that the compatibility section describes Built-in AI support
- document the two durable companion packages and their responsibilities
- keep application-level product policy distinct from reusable package mechanics

## Impact

New developers can distinguish core browser compatibility from optional AI
support and see where reusable OBF and Built-in AI behavior is owned without
adding a new onboarding section.

## Validation

- `npx prettier --check README.md docs/architecture.md`
- `npm run lint`
- `npm test` — 554 tests passed
- `npm run build`
