### PR TITLE
Polish activation, settings, and store naming

### DIFF
--- a/src/app/settings/board-settings.tsx
+++ b/src/app/settings/board-settings.tsx
@@ -1,8 +1,6 @@
 import FormControlLabel from "@mui/material/FormControlLabel";
-import Slider from "@mui/material/Slider";
 import Stack from "@mui/material/Stack";
 import Switch from "@mui/material/Switch";
-import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
 import { useTranslate } from "@shared/language/use-translate";
 import {
@@ -11,6 +9,7 @@ import {
   TILE_SATURATION,
   useTileAppearanceConfig,
 } from "@shared/tile-appearance/tile-appearance-store";
+import { SettingSlider } from "./setting-slider";
 
 function formatSaturation(value: number): string {
   return `${Math.round(value * 100)}%`;
@@ -19,7 +18,6 @@ function formatSaturation(value: number): string {
 export function BoardSettings() {
   const t = useTranslate();
   const { saturation, borderVisible } = useTileAppearanceConfig();
-  const saturationLabel = formatSaturation(saturation);
 
   return (
     <Stack spacing={3}>
@@ -35,25 +33,15 @@ export function BoardSettings() {
         }
       />
 
-      <Stack spacing={0.5}>
-        <Stack direction="row" sx={{ justifyContent: "space-between", gap: 2 }}>
-          <Typography variant="body2" sx={{ color: "text.secondary" }}>
-            {t(m.tileSaturation)}
-          </Typography>
-          <Typography variant="body2" sx={{ fontWeight: 600 }}>
-            {saturationLabel}
-          </Typography>
-        </Stack>
-        <Slider
-          aria-label={t(m.tileSaturation)}
-          getAriaValueText={formatSaturation}
-          value={saturation}
-          min={TILE_SATURATION.min}
-          max={TILE_SATURATION.max}
-          step={0.1}
-          onChange={(_event, newValue) => setTileSaturation(newValue)}
-        />
-      </Stack>
+      <SettingSlider
+        label={t(m.tileSaturation)}
+        value={saturation}
+        min={TILE_SATURATION.min}
+        max={TILE_SATURATION.max}
+        step={0.1}
+        formatValue={formatSaturation}
+        onChange={setTileSaturation}
+      />
     </Stack>
   );
 }

--- a/src/app/settings/setting-slider.tsx
+++ b/src/app/settings/setting-slider.tsx
@@ -1,0 +1,45 @@
+import Slider from "@mui/material/Slider";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+
+interface SettingSliderProps {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  formatValue: (value: number) => string;
+  onChange: (value: number) => void;
+}
+
+export function SettingSlider({
+  label,
+  value,
+  min,
+  max,
+  step,
+  formatValue,
+  onChange,
+}: SettingSliderProps) {
+  return (
+    <Stack spacing={0.5} role="group" aria-label={label}>
+      <Stack direction="row" sx={{ justifyContent: "space-between", gap: 2 }}>
+        <Typography variant="body2" sx={{ color: "text.secondary" }}>
+          {label}
+        </Typography>
+        <Typography variant="body2" sx={{ fontWeight: 600 }}>
+          {formatValue(value)}
+        </Typography>
+      </Stack>
+      <Slider
+        aria-label={label}
+        getAriaValueText={formatValue}
+        value={value}
+        min={min}
+        max={max}
+        step={step}
+        onChange={(_event, newValue) => onChange(newValue)}
+      />
+    </Stack>
+  );
+}

--- a/src/app/settings/speech-settings.tsx
+++ b/src/app/settings/speech-settings.tsx
@@ -6,10 +6,8 @@ import InputLabel from "@mui/material/InputLabel";
 import ListSubheader from "@mui/material/ListSubheader";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
-import Slider from "@mui/material/Slider";
 import Stack from "@mui/material/Stack";
 import Switch from "@mui/material/Switch";
-import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
 import {
   setHighlightActivePart,
@@ -29,6 +27,7 @@ import {
   useSpeechConfig,
   useVoicesByLanguage,
 } from "@shared/speech/speech-store";
+import { SettingSlider } from "./setting-slider";
 
 export function SpeechSettings() {
   const t = useTranslate();
@@ -119,28 +118,16 @@ export function SpeechSettings() {
 
       {speechControls.map(
         ({ id, label, value, min, max, onChange, formatValue }) => (
-          <Stack key={id} spacing={0.5} role="group" aria-label={label}>
-            <Stack
-              direction="row"
-              sx={{ justifyContent: "space-between", gap: 2 }}
-            >
-              <Typography variant="body2" sx={{ color: "text.secondary" }}>
-                {label}
-              </Typography>
-              <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                {formatValue(value)}
-              </Typography>
-            </Stack>
-            <Slider
-              aria-label={label}
-              getAriaValueText={formatValue}
-              value={value}
-              min={min}
-              max={max}
-              step={0.1}
-              onChange={(_event, newValue) => onChange(newValue)}
-            />
-          </Stack>
+          <SettingSlider
+            key={id}
+            label={label}
+            value={value}
+            min={min}
+            max={max}
+            step={0.1}
+            formatValue={formatValue}
+            onChange={onChange}
+          />
         ),
       )}
 

--- a/src/app/settings/speech-settings.tsx
+++ b/src/app/settings/speech-settings.tsx
@@ -9,12 +9,12 @@ import Select from "@mui/material/Select";
 import Stack from "@mui/material/Stack";
 import Switch from "@mui/material/Switch";
 import { m } from "@paraglide/messages.js";
+import { useLanguage } from "@shared/language/use-language";
+import { useTranslate } from "@shared/language/use-translate";
 import {
   setHighlightActivePart,
   useHighlightConfig,
 } from "@shared/playback-highlight/highlight-store";
-import { useLanguage } from "@shared/language/use-language";
-import { useTranslate } from "@shared/language/use-translate";
 import { usePlayback } from "@shared/playback/use-playback";
 import {
   setPitch,

--- a/src/app/settings/switch-scanning/switch-scanning-advanced-settings.tsx
+++ b/src/app/settings/switch-scanning/switch-scanning-advanced-settings.tsx
@@ -2,7 +2,6 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import Accordion from "@mui/material/Accordion";
 import AccordionDetails from "@mui/material/AccordionDetails";
 import AccordionSummary from "@mui/material/AccordionSummary";
-import Slider from "@mui/material/Slider";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
@@ -17,18 +16,9 @@ import {
   setIgnoreRepeatMs,
   setMinimumPressDurationMs,
 } from "@shared/switch-scanning/switch-scanning-store";
+import { SettingSlider } from "../setting-slider";
 
 const MILLISECONDS_PER_SECOND = 1_000;
-
-interface SettingSliderProps {
-  label: string;
-  value: number;
-  min: number;
-  max: number;
-  step: number;
-  formatValue: (value: number) => string;
-  onChange: (value: number) => void;
-}
 
 interface SwitchScanningAdvancedSettingsProps {
   cyclesBeforePausing: number;
@@ -37,38 +27,6 @@ interface SwitchScanningAdvancedSettingsProps {
   ignoreRepeatMs: number;
   minimumPressDurationMs: number;
   formatSeconds: (value: number) => string;
-}
-
-function SettingSlider({
-  label,
-  value,
-  min,
-  max,
-  step,
-  formatValue,
-  onChange,
-}: SettingSliderProps) {
-  return (
-    <Stack spacing={0.5}>
-      <Stack direction="row" sx={{ justifyContent: "space-between", gap: 2 }}>
-        <Typography variant="body2" sx={{ color: "text.secondary" }}>
-          {label}
-        </Typography>
-        <Typography variant="body2" sx={{ fontWeight: 600 }}>
-          {formatValue(value)}
-        </Typography>
-      </Stack>
-      <Slider
-        aria-label={label}
-        getAriaValueText={formatValue}
-        value={value}
-        min={min}
-        max={max}
-        step={step}
-        onChange={(_event, newValue) => onChange(newValue)}
-      />
-    </Stack>
-  );
 }
 
 export function SwitchScanningAdvancedSettings({

--- a/src/app/settings/switch-scanning/switch-scanning-settings.tsx
+++ b/src/app/settings/switch-scanning/switch-scanning-settings.tsx
@@ -4,10 +4,8 @@ import FormHelperText from "@mui/material/FormHelperText";
 import InputLabel from "@mui/material/InputLabel";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
-import Slider from "@mui/material/Slider";
 import Stack from "@mui/material/Stack";
 import Switch from "@mui/material/Switch";
-import Typography from "@mui/material/Typography";
 import { m } from "@paraglide/messages.js";
 import { useLanguage } from "@shared/language/use-language";
 import { type Translate, useTranslate } from "@shared/language/use-translate";
@@ -21,6 +19,7 @@ import {
   type SwitchScanningMethod,
   useSwitchScanningConfig,
 } from "@shared/switch-scanning/switch-scanning-store";
+import { SettingSlider } from "../setting-slider";
 import { SwitchInputSetup } from "./switch-input-setup";
 import { SwitchScanningAdvancedSettings } from "./switch-scanning-advanced-settings";
 
@@ -158,30 +157,17 @@ export function SwitchScanningSettings() {
           <SwitchInputSetup inputs={inputs} method={method} />
 
           {timing && (
-            <Stack spacing={0.5}>
-              <Stack
-                direction="row"
-                sx={{ justifyContent: "space-between", gap: 2 }}
-              >
-                <Typography variant="body2" sx={{ color: "text.secondary" }}>
-                  {timing.label}
-                </Typography>
-                <Typography variant="body2" sx={{ fontWeight: 600 }}>
-                  {seconds.format(timing.value / MILLISECONDS_PER_SECOND)}
-                </Typography>
-              </Stack>
-              <Slider
-                aria-label={timing.label}
-                getAriaValueText={(value) => seconds.format(value)}
-                value={timing.value / MILLISECONDS_PER_SECOND}
-                min={timing.range.min / MILLISECONDS_PER_SECOND}
-                max={timing.range.max / MILLISECONDS_PER_SECOND}
-                step={0.1}
-                onChange={(_event, value) =>
-                  timing.onChange(value * MILLISECONDS_PER_SECOND)
-                }
-              />
-            </Stack>
+            <SettingSlider
+              label={timing.label}
+              value={timing.value / MILLISECONDS_PER_SECOND}
+              min={timing.range.min / MILLISECONDS_PER_SECOND}
+              max={timing.range.max / MILLISECONDS_PER_SECOND}
+              step={0.1}
+              formatValue={(value) => seconds.format(value)}
+              onChange={(value) =>
+                timing.onChange(value * MILLISECONDS_PER_SECOND)
+              }
+            />
           )}
 
           <SwitchScanningAdvancedSettings

--- a/src/features/board/activation/button-activation.test.ts
+++ b/src/features/board/activation/button-activation.test.ts
@@ -2,9 +2,9 @@ import type { PlaybackOutcome } from "@shared/playback/playback-context";
 import { describe, expect, test, vi } from "vitest";
 import type { MessagePart } from "../message/message-types";
 import type { BoardButton } from "../types";
-import { createButtonActivation } from "./button-activation";
+import { createButtonActivator } from "./button-activation";
 
-type ActivationOptions = Parameters<typeof createButtonActivation>[0];
+type ActivationOptions = Parameters<typeof createButtonActivator>[0];
 
 function createMessageStub(
   parts: MessagePart[] = [],
@@ -40,14 +40,18 @@ function setup(opts: SetupOptions = {}) {
   const playback = opts.playback ?? createPlaybackStub();
   const navigation = opts.navigation ?? createNavigationStub();
 
-  const activation = createButtonActivation({ message, playback, navigation });
+  const activateButton = createButtonActivator({
+    message,
+    playback,
+    navigation,
+  });
 
-  return { activation, message, playback, navigation };
+  return { activateButton, message, playback, navigation };
 }
 
-describe("createButtonActivation", () => {
+describe("createButtonActivator", () => {
   test("navigates to the linked board and skips message and audio when loadBoard.id is set", () => {
-    const { activation, message, playback, navigation } = setup();
+    const { activateButton, message, playback, navigation } = setup();
 
     const button: BoardButton = {
       id: "btn",
@@ -55,7 +59,7 @@ describe("createButtonActivation", () => {
       loadBoard: { id: "child-board" },
     };
 
-    activation.activateButton(button);
+    activateButton(button);
 
     expect(navigation.goToBoard).toHaveBeenCalledWith("child-board");
     expect(message.setParts).not.toHaveBeenCalled();
@@ -64,18 +68,18 @@ describe("createButtonActivation", () => {
   });
 
   test("maps home to navigation.goHome", () => {
-    const { activation, navigation } = setup();
+    const { activateButton, navigation } = setup();
 
-    activation.activateButton({ id: "btn", actions: [{ kind: "home" }] });
+    activateButton({ id: "btn", actions: [{ kind: "home" }] });
 
     expect(navigation.goHome).toHaveBeenCalledTimes(1);
   });
 
   test("spell appends the text via setParts", () => {
     const message = createMessageStub([]);
-    const { activation } = setup({ message });
+    const { activateButton } = setup({ message });
 
-    activation.activateButton({
+    activateButton({
       id: "btn",
       actions: [{ kind: "spell", text: "t" }],
     });
@@ -89,9 +93,9 @@ describe("createButtonActivation", () => {
 
   test("space appends an empty-label part via setParts", () => {
     const message = createMessageStub([]);
-    const { activation } = setup({ message });
+    const { activateButton } = setup({ message });
 
-    activation.activateButton({ id: "btn", actions: [{ kind: "space" }] });
+    activateButton({ id: "btn", actions: [{ kind: "space" }] });
 
     expect(message.setParts).toHaveBeenCalledTimes(1);
     const [committed] = vi.mocked(message.setParts).mock.calls[0];
@@ -105,9 +109,9 @@ describe("createButtonActivation", () => {
       { id: "1", label: "hello" },
       { id: "2", label: "world" },
     ]);
-    const { activation } = setup({ message });
+    const { activateButton } = setup({ message });
 
-    activation.activateButton({ id: "btn", actions: [{ kind: "backspace" }] });
+    activateButton({ id: "btn", actions: [{ kind: "backspace" }] });
 
     expect(message.setParts).toHaveBeenCalledWith([
       { id: "1", label: "hello" },
@@ -117,9 +121,9 @@ describe("createButtonActivation", () => {
 
   test("clear empties the message via setParts", () => {
     const message = createMessageStub([{ id: "1", label: "hello" }]);
-    const { activation } = setup({ message });
+    const { activateButton } = setup({ message });
 
-    activation.activateButton({ id: "btn", actions: [{ kind: "clear" }] });
+    activateButton({ id: "btn", actions: [{ kind: "clear" }] });
 
     expect(message.setParts).toHaveBeenCalledWith([]);
   });
@@ -127,9 +131,9 @@ describe("createButtonActivation", () => {
   test("spelling then speaking speaks a message that includes the spelled letter", () => {
     const message = createMessageStub([]);
     const playback = createPlaybackStub();
-    const { activation } = setup({ message, playback });
+    const { activateButton } = setup({ message, playback });
 
-    activation.activateButton({
+    activateButton({
       id: "btn",
       actions: [{ kind: "spell", text: "s" }, { kind: "speak" }],
     });
@@ -153,9 +157,9 @@ describe("createButtonActivation", () => {
           resolvePlay = () => resolve("completed");
         }),
     );
-    const { activation } = setup({ message, playback });
+    const { activateButton } = setup({ message, playback });
 
-    activation.activateButton({
+    activateButton({
       id: "btn",
       actions: [{ kind: "speak" }, { kind: "clear" }],
     });
@@ -176,9 +180,9 @@ describe("createButtonActivation", () => {
     playback.playMessage = vi.fn((): Promise<PlaybackOutcome> =>
       Promise.resolve("interrupted"),
     );
-    const { activation } = setup({ message, playback });
+    const { activateButton } = setup({ message, playback });
 
-    activation.activateButton({
+    activateButton({
       id: "btn",
       actions: [{ kind: "speak" }, { kind: "clear" }],
     });
@@ -190,9 +194,9 @@ describe("createButtonActivation", () => {
   test("a mutation-only sequence folds every mutation into one commit and never plays", () => {
     const message = createMessageStub([]);
     const playback = createPlaybackStub();
-    const { activation } = setup({ message, playback });
+    const { activateButton } = setup({ message, playback });
 
-    activation.activateButton({
+    activateButton({
       id: "btn",
       actions: [
         { kind: "spell", text: "h" },
@@ -211,9 +215,9 @@ describe("createButtonActivation", () => {
     const initialParts: MessagePart[] = [{ id: "1", label: "hi" }];
     const message = createMessageStub(initialParts);
     const playback = createPlaybackStub();
-    const { activation } = setup({ message, playback });
+    const { activateButton } = setup({ message, playback });
 
-    activation.activateButton({ id: "btn", actions: [{ kind: "speak" }] });
+    activateButton({ id: "btn", actions: [{ kind: "speak" }] });
 
     expect(playback.playMessage).toHaveBeenCalledWith(initialParts);
 
@@ -223,9 +227,9 @@ describe("createButtonActivation", () => {
   });
 
   test("treats an empty actions array as no actions and speaks instead", () => {
-    const { activation, message } = setup();
+    const { activateButton, message } = setup();
 
-    activation.activateButton({
+    activateButton({
       id: "btn",
       label: "hi",
       actions: [],
@@ -236,9 +240,9 @@ describe("createButtonActivation", () => {
 
   test("adds the button as a message part when there are no actions and no loadBoard", () => {
     const message = createMessageStub([]);
-    const { activation } = setup({ message });
+    const { activateButton } = setup({ message });
 
-    activation.activateButton({
+    activateButton({
       id: "btn",
       label: "hi",
       vocalization: "hello",
@@ -257,9 +261,9 @@ describe("createButtonActivation", () => {
   });
 
   test("passes the composed sound part to playback", () => {
-    const { activation, playback } = setup();
+    const { activateButton, playback } = setup();
 
-    activation.activateButton({
+    activateButton({
       id: "btn",
       label: "bell",
       soundSrc: "bell.mp3",
@@ -272,9 +276,9 @@ describe("createButtonActivation", () => {
   });
 
   test("passes vocalization to playback without handling speech mechanics", () => {
-    const { activation, playback } = setup();
+    const { activateButton, playback } = setup();
 
-    activation.activateButton({
+    activateButton({
       id: "btn",
       label: "I",
       vocalization: "Hello",
@@ -286,9 +290,9 @@ describe("createButtonActivation", () => {
   });
 
   test("passes label-only content to playback", () => {
-    const { activation, playback } = setup();
+    const { activateButton, playback } = setup();
 
-    activation.activateButton({ id: "btn", label: "Goodbye" });
+    activateButton({ id: "btn", label: "Goodbye" });
 
     expect(playback.playPart).toHaveBeenCalledWith(
       expect.objectContaining({ label: "Goodbye" }),
@@ -296,9 +300,9 @@ describe("createButtonActivation", () => {
   });
 
   test("delegates inaudible content so playback policy stays centralized", () => {
-    const { activation, message, playback } = setup();
+    const { activateButton, message, playback } = setup();
 
-    activation.activateButton({ id: "btn" });
+    activateButton({ id: "btn" });
 
     expect(message.setParts).toHaveBeenCalledTimes(1);
     expect(playback.playPart).toHaveBeenCalledTimes(1);

--- a/src/features/board/activation/button-activation.ts
+++ b/src/features/board/activation/button-activation.ts
@@ -31,15 +31,11 @@ interface ButtonActivationOptions {
   navigation: ActivationNavigation;
 }
 
-interface ButtonActivation {
-  activateButton: (button: BoardButton) => void;
-}
-
-export function createButtonActivation({
+export function createButtonActivator({
   message,
   playback,
   navigation,
-}: ButtonActivationOptions): ButtonActivation {
+}: ButtonActivationOptions): (button: BoardButton) => void {
   function activateButton(button: BoardButton) {
     const intents = resolveButtonIntents(button);
 
@@ -108,5 +104,5 @@ export function createButtonActivation({
     }
   }
 
-  return { activateButton };
+  return activateButton;
 }

--- a/src/features/board/board-viewer.tsx
+++ b/src/features/board/board-viewer.tsx
@@ -11,7 +11,7 @@ import { switchScanningSx } from "@shared/switch-scanning/switch-scanning-presen
 import { safeAreaInset } from "@shared/theme/safe-area";
 import { useTileAppearanceConfig } from "@shared/tile-appearance/tile-appearance-store";
 import { useRef } from "react";
-import { createButtonActivation } from "./activation/button-activation";
+import { createButtonActivator } from "./activation/button-activation";
 import { Grid, type GridItemProps, type GridRowProps } from "./grid/grid";
 import { useBoardKeyboard } from "./keyboard/use-board-keyboard";
 import { BackspaceButton } from "./message/backspace-button";
@@ -70,7 +70,7 @@ function BoardViewerContent({ board }: BoardViewerProps) {
     gridRef.current?.scrollTo({ left: 0, top: 0 });
   }
 
-  const { activateButton } = createButtonActivation({
+  const activateButton = createButtonActivator({
     message,
     playback,
     navigation,

--- a/src/shared/playback/transports/speak.test.ts
+++ b/src/shared/playback/transports/speak.test.ts
@@ -1,5 +1,5 @@
 import { stubSpeech, stubVoices } from "@shared/testing/stub-speech";
-import { resetPersistedStores } from "@shared/utils/persisted-store";
+import { reloadPersistedStores } from "@shared/utils/persisted-store";
 import {
   setPitch,
   setRate,
@@ -74,7 +74,7 @@ describe("speak() utterance mapping", () => {
   test("clamps a malformed stored rate to the configured max", async () => {
     const speech = stubSpeech();
     localStorage.setItem("speech-config", JSON.stringify({ rate: 99 }));
-    resetPersistedStores();
+    reloadPersistedStores();
 
     await speak("hi");
 

--- a/src/shared/testing/global-setup.ts
+++ b/src/shared/testing/global-setup.ts
@@ -1,4 +1,4 @@
-import { resetPersistedStores } from "@shared/utils/persisted-store";
+import { reloadPersistedStores } from "@shared/utils/persisted-store";
 import { afterEach, beforeEach, vi } from "vitest";
 
 // Built-in AI namespaces the app reads off globalThis. Their ambient state can
@@ -16,11 +16,10 @@ beforeEach(() => {
     vi.stubGlobal(namespace, undefined);
   }
   clearStorage();
-  // Persisted stores snapshot localStorage at module import, so import order
-  // can leak state between test files. Reloading here resets every store to
-  // parse(undefined) regardless of import order. Note: setState() emits, so
-  // each store's persist() subscriber immediately writes its parsed defaults
-  // back into localStorage — storage isn't empty after this call, just reset.
-  resetPersistedStores();
+  // Persisted stores read localStorage at module import, so test-file import
+  // order can leak state. Reload every store from parse(undefined) to remove
+  // that dependency. Because setState() notifies persist() subscribers,
+  // localStorage is repopulated with parsed defaults—reset, not emptied.
+  reloadPersistedStores();
 });
 afterEach(clearStorage);

--- a/src/shared/utils/persisted-store.test.ts
+++ b/src/shared/utils/persisted-store.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from "vitest";
-import { createPersistedStore, resetPersistedStores } from "./persisted-store";
+import { createPersistedStore, reloadPersistedStores } from "./persisted-store";
 
 interface Counter {
   count: number;
@@ -46,12 +46,12 @@ describe("createPersistedStore", () => {
     expect(localStorage.getItem("counter")).toBe(JSON.stringify({ count: 9 }));
   });
 
-  test("resetPersistedStores reloads registered stores back to their parsed default", () => {
+  test("reloadPersistedStores reloads registered stores back to their parsed default", () => {
     const store = createPersistedStore("counter", parseCounter);
 
     store.setState({ count: 9 });
     localStorage.clear();
-    resetPersistedStores();
+    reloadPersistedStores();
 
     expect(store.getSnapshot()).toEqual({ count: 0 });
   });

--- a/src/shared/utils/persisted-store.ts
+++ b/src/shared/utils/persisted-store.ts
@@ -2,7 +2,7 @@ import { createExternalStore, type ExternalStore } from "./external-store";
 
 const reloaders = new Set<() => void>();
 
-export function resetPersistedStores(): void {
+export function reloadPersistedStores(): void {
   for (const reload of reloaders) {
     reload();
   }


### PR DESCRIPTION
## Summary

- return the button activation function directly instead of wrapping it in a one-method object
- promote the repeated setting slider UI into a shared app-settings component
- rename `resetPersistedStores` to `reloadPersistedStores` and update its tests and explanatory comments

## Why

These changes make the code read at the level of intent: activation is represented by the function callers use, repeated slider mechanics have one owner, and the persisted-store helper now names the operation it actually performs.

## Impact

This is a behavior-preserving refactor. Domain terminology remains unchanged: board buttons are still domain objects and tiles remain their current UI representation. The shared slider gives each setting the same accessible group structure.

## Validation

- `npm run lint`
- affected tests: 41 passed
- `npm test`: 76 files, 554 tests passed
- `npm run build`
