### PR TITLE
Rename AAC board components

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@
 > or tracking.**
 >
 > New here? The board domain lives under `src/features/board/`; start with
-> `board-viewer.tsx`.
+> `communication-board.tsx`.
 
 This document describes the app's modules, ownership boundaries, invariants, and
 load-bearing decisions. Setup and basic commands live in `README.md`; contributor
@@ -139,7 +139,7 @@ seam. Search by path or symbol name to locate the code.
 | ------------------------- | ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Composition               | `src/main.tsx`, `src/app/`, `src/pages/`                                                                     | `AppProviders` and the router assemble features; pages are route entry components.                                                                                            |
 | Active-board data         | `src/app/routing/loaders/`                                                                                   | The active board enters the render tree through `boardLoader`; ancillary summaries may use feature hooks.                                                                     |
-| Board domain              | `src/features/board/`                                                                                        | `board-viewer.tsx` orchestrates the grid, activation, message, navigation, keyboard, scanning, suggestions, and playback adapters.                                            |
+| Board domain              | `src/features/board/`                                                                                        | `communication-board.tsx` orchestrates the grid, activation, message, navigation, keyboard, scanning, suggestions, and playback adapters.                                     |
 | OBF runtime mapping       | `src/features/board/obf/`                                                                                    | `obfToBoard` and `parseAction` define how imported OBF becomes the in-memory domain model.                                                                                    |
 | Board ingestion           | `src/features/board/import/`                                                                                 | File picker, drag-and-drop, `?board=` URL, and PWA file-handler inputs converge on `importBoardSets` before storage writes.                                                   |
 | Board persistence         | `src/features/board/storage/`                                                                                | This is the only production reader/writer of IndexedDB. Schema changes belong in the `idb` upgrade path.                                                                      |

--- a/src/features/board/aac-symbol/aac-symbol.test.tsx
+++ b/src/features/board/aac-symbol/aac-symbol.test.tsx
@@ -1,18 +1,18 @@
 import { describe, expect, test } from "vitest";
 import { render } from "vitest-browser-react";
 import { TEST_IMAGE_SRC } from "../testing";
-import { CommunicationSymbol } from "./communication-symbol";
+import { AACSymbol } from "./aac-symbol";
 
-describe("CommunicationSymbol", () => {
+describe("AACSymbol", () => {
   test("renders no content when no image source or label is provided", async () => {
-    const screen = await render(<CommunicationSymbol label="" />);
+    const screen = await render(<AACSymbol label="" />);
 
     expect(screen.container.textContent).toBe("");
     expect(screen.container.querySelector("img")).toBeNull();
   });
 
   test("renders label when provided", async () => {
-    const screen = await render(<CommunicationSymbol label="Hello" />);
+    const screen = await render(<AACSymbol label="Hello" />);
 
     await expect.element(screen.getByText("Hello")).toBeVisible();
     expect(screen.container.querySelector("img")).toBeNull();
@@ -20,7 +20,7 @@ describe("CommunicationSymbol", () => {
 
   test("renders image when imageSrc is provided", async () => {
     const screen = await render(
-      <CommunicationSymbol imageSrc={TEST_IMAGE_SRC} label="" />,
+      <AACSymbol imageSrc={TEST_IMAGE_SRC} label="" />,
     );
 
     const img = screen.container.querySelector("img");
@@ -31,7 +31,7 @@ describe("CommunicationSymbol", () => {
 
   test("renders both image and label when both are provided", async () => {
     const screen = await render(
-      <CommunicationSymbol imageSrc={TEST_IMAGE_SRC} label="Action" />,
+      <AACSymbol imageSrc={TEST_IMAGE_SRC} label="Action" />,
     );
 
     await expect.element(screen.getByText("Action")).toBeVisible();
@@ -40,7 +40,7 @@ describe("CommunicationSymbol", () => {
 
   test("places the label above the image when labelPlacement is top", async () => {
     const screen = await render(
-      <CommunicationSymbol
+      <AACSymbol
         imageSrc={TEST_IMAGE_SRC}
         label="Action"
         labelPlacement="top"
@@ -49,14 +49,14 @@ describe("CommunicationSymbol", () => {
 
     const container = screen.getByText("Action").element().parentElement;
     if (!container) {
-      throw new Error("Communication symbol container not found");
+      throw new Error("AAC symbol container not found");
     }
     expect(getComputedStyle(container).flexDirection).toBe("column-reverse");
   });
 
   test("keeps the label accessible when labelPlacement is hidden", async () => {
     const screen = await render(
-      <CommunicationSymbol
+      <AACSymbol
         imageSrc={TEST_IMAGE_SRC}
         label="Action"
         labelPlacement="hidden"
@@ -68,7 +68,7 @@ describe("CommunicationSymbol", () => {
 
   test("takes no layout space for the label when labelPlacement is hidden", async () => {
     const screen = await render(
-      <CommunicationSymbol
+      <AACSymbol
         imageSrc={TEST_IMAGE_SRC}
         label="Action"
         labelPlacement="hidden"

--- a/src/features/board/aac-symbol/aac-symbol.tsx
+++ b/src/features/board/aac-symbol/aac-symbol.tsx
@@ -2,17 +2,17 @@ import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import visuallyHidden from "@mui/utils/visuallyHidden";
 
-interface CommunicationSymbolProps {
+interface AACSymbolProps {
   imageSrc?: string;
   label: string;
   labelPlacement?: "top" | "bottom" | "hidden";
 }
 
-export function CommunicationSymbol({
+export function AACSymbol({
   imageSrc,
   label,
   labelPlacement = "bottom",
-}: CommunicationSymbolProps) {
+}: AACSymbolProps) {
   return (
     <Box
       sx={{

--- a/src/features/board/communication-board.test.tsx
+++ b/src/features/board/communication-board.test.tsx
@@ -17,9 +17,9 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { userEvent } from "vitest/browser";
 import { seedBoardSets, TEST_IMAGE_SRC } from "./testing";
 import {
-  renderBoardViewer,
+  renderCommunicationBoard,
   TWO_BUTTON_BOARD,
-} from "./testing/render-board-viewer";
+} from "./testing/render-communication-board";
 
 const SPELL_THEN_SPEAK_BOARD: OBFBoard = {
   format: "open-board-0.1",
@@ -94,7 +94,7 @@ function pressMouseSwitch(button: number): void {
   );
 }
 
-describe("BoardViewer", () => {
+describe("CommunicationBoard", () => {
   let speech: ReturnType<typeof stubSpeech>;
 
   beforeEach(() => {
@@ -103,7 +103,7 @@ describe("BoardViewer", () => {
   });
 
   test("composing tiles and pressing play speaks the merged message", async () => {
-    const screen = await renderBoardViewer(TWO_BUTTON_BOARD);
+    const screen = await renderCommunicationBoard(TWO_BUTTON_BOARD);
 
     await screen.getByRole("button", { name: "hello" }).click();
     await screen.getByRole("button", { name: "world" }).click();
@@ -120,7 +120,7 @@ describe("BoardViewer", () => {
 
   test("keeps the message play action visible while a tile speaks", async () => {
     speech.speak.mockImplementationOnce(() => undefined);
-    const screen = await renderBoardViewer(TWO_BUTTON_BOARD);
+    const screen = await renderCommunicationBoard(TWO_BUTTON_BOARD);
 
     await screen.getByRole("button", { name: "hello" }).click();
 
@@ -130,7 +130,7 @@ describe("BoardViewer", () => {
   });
 
   test("enables message playback only after content is composed", async () => {
-    const screen = await renderBoardViewer(TWO_BUTTON_BOARD);
+    const screen = await renderCommunicationBoard(TWO_BUTTON_BOARD);
     const play = screen.getByRole("button", { name: "Play message" });
 
     await expect.element(play).toBeDisabled();
@@ -141,7 +141,7 @@ describe("BoardViewer", () => {
   });
 
   test("a button that spells then speaks in one tap speaks the spelled letter", async () => {
-    const screen = await renderBoardViewer(SPELL_THEN_SPEAK_BOARD);
+    const screen = await renderCommunicationBoard(SPELL_THEN_SPEAK_BOARD);
 
     await screen.getByRole("button", { name: "S", exact: true }).click();
 
@@ -154,7 +154,7 @@ describe("BoardViewer", () => {
   test("names the tile grid with the board's name", async () => {
     const namedBoard: OBFBoard = { ...TWO_BUTTON_BOARD, name: "Core words" };
 
-    const screen = await renderBoardViewer(namedBoard);
+    const screen = await renderCommunicationBoard(namedBoard);
 
     await expect
       .element(screen.getByRole("grid", { name: "Core words" }))
@@ -164,7 +164,7 @@ describe("BoardViewer", () => {
   test("does not scroll the grid when Home navigates to the home board", async () => {
     await seedBoardSets([{ setId: "set-1", rootBoardId: "root-board" }]);
 
-    const screen = await renderBoardViewer(LARGE_GRID_BOARD, [
+    const screen = await renderCommunicationBoard(LARGE_GRID_BOARD, [
       "/sets/set-1/boards/other-board",
     ]);
     const grid = screen.getByRole("grid").element();
@@ -190,7 +190,7 @@ describe("BoardViewer", () => {
   test("scrolls the grid to both origins when Home is clicked from Home", async () => {
     await seedBoardSets([{ setId: "set-1", rootBoardId: "root-board" }]);
 
-    const screen = await renderBoardViewer(LARGE_GRID_BOARD, [
+    const screen = await renderCommunicationBoard(LARGE_GRID_BOARD, [
       "/sets/set-1/boards/root-board",
     ]);
     const grid = screen.getByRole("grid").element();
@@ -216,7 +216,7 @@ describe("BoardViewer", () => {
   });
 
   test("falls back to a generic grid name when the board is unnamed", async () => {
-    const screen = await renderBoardViewer(TWO_BUTTON_BOARD);
+    const screen = await renderCommunicationBoard(TWO_BUTTON_BOARD);
 
     await expect
       .element(screen.getByRole("grid", { name: "Communication board" }))
@@ -227,7 +227,7 @@ describe("BoardViewer", () => {
     setSwitchScanningEnabled(true);
     setSwitchScanningMethod("step");
 
-    const screen = await renderBoardViewer(ROW_SCAN_BOARD);
+    const screen = await renderCommunicationBoard(ROW_SCAN_BOARD);
     const firstRow = screen.getByRole("row").nth(0);
     const secondRow = screen.getByRole("row").nth(1);
     const yes = screen.getByRole("button", { name: "yes", exact: true });
@@ -260,7 +260,7 @@ describe("BoardViewer", () => {
     setSwitchInput("next", { kind: "mouse", button: 3 });
     setSwitchInput("select", { kind: "mouse", button: 4 });
 
-    const screen = await renderBoardViewer(ROW_SCAN_BOARD);
+    const screen = await renderCommunicationBoard(ROW_SCAN_BOARD);
     const firstRow = screen.getByRole("row").nth(0);
     const secondRow = screen.getByRole("row").nth(1);
     const yes = screen.getByRole("button", { name: "yes", exact: true });
@@ -280,7 +280,7 @@ describe("BoardViewer", () => {
     setSwitchScanningEnabled(true);
     setSwitchScanningMethod("step");
 
-    const screen = await renderBoardViewer(TWO_BUTTON_BOARD, [
+    const screen = await renderCommunicationBoard(TWO_BUTTON_BOARD, [
       {
         pathname: "/sets/set-1/boards/other-board",
         state: { backStack: ["root-board"] },
@@ -321,7 +321,7 @@ describe("BoardViewer", () => {
     setSwitchScanningEnabled(true);
     setSwitchScanningMethod("step");
 
-    const screen = await renderBoardViewer(TWO_BUTTON_BOARD);
+    const screen = await renderCommunicationBoard(TWO_BUTTON_BOARD);
 
     await screen.getByRole("button", { name: "hello" }).click();
 
@@ -346,7 +346,7 @@ describe("BoardViewer", () => {
     try {
       setThemeMode("light");
 
-      const screen = await renderBoardViewer(ROW_SCAN_BOARD);
+      const screen = await renderCommunicationBoard(ROW_SCAN_BOARD);
       const firstRow = screen.getByRole("row").nth(0);
       const hello = screen.getByRole("button", {
         name: "hello",
@@ -388,7 +388,7 @@ describe("BoardViewer", () => {
   });
 
   test("leaves native Space activation intact while switch scanning is off", async () => {
-    const screen = await renderBoardViewer(TWO_BUTTON_BOARD);
+    const screen = await renderCommunicationBoard(TWO_BUTTON_BOARD);
     const hello = screen.getByRole("button", { name: "hello" });
 
     hello.element().focus();
@@ -407,7 +407,7 @@ describe("BoardViewer", () => {
     setSwitchScanningEnabled(true);
     setSwitchScanningMethod("step");
 
-    const screen = await renderBoardViewer(TWO_BUTTON_BOARD);
+    const screen = await renderCommunicationBoard(TWO_BUTTON_BOARD);
     const enableSuggestions = screen.getByRole("button", {
       name: "Enable suggestions",
     });
@@ -429,13 +429,13 @@ describe("BoardViewer", () => {
   });
 
   test("has no accessibility violations", async () => {
-    const screen = await renderBoardViewer(TWO_BUTTON_BOARD);
+    const screen = await renderCommunicationBoard(TWO_BUTTON_BOARD);
 
     await expectNoA11yViolations(screen.container);
   });
 
   test("has no accessibility violations with a composed message", async () => {
-    const screen = await renderBoardViewer(SYMBOL_BOARD);
+    const screen = await renderCommunicationBoard(SYMBOL_BOARD);
 
     await screen.getByRole("button", { name: "hello" }).click();
     await screen.getByRole("button", { name: "world" }).click();

--- a/src/features/board/communication-board.tsx
+++ b/src/features/board/communication-board.tsx
@@ -30,7 +30,7 @@ import { SuggestionBar } from "./suggestions/suggestion-bar";
 import { useMessageSuggestions } from "./suggestions/use-message-suggestions";
 import type { Board, BoardButton } from "./types";
 
-interface BoardViewerProps {
+interface CommunicationBoardProps {
   board: Board;
 }
 
@@ -47,15 +47,15 @@ const boardRootSx = (theme: Theme) => ({
   },
 });
 
-export function BoardViewer({ board }: BoardViewerProps) {
+export function CommunicationBoard({ board }: CommunicationBoardProps) {
   return (
     <SwitchScanningBoundary>
-      <BoardViewerContent board={board} />
+      <CommunicationBoardContent board={board} />
     </SwitchScanningBoundary>
   );
 }
 
-function BoardViewerContent({ board }: BoardViewerProps) {
+function CommunicationBoardContent({ board }: CommunicationBoardProps) {
   const t = useTranslate();
   const { direction } = useLanguage();
   const isSmallScreen = useMediaQuery((theme) => theme.breakpoints.down("sm"));

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -1,6 +1,6 @@
 export { BoardSetLibrary } from "./board-sets/board-set-library";
 export { getBoardSets } from "./board-sets/board-sets-store";
-export { BoardViewer } from "./board-viewer";
+export { CommunicationBoard } from "./communication-board";
 export { BoardFileDropOverlay } from "./import/board-file-drop-overlay";
 export { importBoardFromUrl } from "./import/import-from-url";
 export { useBoardFileDrop } from "./import/use-board-file-drop";

--- a/src/features/board/keyboard/use-board-keyboard.test.tsx
+++ b/src/features/board/keyboard/use-board-keyboard.test.tsx
@@ -3,9 +3,9 @@ import { preventSpeechEnd, stubSpeech } from "@shared/testing/stub-speech";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { userEvent } from "vitest/browser";
 import {
-  renderBoardViewer,
+  renderCommunicationBoard,
   TWO_BUTTON_BOARD,
-} from "../testing/render-board-viewer";
+} from "../testing/render-communication-board";
 
 describe("board keyboard shortcuts", () => {
   let speech: ReturnType<typeof stubSpeech>;
@@ -16,7 +16,7 @@ describe("board keyboard shortcuts", () => {
   });
 
   test("Backspace from a focused tile removes a character from a text-only message part", async () => {
-    const screen = await renderBoardViewer(TWO_BUTTON_BOARD);
+    const screen = await renderCommunicationBoard(TWO_BUTTON_BOARD);
     await screen.getByRole("button", { name: "hello" }).click();
     await screen.getByRole("button", { name: "world" }).click();
 
@@ -35,7 +35,7 @@ describe("board keyboard shortcuts", () => {
   });
 
   test("Backspace works board-wide — even from a non-grid button", async () => {
-    const screen = await renderBoardViewer(TWO_BUTTON_BOARD);
+    const screen = await renderCommunicationBoard(TWO_BUTTON_BOARD);
     await screen.getByRole("button", { name: "hello" }).click();
     await screen.getByRole("button", { name: "world" }).click();
 
@@ -51,7 +51,7 @@ describe("board keyboard shortcuts", () => {
   });
 
   test("⌘+Enter speaks the message", async () => {
-    const screen = await renderBoardViewer(TWO_BUTTON_BOARD);
+    const screen = await renderCommunicationBoard(TWO_BUTTON_BOARD);
     await screen.getByRole("button", { name: "hello" }).click();
     await screen.getByRole("button", { name: "world" }).click();
 
@@ -66,7 +66,7 @@ describe("board keyboard shortcuts", () => {
   });
 
   test("Escape stops playback in progress", async () => {
-    const screen = await renderBoardViewer(TWO_BUTTON_BOARD);
+    const screen = await renderCommunicationBoard(TWO_BUTTON_BOARD);
     await screen.getByRole("button", { name: "hello" }).click();
 
     preventSpeechEnd(speech.speak);

--- a/src/features/board/message/message-bar.tsx
+++ b/src/features/board/message/message-bar.tsx
@@ -1,6 +1,6 @@
 import Stack from "@mui/material/Stack";
 import { useEffect, useRef } from "react";
-import { CommunicationSymbol } from "../communication-symbol/communication-symbol";
+import { AACSymbol } from "../aac-symbol/aac-symbol";
 import type { MessagePart } from "./message-types";
 import { PlayButton, type PlayButtonRootProps } from "./play-button";
 
@@ -92,10 +92,7 @@ export function MessageBar({
                     : "none",
                 })}
               >
-                <CommunicationSymbol
-                  label={part.label ?? ""}
-                  imageSrc={part.imageSrc}
-                />
+                <AACSymbol label={part.label ?? ""} imageSrc={part.imageSrc} />
               </Stack>
             );
           })}

--- a/src/features/board/testing/render-communication-board.tsx
+++ b/src/features/board/testing/render-communication-board.tsx
@@ -2,7 +2,7 @@ import { AppProviders } from "@shared/providers/app-providers";
 import type { OBFBoard } from "@shayc/open-board-format";
 import { MemoryRouter, type InitialEntry } from "react-router";
 import { render } from "vitest-browser-react";
-import { BoardViewer } from "../board-viewer";
+import { CommunicationBoard } from "../communication-board";
 import { obfToBoard } from "../obf/obf-to-board";
 
 export const TWO_BUTTON_BOARD: OBFBoard = {
@@ -16,7 +16,7 @@ export const TWO_BUTTON_BOARD: OBFBoard = {
   grid: { rows: 1, columns: 2, order: [["btn-1", "btn-2"]] },
 };
 
-export function renderBoardViewer(
+export function renderCommunicationBoard(
   obfBoard: OBFBoard,
   initialEntries: InitialEntry[] = ["/"],
 ) {
@@ -24,7 +24,7 @@ export function renderBoardViewer(
     <MemoryRouter initialEntries={initialEntries}>
       <AppProviders>
         <div style={{ height: "100vh" }}>
-          <BoardViewer board={obfToBoard(obfBoard)} />
+          <CommunicationBoard board={obfToBoard(obfBoard)} />
         </div>
       </AppProviders>
     </MemoryRouter>,

--- a/src/features/board/tile/tile.tsx
+++ b/src/features/board/tile/tile.tsx
@@ -1,7 +1,7 @@
 import Button, { buttonClasses, type ButtonProps } from "@mui/material/Button";
 import { alpha } from "@mui/material/styles";
 import { mergeSx } from "@shared/theme/merge-sx";
-import { CommunicationSymbol } from "../communication-symbol/communication-symbol";
+import { AACSymbol } from "../aac-symbol/aac-symbol";
 
 interface TileOwnProps {
   label: string;
@@ -18,7 +18,7 @@ type TileProps = TileOwnProps &
 
 // Scale an author-supplied color's OKLCH chroma by the board's saturation
 // setting so bright third-party boards can be toned down without shifting hue
-// or perceived lightness. The var fallback keeps colors intact outside BoardViewer.
+// or perceived lightness. The var fallback keeps colors intact outside CommunicationBoard.
 function desaturate(color: string): string {
   return `oklch(from ${color} l calc(c * var(--tile-saturation, 1)) h)`;
 }
@@ -120,7 +120,7 @@ export function Tile({
         sx,
       )}
     >
-      <CommunicationSymbol label={label} imageSrc={imageSrc} />
+      <AACSymbol label={label} imageSrc={imageSrc} />
     </Button>
   );
 }

--- a/src/pages/board-page.tsx
+++ b/src/pages/board-page.tsx
@@ -1,4 +1,4 @@
-import { BoardViewer, type HydratedBoard } from "@features/board";
+import { CommunicationBoard, type HydratedBoard } from "@features/board";
 import { useLoaderData } from "react-router";
 
 export function BoardPage() {
@@ -7,7 +7,7 @@ export function BoardPage() {
   return (
     <>
       <title>{board.name}</title>
-      <BoardViewer board={board} />
+      <CommunicationBoard board={board} />
     </>
   );
 }


### PR DESCRIPTION
## Summary

- rename `CommunicationSymbol` and its files to `AACSymbol`
- rename `BoardViewer` and its files to `CommunicationBoard`
- update the shared test renderer, imports, exports, tests, comments, and architecture documentation

## Why

Use established AAC terminology for symbols and describe the board as the interactive communication surface rather than a passive viewer.

## Impact

This is an internal naming refactor with no intended behavior or UI changes.

## Validation

- `npm run lint`
- `npm test` — 551 tests passed
- `npm run build`
