### PR TITLE
Clarify board vocabulary

### DIFF
--- a/src/app/library/library-drawer.tsx
+++ b/src/app/library/library-drawer.tsx
@@ -1,5 +1,5 @@
 import { LIBRARY_DRAWER_WIDTH } from "@app/shell/drawer-width";
-import { BoardSetLibrary, boardSetPath } from "@features/board";
+import { BoardSetLibrary, rootBoardPath } from "@features/board";
 import ViewSidebarOutlinedIcon from "@mui/icons-material/ViewSidebarOutlined";
 import Box from "@mui/material/Box";
 import Drawer from "@mui/material/Drawer";
@@ -87,7 +87,7 @@ export function LibraryDrawer({
         <BoardSetLibrary
           selectedSetId={activeSetId}
           onSelect={(boardSet) => {
-            void navigate(boardSetPath(boardSet));
+            void navigate(rootBoardPath(boardSet));
             closeOnNavigate?.();
           }}
         />

--- a/src/app/routing/loaders/board-set-index-loader.ts
+++ b/src/app/routing/loaders/board-set-index-loader.ts
@@ -1,4 +1,4 @@
-import { boardSetPath, getBoardSet, InvalidIdError } from "@features/board";
+import { getBoardSet, InvalidIdError, rootBoardPath } from "@features/board";
 import { data, redirect, type LoaderFunctionArgs } from "react-router";
 import { createLocalizedRouteError, routeErrorCodes } from "../route-error";
 
@@ -23,5 +23,5 @@ export async function boardSetIndexLoader({
     });
   }
 
-  return redirect(boardSetPath(boardSet));
+  return redirect(rootBoardPath(boardSet));
 }

--- a/src/app/routing/loaders/root-index-loader.ts
+++ b/src/app/routing/loaders/root-index-loader.ts
@@ -1,5 +1,5 @@
 import {
-  boardSetPath,
+  rootBoardPath,
   getBoardSets,
   importBoardFromUrl,
 } from "@features/board";
@@ -13,7 +13,7 @@ const DEFAULT_BOARD_URL = `${import.meta.env.BASE_URL}quick-core-24.obz`;
 // ID, while rejected URLs and failed imports surface as localized errors.
 async function importFromBoardUrl(boardUrl: string): Promise<Response> {
   try {
-    return redirect(boardSetPath(await importBoardFromUrl(boardUrl)));
+    return redirect(rootBoardPath(await importBoardFromUrl(boardUrl)));
   } catch {
     throw importFailed();
   }
@@ -36,8 +36,8 @@ export async function rootIndexLoader({
 
   const [boardSet] = await getBoardSets();
   if (boardSet) {
-    return redirect(boardSetPath(boardSet));
+    return redirect(rootBoardPath(boardSet));
   }
 
-  return redirect(boardSetPath(await importBoardFromUrl(DEFAULT_BOARD_URL)));
+  return redirect(rootBoardPath(await importBoardFromUrl(DEFAULT_BOARD_URL)));
 }

--- a/src/features/board/activation/button-activation.ts
+++ b/src/features/board/activation/button-activation.ts
@@ -1,10 +1,10 @@
 import type { PlaybackOutcome } from "@shared/playback/playback-context";
 import { assertNever } from "@shared/utils/assert-never";
 import {
+  applyBackspace,
   appendSpace,
   appendTextToLastPart,
   createPart,
-  dropLastPart,
 } from "../message/message-transforms";
 import type { MessagePart } from "../message/message-types";
 import type { BoardButton } from "../types";
@@ -65,7 +65,7 @@ export function createButtonActivation({
               parts = appendSpace(parts);
               break;
             case "backspace":
-              parts = dropLastPart(parts);
+              parts = applyBackspace(parts);
               break;
             case "clear":
               parts = [];

--- a/src/features/board/communication-board.tsx
+++ b/src/features/board/communication-board.tsx
@@ -80,7 +80,7 @@ function CommunicationBoardContent({ board }: CommunicationBoardProps) {
   const hasMessage = message.parts.length > 0;
   const scanning = useBoardScanning({
     hasMessage,
-    isPlaying: playback.isPlaying,
+    isMessagePlaying: playback.isMessagePlaying,
     navigation: {
       canGoBack: navigation.canGoBack,
       canGoHome: navigation.canGoHome,
@@ -164,7 +164,7 @@ function CommunicationBoardContent({ board }: CommunicationBoardProps) {
           <BackspaceButton
             {...scanning.backspaceTarget}
             disabled={!hasMessage}
-            onPress={message.removeLastPart}
+            onPress={message.backspace}
             onLongPress={message.clear}
           />
         )}
@@ -205,7 +205,7 @@ function CommunicationBoardContent({ board }: CommunicationBoardProps) {
           <BackspaceButton
             {...scanning.backspaceTarget}
             disabled={!hasMessage}
-            onPress={message.removeLastPart}
+            onPress={message.backspace}
             onLongPress={message.clear}
           />
         </Toolbar>

--- a/src/features/board/import/use-import-board-files.ts
+++ b/src/features/board/import/use-import-board-files.ts
@@ -2,7 +2,7 @@ import { m } from "@paraglide/messages.js";
 import { useSnackbar } from "@shared/snackbar/use-snackbar";
 import { OBFError } from "@shayc/open-board-format";
 import { useNavigate } from "react-router";
-import { boardSetPath } from "../navigation/board-paths";
+import { rootBoardPath } from "../navigation/board-paths";
 import { BOARD_FILE_ACCEPT } from "./board-file-formats";
 import { importBoardSets, type ImportResult } from "./board-import";
 import { openFiles } from "./file-picker";
@@ -62,7 +62,7 @@ export function useImportBoardFiles(): UseImportBoardFilesReturn {
     }
 
     const [result] = results;
-    void navigate(boardSetPath(result));
+    void navigate(rootBoardPath(result));
   }
 
   async function pickAndImportBoardFiles() {

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -8,7 +8,7 @@ export { useFileHandlerLaunch } from "./import/use-file-handler-launch";
 export {
   BOARD_SEGMENT,
   BOARD_SET_SEGMENT,
-  boardSetPath,
+  rootBoardPath,
 } from "./navigation/board-paths";
 export { BoardSelector } from "./navigation/board-selector";
 export { hydrateBoard } from "./storage/board-hydration";

--- a/src/features/board/keyboard/board-key-resolver.test.ts
+++ b/src/features/board/keyboard/board-key-resolver.test.ts
@@ -6,7 +6,7 @@ function key(overrides: Partial<KeyEventLike>): KeyEventLike {
 }
 
 describe("resolveBoardKey", () => {
-  test("Backspace removes the last part", () => {
+  test("Backspace applies message backspace behavior", () => {
     expect(resolveBoardKey(key({ key: "Backspace" }), false)).toEqual({
       kind: "backspace",
     });

--- a/src/features/board/keyboard/board-key-resolver.ts
+++ b/src/features/board/keyboard/board-key-resolver.ts
@@ -17,11 +17,11 @@ export interface KeyEventLike {
  */
 export function resolveBoardKey(
   event: KeyEventLike,
-  isPlaying: boolean,
+  isMessagePlaying: boolean,
 ): BoardKeyAction | null {
   if (event.metaKey || event.ctrlKey) {
     if (event.key === "Enter") {
-      return isPlaying ? null : { kind: "speak" };
+      return isMessagePlaying ? null : { kind: "speak" };
     }
 
     if (event.key === "Backspace") {
@@ -32,7 +32,7 @@ export function resolveBoardKey(
   }
 
   if (event.key === "Escape") {
-    return isPlaying ? { kind: "stop" } : null;
+    return isMessagePlaying ? { kind: "stop" } : null;
   }
 
   if (event.key === "Backspace") {

--- a/src/features/board/keyboard/use-board-keyboard.ts
+++ b/src/features/board/keyboard/use-board-keyboard.ts
@@ -6,8 +6,11 @@ import type { UseBoardPlaybackReturn } from "../playback/use-board-playback";
 import { resolveBoardKey } from "./board-key-resolver";
 
 interface UseBoardKeyboardOptions {
-  message: Pick<UseMessageReturn, "parts" | "removeLastPart" | "clear">;
-  playback: Pick<UseBoardPlaybackReturn, "playMessage" | "stop" | "isPlaying">;
+  message: Pick<UseMessageReturn, "parts" | "backspace" | "clear">;
+  playback: Pick<
+    UseBoardPlaybackReturn,
+    "playMessage" | "stop" | "isMessagePlaying"
+  >;
 }
 
 interface UseBoardKeyboardReturn {
@@ -22,7 +25,7 @@ export function useBoardKeyboard({
     onKeyDown: (event) => {
       const action = resolveBoardKey(
         { key: event.key, metaKey: event.metaKey, ctrlKey: event.ctrlKey },
-        playback.isPlaying,
+        playback.isMessagePlaying,
       );
 
       if (!action) {
@@ -34,7 +37,7 @@ export function useBoardKeyboard({
       event.preventDefault();
       switch (action.kind) {
         case "backspace":
-          message.removeLastPart();
+          message.backspace();
           break;
         case "clear":
           message.clear();

--- a/src/features/board/message/message-transforms.test.ts
+++ b/src/features/board/message/message-transforms.test.ts
@@ -3,7 +3,7 @@ import {
   appendPart,
   appendSpace,
   appendTextToLastPart,
-  dropLastPart,
+  applyBackspace,
 } from "./message-transforms";
 import type { MessagePart } from "./message-types";
 
@@ -91,9 +91,9 @@ describe("appendTextToLastPart", () => {
   });
 });
 
-describe("dropLastPart", () => {
+describe("applyBackspace", () => {
   test("removes a single character if the last part is text-only", () => {
-    const parts = dropLastPart([
+    const parts = applyBackspace([
       { id: "1", label: "hello" },
       { id: "2", label: "world" },
     ]);
@@ -105,7 +105,7 @@ describe("dropLastPart", () => {
   });
 
   test("removes the entire part if it is text-only but has 1 or 0 characters", () => {
-    const parts = dropLastPart([
+    const parts = applyBackspace([
       { id: "1", label: "hello" },
       { id: "2", label: "w" },
     ]);
@@ -114,7 +114,7 @@ describe("dropLastPart", () => {
   });
 
   test("removes the entire part if it is not text-only", () => {
-    const parts = dropLastPart([
+    const parts = applyBackspace([
       { id: "1", label: "hello" },
       { id: "2", label: "world", imageSrc: "img.png" },
     ]);
@@ -123,10 +123,10 @@ describe("dropLastPart", () => {
   });
 
   test("returns an empty array when there is only one part and it gets removed", () => {
-    expect(dropLastPart([{ id: "1", label: "h" }])).toEqual([]);
+    expect(applyBackspace([{ id: "1", label: "h" }])).toEqual([]);
   });
 
   test("returns an empty array when already empty", () => {
-    expect(dropLastPart([])).toEqual([]);
+    expect(applyBackspace([])).toEqual([]);
   });
 });

--- a/src/features/board/message/message-transforms.ts
+++ b/src/features/board/message/message-transforms.ts
@@ -37,7 +37,7 @@ export function appendTextToLastPart(
   });
 }
 
-export function dropLastPart(parts: MessagePart[]): MessagePart[] {
+export function applyBackspace(parts: MessagePart[]): MessagePart[] {
   const lastPart = parts.at(-1);
   if (!lastPart) {
     return parts;

--- a/src/features/board/message/use-message.ts
+++ b/src/features/board/message/use-message.ts
@@ -1,12 +1,12 @@
 import { useState } from "react";
-import { createPart, dropLastPart } from "./message-transforms";
+import { applyBackspace, createPart } from "./message-transforms";
 import type { MessagePart } from "./message-types";
 
 export interface UseMessageReturn {
   parts: MessagePart[];
   text: string;
   setFromText: (input: string) => void;
-  removeLastPart: () => void;
+  backspace: () => void;
   setParts: (parts: MessagePart[]) => void;
   clear: () => void;
 }
@@ -25,8 +25,8 @@ export function useMessage(): UseMessageReturn {
     );
   }
 
-  function removeLastPart() {
-    setParts((prev) => dropLastPart(prev));
+  function backspace() {
+    setParts((prev) => applyBackspace(prev));
   }
 
   function clear() {
@@ -37,7 +37,7 @@ export function useMessage(): UseMessageReturn {
     parts,
     text,
     setFromText,
-    removeLastPart,
+    backspace,
     setParts,
     clear,
   };

--- a/src/features/board/navigation/board-paths.ts
+++ b/src/features/board/navigation/board-paths.ts
@@ -14,7 +14,7 @@ export function boardPath({
   return generatePath(BOARD_ROUTE_PATTERN, { setId, boardId });
 }
 
-export function boardSetPath({
+export function rootBoardPath({
   setId,
   rootBoardId,
 }: {

--- a/src/features/board/navigation/use-board-navigation.ts
+++ b/src/features/board/navigation/use-board-navigation.ts
@@ -1,6 +1,6 @@
 import { useLocation, useMatch, useNavigate } from "react-router";
 import { useBoardSets } from "../board-sets/use-board-sets";
-import { BOARD_ROUTE_PATTERN, boardPath, boardSetPath } from "./board-paths";
+import { BOARD_ROUTE_PATTERN, boardPath, rootBoardPath } from "./board-paths";
 
 export interface UseBoardNavigationReturn {
   setId: string | undefined;
@@ -68,7 +68,7 @@ export function useBoardNavigation(): UseBoardNavigationReturn {
       return;
     }
 
-    void navigate(boardSetPath({ setId, rootBoardId }), {
+    void navigate(rootBoardPath({ setId, rootBoardId }), {
       state: { backStack: [] },
       replace: true,
     });

--- a/src/features/board/playback/board-playback-message-bar.tsx
+++ b/src/features/board/playback/board-playback-message-bar.tsx
@@ -24,7 +24,7 @@ export function BoardPlaybackMessageBar({
     <MessageBar
       parts={parts}
       activePartId={highlightActivePart ? activePartId : null}
-      isPlaying={playback.isPlaying}
+      isPlaying={playback.isMessagePlaying}
       slotProps={{ playButton: playButtonProps }}
       onPlayClick={() => void playback.playMessage(parts)}
       onStopClick={playback.stop}

--- a/src/features/board/playback/use-board-playback.test.ts
+++ b/src/features/board/playback/use-board-playback.test.ts
@@ -94,7 +94,7 @@ describe("useBoardPlayback", () => {
     expect(audio.play).not.toHaveBeenCalled();
   });
 
-  test("reports isPlaying true during playback and false after it resolves", async () => {
+  test("reports isMessagePlaying true during playback and false after it resolves", async () => {
     let resolveSpeak: (() => void) | undefined;
     speech.speak.mockImplementationOnce((utterance) => {
       resolveSpeak = () => {
@@ -108,12 +108,12 @@ describe("useBoardPlayback", () => {
 
     const playPromise = result.current.playMessage(parts);
     await rerender();
-    expect(result.current.isPlaying).toBe(true);
+    expect(result.current.isMessagePlaying).toBe(true);
 
     resolveSpeak?.();
     await playPromise;
     await rerender();
-    expect(result.current.isPlaying).toBe(false);
+    expect(result.current.isMessagePlaying).toBe(false);
   });
 
   test("does not present tile speech as message playback", async () => {
@@ -123,14 +123,14 @@ describe("useBoardPlayback", () => {
     const playPromise = result.current.playPart({ id: "1", label: "hi" });
     await rerender();
 
-    expect(result.current.isPlaying).toBe(false);
+    expect(result.current.isMessagePlaying).toBe(false);
     expect(result.current.activePartId).toBeNull();
 
     result.current.stop();
     await playPromise;
   });
 
-  test("stop() cancels speech and clears isPlaying", async () => {
+  test("stop() cancels speech and clears isMessagePlaying", async () => {
     let resolveSpeak: (() => void) | undefined;
     speech.speak.mockImplementationOnce((utterance) => {
       resolveSpeak = () => {
@@ -149,13 +149,13 @@ describe("useBoardPlayback", () => {
     await rerender();
 
     expect(speech.cancel).toHaveBeenCalled();
-    expect(result.current.isPlaying).toBe(false);
+    expect(result.current.isMessagePlaying).toBe(false);
 
     resolveSpeak?.();
     await playPromise;
   });
 
-  test("resets isPlaying to false after a speech error", async () => {
+  test("resets isMessagePlaying to false after a speech error", async () => {
     speech.speak.mockImplementationOnce((utterance) => {
       queueMicrotask(() => {
         utterance.onerror?.({
@@ -171,7 +171,7 @@ describe("useBoardPlayback", () => {
     await expect(result.current.playMessage(parts)).resolves.toBe("completed");
     await rerender();
 
-    expect(result.current.isPlaying).toBe(false);
+    expect(result.current.isMessagePlaying).toBe(false);
   });
 
   test("has no active part before playback starts", async () => {

--- a/src/features/board/playback/use-board-playback.ts
+++ b/src/features/board/playback/use-board-playback.ts
@@ -11,7 +11,7 @@ const MESSAGE_SOURCE = "board-message";
 const TILE_SOURCE = "board-tile";
 
 export interface UseBoardPlaybackReturn {
-  isPlaying: boolean;
+  isMessagePlaying: boolean;
   playMessage: (parts: MessagePart[]) => Promise<PlaybackOutcome>;
   playPart: (part: MessagePart) => Promise<PlaybackOutcome>;
   stop: () => void;
@@ -19,7 +19,7 @@ export interface UseBoardPlaybackReturn {
 
 export function useBoardPlayback(): UseBoardPlaybackReturn {
   const playback = usePlayback();
-  const isPlaying = useIsPlaybackActive(MESSAGE_SOURCE);
+  const isMessagePlaying = useIsPlaybackActive(MESSAGE_SOURCE);
 
   function playMessage(parts: MessagePart[]) {
     return playback.play({
@@ -33,7 +33,7 @@ export function useBoardPlayback(): UseBoardPlaybackReturn {
   }
 
   return {
-    isPlaying,
+    isMessagePlaying,
     playMessage,
     playPart,
     stop: playback.stop,

--- a/src/features/board/scanning/use-board-scanning.ts
+++ b/src/features/board/scanning/use-board-scanning.ts
@@ -14,7 +14,7 @@ import {
 
 interface UseBoardScanningOptions {
   hasMessage: boolean;
-  isPlaying: boolean;
+  isMessagePlaying: boolean;
   navigation: {
     canGoBack: boolean;
     canGoHome: boolean;
@@ -34,14 +34,14 @@ interface UseBoardScanningReturn {
 
 export function useBoardScanning({
   hasMessage,
-  isPlaying,
+  isMessagePlaying,
   navigation,
   suggestions,
 }: UseBoardScanningOptions): UseBoardScanningReturn {
   const t = useTranslate();
   const playTarget = useScanTarget({
     id: PLAY_SCAN_ID,
-    label: isPlaying ? t(m.messageStop) : t(m.messagePlay),
+    label: isMessagePlaying ? t(m.messageStop) : t(m.messagePlay),
     disabled: !hasMessage,
   });
 


### PR DESCRIPTION
## Summary

- rename the message mutation helpers to explicit backspace vocabulary
- clarify that the board playback state tracks message playback, not tile playback
- rename the board-set route helper to reflect that it returns the root-board path
- update affected tests and call sites

## Why

The previous names overstated or misstated their behavior: the backspace transform may delete one character rather than a whole message part, the playback flag excludes tile playback, and the route helper returns a board route rather than a board-set index route.

## Impact

This is a mechanical internal vocabulary cleanup. It does not change runtime behavior, accessibility behavior, playback outcomes, persistence, or the OBF/OBZ contract.

## Validation

- `npm run lint`
- `npm test` — 551 tests passed
- `npm run build`
- `git diff --check`
