### PR TITLE
Split grid responsibilities

### DIFF
--- a/src/features/board/grid/grid-dom.ts
+++ b/src/features/board/grid/grid-dom.ts
@@ -1,0 +1,71 @@
+import type { GridPosition } from "./grid-model";
+
+const GRID_CELL_SELECTOR = "[role='gridcell']";
+const FOCUSABLE_SELECTOR = "[tabindex]";
+
+export interface GridFocusTarget {
+  element: HTMLElement;
+  position: GridPosition;
+}
+
+export function findGridPosition(target: Element | null): GridPosition | null {
+  return readGridPosition(target?.closest(GRID_CELL_SELECTOR) ?? null);
+}
+
+export function findFocusableInGridPosition(
+  root: HTMLElement,
+  position: GridPosition,
+): HTMLElement | null {
+  return root.querySelector<HTMLElement>(
+    `${GRID_CELL_SELECTOR}[aria-rowindex='${position.row + 1}'][aria-colindex='${position.col + 1}'] ${FOCUSABLE_SELECTOR}`,
+  );
+}
+
+export function findFirstGridFocusable(root: HTMLElement): HTMLElement | null {
+  return root.querySelector<HTMLElement>(
+    `${GRID_CELL_SELECTOR} ${FOCUSABLE_SELECTOR}`,
+  );
+}
+
+export function listGridFocusTargets(
+  root: HTMLElement,
+  row?: number,
+): GridFocusTarget[] {
+  const targets: GridFocusTarget[] = [];
+
+  for (const cell of root.querySelectorAll<HTMLElement>(GRID_CELL_SELECTOR)) {
+    const position = readGridPosition(cell);
+    if (!position || (row !== undefined && position.row !== row)) {
+      continue;
+    }
+
+    for (const element of cell.querySelectorAll<HTMLElement>(
+      FOCUSABLE_SELECTOR,
+    )) {
+      targets.push({ element, position });
+    }
+  }
+
+  return targets;
+}
+
+export function isSameGridPosition(
+  first: GridPosition,
+  second: GridPosition,
+): boolean {
+  return first.row === second.row && first.col === second.col;
+}
+
+function readGridPosition(cell: Element | null): GridPosition | null {
+  if (!cell) {
+    return null;
+  }
+
+  const row = Number.parseInt(cell.getAttribute("aria-rowindex") ?? "", 10) - 1;
+  const col = Number.parseInt(cell.getAttribute("aria-colindex") ?? "", 10) - 1;
+  if (Number.isNaN(row) || Number.isNaN(col)) {
+    return null;
+  }
+
+  return { row, col };
+}

--- a/src/features/board/grid/grid-key-navigation.ts
+++ b/src/features/board/grid/grid-key-navigation.ts
@@ -1,0 +1,114 @@
+import { listGridFocusTargets, type GridFocusTarget } from "./grid-dom";
+import type { GridPosition } from "./grid-model";
+
+interface GridKeyEvent {
+  key: string;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+}
+
+interface GridStep {
+  row: -1 | 0 | 1;
+  col: -1 | 0 | 1;
+}
+
+export function findGridKeyTarget(
+  event: GridKeyEvent,
+  root: HTMLElement,
+  from: GridPosition,
+  direction: "ltr" | "rtl",
+): GridFocusTarget | null {
+  if (event.key === "Home" || event.key === "End") {
+    return findEdgeTarget(event, root, from, direction);
+  }
+
+  if (event.ctrlKey || event.metaKey || event.shiftKey || event.altKey) {
+    return null;
+  }
+
+  const step = resolveArrowStep(event.key, direction);
+
+  return step ? findNearestTarget(root, from, step) : null;
+}
+
+function findEdgeTarget(
+  event: GridKeyEvent,
+  root: HTMLElement,
+  from: GridPosition,
+  direction: "ltr" | "rtl",
+): GridFocusTarget | null {
+  if (event.shiftKey || event.altKey) {
+    return null;
+  }
+
+  const spansWholeGrid = event.ctrlKey || event.metaKey;
+  const candidates = listGridFocusTargets(
+    root,
+    spansWholeGrid ? undefined : from.row,
+  );
+  const goesToFirst =
+    direction === "rtl" ? event.key === "End" : event.key === "Home";
+
+  return (
+    (goesToFirst ? candidates[0] : candidates[candidates.length - 1]) ?? null
+  );
+}
+
+function resolveArrowStep(
+  key: string,
+  direction: "ltr" | "rtl",
+): GridStep | null {
+  const isRtl = direction === "rtl";
+
+  switch (key) {
+    case "ArrowUp":
+      return { row: -1, col: 0 };
+    case "ArrowDown":
+      return { row: 1, col: 0 };
+    case "ArrowLeft":
+      return { row: 0, col: isRtl ? 1 : -1 };
+    case "ArrowRight":
+      return { row: 0, col: isRtl ? -1 : 1 };
+    default:
+      return null;
+  }
+}
+
+function findNearestTarget(
+  root: HTMLElement,
+  from: GridPosition,
+  step: GridStep,
+): GridFocusTarget | null {
+  let best: { target: GridFocusTarget; primary: number; cross: number } | null =
+    null;
+
+  for (const target of listGridFocusTargets(root)) {
+    const { position } = target;
+    const movesAlongRows = step.row !== 0;
+    const primaryDelta = movesAlongRows
+      ? position.row - from.row
+      : position.col - from.col;
+    const crossDelta = movesAlongRows
+      ? position.col - from.col
+      : position.row - from.row;
+    const direction = movesAlongRows ? step.row : step.col;
+
+    if (Math.sign(primaryDelta) !== direction) {
+      continue;
+    }
+
+    const primary = Math.abs(primaryDelta);
+    const cross = Math.abs(crossDelta);
+    if (
+      !best ||
+      cross < best.cross ||
+      (cross === best.cross && primary < best.primary)
+    ) {
+      best = { target, primary, cross };
+    }
+  }
+
+  return best?.target ?? null;
+}

--- a/src/features/board/grid/grid-layout.ts
+++ b/src/features/board/grid/grid-layout.ts
@@ -1,0 +1,126 @@
+import type { Theme } from "@mui/material/styles";
+
+const MUI_SPACING_UNIT_PX = 8;
+const MIN_CELL_SIZE_PX = 96;
+const PAD = "var(--pad)";
+const PAD_TOTAL = `calc(2 * ${PAD})`;
+const SMALL_SCREEN_PADDING = 2;
+const DEFAULT_PADDING = 3;
+
+export const gridCellSx = {
+  flex: 1,
+  minWidth: "var(--cell-width)",
+  minHeight: `${MIN_CELL_SIZE_PX}px`,
+  scrollSnapAlign: "start",
+} as const;
+
+export function createGridViewportSx(theme: Theme) {
+  return {
+    "--pad": theme.spacing(DEFAULT_PADDING),
+    height: "100%",
+    overflow: "auto",
+    containerType: "size",
+    scrollSnapType: "both proximity",
+    scrollPadding: PAD,
+    [theme.breakpoints.down("sm")]: {
+      "--pad": theme.spacing(SMALL_SCREEN_PADDING),
+    },
+  };
+}
+
+export function createGridContentSx(
+  theme: Theme,
+  rows: number,
+  columns: number,
+  gap: number,
+) {
+  return {
+    "--visible-cols": 1,
+    "--visible-rows": 1,
+    [theme.breakpoints.down("sm")]: visibleTrackQueries(
+      rows,
+      columns,
+      gap,
+      SMALL_SCREEN_PADDING,
+    ),
+    [theme.breakpoints.up("sm")]: visibleTrackQueries(
+      rows,
+      columns,
+      gap,
+      DEFAULT_PADDING,
+    ),
+    "--cell-width": trackSize(theme, "100cqi", gap, "var(--visible-cols)"),
+    "--cell-height": trackSize(theme, "100cqb", gap, "var(--visible-rows)"),
+    minWidth: gridExtent(theme, "var(--cell-width)", gap, columns),
+    minHeight: gridExtent(theme, "var(--cell-height)", gap, rows),
+    p: PAD,
+    gap,
+  };
+}
+
+export function createGridRowSx(gap: number) {
+  return { flex: 1, minHeight: "var(--cell-height)", gap };
+}
+
+function visibleTrackQueries(
+  rows: number,
+  columns: number,
+  gap: number,
+  padding: number,
+): Record<string, Record<string, number>> {
+  return {
+    ...trackAxisQueries("min-width", "--visible-cols", columns, gap, padding),
+    ...trackAxisQueries("min-height", "--visible-rows", rows, gap, padding),
+  };
+}
+
+function trackAxisQueries(
+  feature: "min-width" | "min-height",
+  property: "--visible-cols" | "--visible-rows",
+  count: number,
+  gap: number,
+  padding: number,
+): Record<string, Record<string, number>> {
+  const steps: [string, Record<string, number>][] = Array.from(
+    { length: Math.max(0, count - 1) },
+    (_, index) => {
+      const visible = index + 2;
+      const threshold = trackFitThreshold(visible, gap, padding);
+
+      return [`@container (${feature}: ${threshold})`, { [property]: visible }];
+    },
+  );
+
+  return Object.fromEntries(steps);
+}
+
+function trackFitThreshold(
+  count: number,
+  gap: number,
+  padding: number,
+): string {
+  const threshold =
+    count * MIN_CELL_SIZE_PX +
+    (count - 1) * gap * MUI_SPACING_UNIT_PX +
+    2 * padding * MUI_SPACING_UNIT_PX;
+
+  return `${threshold}px`;
+}
+
+function trackSize(
+  theme: Theme,
+  extent: string,
+  gap: number,
+  visible: string,
+): string {
+  return `calc((${extent} - ${PAD_TOTAL} - (${visible} - 1) * ${theme.spacing(gap)}) / ${visible})`;
+}
+
+function gridExtent(
+  theme: Theme,
+  cellSize: string,
+  gap: number,
+  count: number,
+): string {
+  return `calc(${count} * ${cellSize} + ${count - 1} * ${theme.spacing(gap)} + ${PAD_TOTAL})`;
+}

--- a/src/features/board/grid/grid-model.ts
+++ b/src/features/board/grid/grid-model.ts
@@ -1,0 +1,49 @@
+export type GridOrder = readonly (readonly (string | null)[])[];
+
+export interface GridPosition {
+  row: number;
+  col: number;
+}
+
+export function buildGrid<TItem extends { id: string }>(
+  items: readonly TItem[],
+  rows: number,
+  columns: number,
+  order?: GridOrder,
+): (TItem | undefined)[][] {
+  if (order?.length) {
+    const itemsById = new Map(items.map((item) => [item.id, item]));
+
+    return Array.from({ length: rows }, (_, rowIndex) => {
+      const orderRow = order[rowIndex] ?? [];
+
+      return Array.from({ length: columns }, (_, columnIndex) => {
+        const id = orderRow[columnIndex];
+
+        return id ? itemsById.get(id) : undefined;
+      });
+    });
+  }
+
+  return Array.from({ length: rows }, (_, rowIndex) =>
+    Array.from({ length: columns }, (_, columnIndex) => {
+      const index = rowIndex * columns + columnIndex;
+
+      return items[index];
+    }),
+  );
+}
+
+export function findFirstOccupiedPosition(
+  grid: readonly (readonly unknown[])[],
+): GridPosition {
+  for (let row = 0; row < grid.length; row++) {
+    for (let col = 0; col < grid[row].length; col++) {
+      if (grid[row][col]) {
+        return { row, col };
+      }
+    }
+  }
+
+  return { row: 0, col: 0 };
+}

--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -1,20 +1,16 @@
 import Box from "@mui/material/Box";
 import Stack, { type StackProps } from "@mui/material/Stack";
-import type { Theme } from "@mui/material/styles";
 import { mergeSx } from "@shared/theme/merge-sx";
 import type { ReactNode, Ref } from "react";
 import { Fragment } from "react";
+import {
+  createGridContentSx,
+  createGridRowSx,
+  createGridViewportSx,
+  gridCellSx,
+} from "./grid-layout";
+import { buildGrid, type GridOrder } from "./grid-model";
 import { useGridKeyboard } from "./use-grid-keyboard";
-
-const MUI_SPACING_UNIT_PX = 8;
-const MIN_CELL_SIZE_PX = 96;
-const MIN_CELL_SIZE = `${MIN_CELL_SIZE_PX}px`;
-const PAD = "var(--pad)";
-const PAD_TOTAL = `calc(2 * ${PAD})`;
-const SMALL_SCREEN_PADDING = 2;
-const DEFAULT_PADDING = 3;
-
-type GridOrder = readonly (readonly (string | null)[])[];
 
 export interface GridItemProps {
   tabIndex: number;
@@ -64,59 +60,14 @@ export function Grid<TItem extends { id: string }>({
   });
 
   return (
-    <Box
-      ref={ref}
-      dir={dir}
-      sx={(theme) => ({
-        "--pad": theme.spacing(DEFAULT_PADDING),
-        height: "100%",
-        overflow: "auto",
-        containerType: "size",
-        scrollSnapType: "both proximity",
-        scrollPadding: PAD,
-        [theme.breakpoints.down("sm")]: {
-          "--pad": theme.spacing(SMALL_SCREEN_PADDING),
-        },
-      })}
-    >
+    <Box ref={ref} dir={dir} sx={createGridViewportSx}>
       <Stack
         {...rootProps}
         ref={rootRef}
         role="grid"
         aria-label={ariaLabel}
         direction="column"
-        sx={(theme) => ({
-          "--visible-cols": 1,
-          "--visible-rows": 1,
-          [theme.breakpoints.down("sm")]: visibleTrackQueries(
-            rows,
-            columns,
-            gap,
-            SMALL_SCREEN_PADDING,
-          ),
-          [theme.breakpoints.up("sm")]: visibleTrackQueries(
-            rows,
-            columns,
-            gap,
-            DEFAULT_PADDING,
-          ),
-          "--cell-width": trackSize(
-            theme,
-            "100cqi",
-            gap,
-            "var(--visible-cols)",
-          ),
-          "--cell-height": trackSize(
-            theme,
-            "100cqb",
-            gap,
-            "var(--visible-rows)",
-          ),
-          minWidth: gridExtent(theme, "var(--cell-width)", gap, columns),
-          minHeight: gridExtent(theme, "var(--cell-height)", gap, rows),
-          p: PAD,
-          gap,
-        })}
+        sx={(theme) => createGridContentSx(theme, rows, columns, gap)}
       >
         {grid.map((row, rowIndex) => {
           const cells = row.map((item, colIndex) => {
@@ -129,12 +80,7 @@ export function Grid<TItem extends { id: string }>({
                 role="gridcell"
                 aria-rowindex={rowIndex + 1}
                 aria-colindex={colIndex + 1}
-                sx={{
-                  flex: 1,
-                  minWidth: "var(--cell-width)",
-                  minHeight: MIN_CELL_SIZE,
-                  scrollSnapAlign: "start",
-                }}
+                sx={gridCellSx}
               >
                 {item &&
                   renderItem(item, {
@@ -166,101 +112,9 @@ export function GridRow({ children, gap, sx, ...rootProps }: GridRowProps) {
       {...rootProps}
       role="row"
       direction="row"
-      sx={mergeSx({ flex: 1, minHeight: "var(--cell-height)", gap }, sx)}
+      sx={mergeSx(createGridRowSx(gap), sx)}
     >
       {children}
     </Stack>
   );
-}
-
-function buildGrid<TItem extends { id: string }>(
-  items: readonly TItem[],
-  rows: number,
-  columns: number,
-  order?: GridOrder,
-): (TItem | undefined)[][] {
-  if (order?.length) {
-    const itemsById = new Map(items.map((item) => [item.id, item]));
-
-    return Array.from({ length: rows }, (_, r) => {
-      const orderRow = order[r] ?? [];
-
-      return Array.from({ length: columns }, (_, c) => {
-        const id = orderRow[c];
-
-        return id ? itemsById.get(id) : undefined;
-      });
-    });
-  }
-
-  return Array.from({ length: rows }, (_, r) =>
-    Array.from({ length: columns }, (_, c) => {
-      const index = r * columns + c;
-
-      return items[index];
-    }),
-  );
-}
-
-function visibleTrackQueries(
-  rows: number,
-  columns: number,
-  gap: number,
-  padding: number,
-): Record<string, Record<string, number>> {
-  return {
-    ...trackAxisQueries("min-width", "--visible-cols", columns, gap, padding),
-    ...trackAxisQueries("min-height", "--visible-rows", rows, gap, padding),
-  };
-}
-
-function trackAxisQueries(
-  feature: "min-width" | "min-height",
-  property: "--visible-cols" | "--visible-rows",
-  count: number,
-  gap: number,
-  padding: number,
-): Record<string, Record<string, number>> {
-  const steps: [string, Record<string, number>][] = Array.from(
-    { length: Math.max(0, count - 1) },
-    (_, index) => {
-      const visible = index + 2;
-      const threshold = trackFitThreshold(visible, gap, padding);
-
-      return [`@container (${feature}: ${threshold})`, { [property]: visible }];
-    },
-  );
-
-  return Object.fromEntries(steps);
-}
-
-function trackFitThreshold(
-  count: number,
-  gap: number,
-  padding: number,
-): string {
-  const threshold =
-    count * MIN_CELL_SIZE_PX +
-    (count - 1) * gap * MUI_SPACING_UNIT_PX +
-    2 * padding * MUI_SPACING_UNIT_PX;
-
-  return `${threshold}px`;
-}
-
-function trackSize(
-  theme: Theme,
-  extent: string,
-  gap: number,
-  visible: string,
-): string {
-  return `calc((${extent} - ${PAD_TOTAL} - (${visible} - 1) * ${theme.spacing(gap)}) / ${visible})`;
-}
-
-function gridExtent(
-  theme: Theme,
-  cellSize: string,
-  gap: number,
-  count: number,
-): string {
-  return `calc(${count} * ${cellSize} + ${count - 1} * ${theme.spacing(gap)} + ${PAD_TOTAL})`;
 }

--- a/src/features/board/grid/use-grid-keyboard.ts
+++ b/src/features/board/grid/use-grid-keyboard.ts
@@ -1,14 +1,14 @@
 import type { DOMAttributes, FocusEvent, RefObject } from "react";
 import { useEffect, useRef, useState } from "react";
 import { useKeyboard } from "react-aria";
-
-const CELL = "[role='gridcell']";
-const FOCUSABLE = "[tabindex]";
-
-interface Cell {
-  row: number;
-  col: number;
-}
+import {
+  findFirstGridFocusable,
+  findFocusableInGridPosition,
+  findGridPosition,
+  isSameGridPosition,
+} from "./grid-dom";
+import { findGridKeyTarget } from "./grid-key-navigation";
+import { findFirstOccupiedPosition, type GridPosition } from "./grid-model";
 
 interface UseGridKeyboardOptions {
   grid: readonly (readonly unknown[])[];
@@ -18,25 +18,7 @@ interface UseGridKeyboardOptions {
 interface UseGridKeyboardReturn {
   rootRef: RefObject<HTMLDivElement | null>;
   rootProps: DOMAttributes<HTMLElement>;
-  activeCell: Cell;
-}
-
-interface Step {
-  row: -1 | 0 | 1;
-  col: -1 | 0 | 1;
-}
-
-interface FocusTarget {
-  element: HTMLElement;
-  position: Cell;
-}
-
-interface KeyEventLike {
-  key: string;
-  ctrlKey: boolean;
-  metaKey: boolean;
-  shiftKey: boolean;
-  altKey: boolean;
+  activeCell: GridPosition;
 }
 
 export function useGridKeyboard({
@@ -44,13 +26,13 @@ export function useGridKeyboard({
   dir,
 }: UseGridKeyboardOptions): UseGridKeyboardReturn {
   const rootRef = useRef<HTMLDivElement>(null);
-  const [rememberedCell, setRememberedCell] = useState<Cell>(() =>
-    findFirstNonEmptyCell(grid),
+  const [rememberedPosition, setRememberedPosition] = useState<GridPosition>(
+    () => findFirstOccupiedPosition(grid),
   );
-  const rememberedCellRef = useRef(rememberedCell);
-  const rememberCell = (next: Cell) => {
-    rememberedCellRef.current = next;
-    setRememberedCell(next);
+  const rememberedPositionRef = useRef(rememberedPosition);
+  const rememberPosition = (next: GridPosition) => {
+    rememberedPositionRef.current = next;
+    setRememberedPosition(next);
   };
 
   const { keyboardProps } = useKeyboard({
@@ -62,30 +44,30 @@ export function useGridKeyboard({
         return;
       }
 
-      const from = cellOf(event.target as Element | null);
+      const from = findGridPosition(event.target as Element | null);
       if (!from) {
         event.continuePropagation();
 
         return;
       }
 
-      const next = nextFocus(event, root, from, dir);
-      if (!next || sameCell(next.position, from)) {
+      const next = findGridKeyTarget(event, root, from, dir);
+      if (!next || isSameGridPosition(next.position, from)) {
         event.continuePropagation();
 
         return;
       }
 
       event.preventDefault();
-      rememberCell(next.position);
+      rememberPosition(next.position);
       next.element.focus();
     },
   });
 
   const handleFocus = (event: FocusEvent<HTMLElement>) => {
-    const position = cellOf(event.target);
+    const position = findGridPosition(event.target);
     if (position) {
-      rememberCell(position);
+      rememberPosition(position);
     }
   };
 
@@ -107,165 +89,18 @@ export function useGridKeyboard({
     }
 
     const target =
-      findFocusableInCell(root, rememberedCellRef.current) ??
-      findFirstFocusable(root);
+      findFocusableInGridPosition(root, rememberedPositionRef.current) ??
+      findFirstGridFocusable(root);
     target?.focus();
   }, [grid]);
 
-  const activeCell = grid[rememberedCell.row]?.[rememberedCell.col]
-    ? rememberedCell
-    : findFirstNonEmptyCell(grid);
+  const activeCell = grid[rememberedPosition.row]?.[rememberedPosition.col]
+    ? rememberedPosition
+    : findFirstOccupiedPosition(grid);
 
   return {
     rootRef,
     rootProps: { ...keyboardProps, onFocus: handleFocus },
     activeCell,
   };
-}
-
-function findFirstNonEmptyCell(grid: readonly (readonly unknown[])[]): Cell {
-  for (let row = 0; row < grid.length; row++) {
-    for (let col = 0; col < grid[row].length; col++) {
-      if (grid[row][col]) {
-        return { row, col };
-      }
-    }
-  }
-
-  return { row: 0, col: 0 };
-}
-
-function findFocusableInCell(
-  root: HTMLElement,
-  cell: Cell,
-): HTMLElement | null {
-  return root.querySelector<HTMLElement>(
-    `${CELL}[aria-rowindex='${cell.row + 1}'][aria-colindex='${cell.col + 1}'] ${FOCUSABLE}`,
-  );
-}
-
-function findFirstFocusable(root: HTMLElement): HTMLElement | null {
-  return root.querySelector<HTMLElement>(`${CELL} ${FOCUSABLE}`);
-}
-
-function nextFocus(
-  event: KeyEventLike,
-  root: HTMLElement,
-  from: Cell,
-  dir: "ltr" | "rtl",
-): FocusTarget | null {
-  if (event.key === "Home" || event.key === "End") {
-    if (event.shiftKey || event.altKey) {
-      return null;
-    }
-
-    const spansWholeGrid = event.ctrlKey || event.metaKey;
-    const scope = spansWholeGrid
-      ? CELL
-      : `${CELL}[aria-rowindex='${from.row + 1}']`;
-    const candidates = root.querySelectorAll<HTMLElement>(
-      `${scope} ${FOCUSABLE}`,
-    );
-
-    const goToFirst =
-      dir === "rtl" ? event.key === "End" : event.key === "Home";
-
-    const element = goToFirst
-      ? candidates[0]
-      : candidates[candidates.length - 1];
-
-    if (!element) {
-      return null;
-    }
-
-    const position = cellOf(element);
-
-    return position ? { element, position } : null;
-  }
-
-  if (event.ctrlKey || event.metaKey || event.shiftKey || event.altKey) {
-    return null;
-  }
-
-  const step = arrowStep(event.key, dir);
-
-  return step ? nearestInDirection(root, from, step) : null;
-}
-
-function arrowStep(key: string, dir: "ltr" | "rtl"): Step | null {
-  const rtl = dir === "rtl";
-  switch (key) {
-    case "ArrowUp":
-      return { row: -1, col: 0 };
-    case "ArrowDown":
-      return { row: 1, col: 0 };
-    case "ArrowLeft":
-      return { row: 0, col: rtl ? 1 : -1 };
-    case "ArrowRight":
-      return { row: 0, col: rtl ? -1 : 1 };
-    default:
-      return null;
-  }
-}
-
-function nearestInDirection(
-  root: HTMLElement,
-  from: Cell,
-  step: Step,
-): FocusTarget | null {
-  let best: { target: FocusTarget; primary: number; cross: number } | null =
-    null;
-
-  for (const cell of root.querySelectorAll<HTMLElement>(CELL)) {
-    const position = positionOf(cell);
-    const element = cell.querySelector<HTMLElement>(FOCUSABLE);
-    if (!position || !element) {
-      continue;
-    }
-
-    const onRowAxis = step.row !== 0;
-    const dPrimary = onRowAxis
-      ? position.row - from.row
-      : position.col - from.col;
-    const dCross = onRowAxis
-      ? position.col - from.col
-      : position.row - from.row;
-    if (Math.sign(dPrimary) !== (onRowAxis ? step.row : step.col)) {
-      continue;
-    }
-
-    const primary = Math.abs(dPrimary);
-    const cross = Math.abs(dCross);
-    if (
-      !best ||
-      cross < best.cross ||
-      (cross === best.cross && primary < best.primary)
-    ) {
-      best = { target: { element, position }, primary, cross };
-    }
-  }
-
-  return best?.target ?? null;
-}
-
-function cellOf(target: Element | null): Cell | null {
-  return positionOf(target?.closest(CELL) ?? null);
-}
-
-function positionOf(cell: Element | null): Cell | null {
-  if (!cell) {
-    return null;
-  }
-
-  const row = Number.parseInt(cell.getAttribute("aria-rowindex") ?? "", 10) - 1;
-  const col = Number.parseInt(cell.getAttribute("aria-colindex") ?? "", 10) - 1;
-  if (Number.isNaN(row) || Number.isNaN(col)) {
-    return null;
-  }
-
-  return { row, col };
-}
-
-function sameCell(a: Cell, b: Cell): boolean {
-  return a.row === b.row && a.col === b.col;
 }


### PR DESCRIPTION
## What changed

- Extracted grid model construction and occupied-position lookup.
- Extracted DOM focus-target helpers and keyboard-navigation resolution.
- Extracted responsive grid layout calculations and styles.
- Kept the `Grid` component and keyboard hook focused on orchestration.

## Why

The grid component and keyboard hook mixed rendering, responsive layout calculations, DOM traversal, state modeling, and navigation rules. Splitting these responsibilities makes the accessibility-critical behavior easier to understand and maintain without changing the public behavior.

## Impact

No intended user-facing behavior change. Grid rendering, responsive sizing, focus restoration, arrow navigation, Home/End navigation, and RTL behavior remain intact.

## Validation

- `npm run lint`
- `npm test` — 75 files, 551 tests passed
- `npm run build`
