### PR TITLE
Cache remote AAC images

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,6 +37,21 @@ export default defineConfig({
     VitePWA({
       registerType: "autoUpdate",
       includeAssets: ["board.svg"],
+      workbox: {
+        runtimeCaching: [
+          {
+            urlPattern: ({ request, sameOrigin }) =>
+              !sameOrigin && request.destination === "image",
+            handler: "CacheFirst",
+            options: {
+              cacheName: "aac-remote-images",
+              // Cross-origin <img> responses are opaque but remain renderable.
+              cacheableResponse: { statuses: [0, 200] },
+              expiration: { maxEntries: 1000, purgeOnQuotaError: true },
+            },
+          },
+        ],
+      },
       manifest: {
         name: "AAC Board AI",
         short_name: "AAC Board",


### PR DESCRIPTION
## Summary

- add a Workbox `CacheFirst` runtime route for cross-origin image requests
- cache both opaque and successful image responses under `aac-remote-images`
- cap the cache at 1,000 entries and purge it automatically on quota errors

## Why

Third-party AAC boards can reference images on hosts without CORS support. Browsers can render those URLs directly, but application JavaScript cannot reliably fetch their bytes for IndexedDB. The existing generated service worker had no runtime image-caching rule, so those images were unavailable after the network source disappeared.

This keeps the original remote URL in board data and lets the existing Workbox/Cache Storage layer transparently provide subsequent loads.

## Impact

Remote AAC images download normally the first time they are displayed and are reused from Cache Storage afterwards. Packaged board assets and canonical board data continue using IndexedDB unchanged.

## Validation

- `npm run lint`
- `npm test` — 72 files, 525 tests passed
- `npm run build`
- production-preview smoke test with a no-CORS, `Cache-Control: no-store` image server; the image still rendered after that server was stopped and the page was fully reloaded
