### PR TITLE
Clarify privacy and offline claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,15 @@ Suggestions are optional; the original message is replaced only when the user ac
 - **Accessible input** — Supports touch and keyboard navigation.
 - **Open boards** — Imports `.obf` and `.obz` [Open Board Format](https://www.openboardformat.org) files from your device or a URL.
 - **Multilingual** — Supports 35 interface languages, right-to-left layouts, and on-device caching for translated boards.
-- **Offline and installable** — Runs as a PWA and keeps loaded boards available without a connection.
+- **Offline and installable** — Runs as a PWA and keeps core board features available after the app and board data have loaded.
 
 ## Privacy, offline use, and current limits
 
-AAC Board AI has no accounts, backend, telemetry, or tracking. Imported boards, settings, and cached translations stay on the device; messages are never sent to an AAC Board AI server.
+AAC Board AI has no accounts, application backend, telemetry, or tracking. Imported board data, settings, and cached translations stay on the device; messages are never sent to an AAC Board AI service.
 
-After the first successful load, the app and loaded boards work offline. URL imports require a connection, and text-to-speech support depends on the platform and its available voices.
+After the first successful load, the app shell and stored board data support offline reading, navigation, and message composition. Locally stored media and locally available speech voices can also play without a connection.
+
+Opening a board with third-party media contacts the hosts named in those URLs. Remote images are cached after their first successful display, subject to browser storage limits and eviction; remote audio remains network-dependent. URL imports and initial AI model or language-pack downloads also require a connection. Text-to-speech availability and whether speech is processed locally depend on the platform and selected voice.
 
 Boards can be imported and stored, but not edited, exported, or synchronized between devices. Prepare custom boards with an Open Board Format-compatible tool and import them on each device.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,8 +35,10 @@ later" into more natural language.
 Two constraints shape the architecture:
 
 - **Device-local core.** IndexedDB is the source of truth for imported boards.
-  Reading, composing, navigating, and speaking a board do not require a network.
-  AI suggestions, board translation, and URL imports are progressive enhancements.
+  Reading, composing, and navigating a loaded board do not require a network.
+  Playback is offline when its media and speech voice are locally available. AI
+  suggestions, board translation, URL imports, and remote media are progressive
+  enhancements.
 - **No application backend.** A static host serves the SPA and service-worker
   updates, but no application server stores user content. Cross-device sync is
   therefore outside the current architecture.
@@ -46,7 +48,8 @@ Two constraints shape the architecture:
 The app is one React SPA. Browser APIs provide persistence and output; feature
 modules isolate the board domain, imports, playback, and optional AI. A
 `vite-plugin-pwa` service worker caches the app shell after a successful first
-load, and the manifest registers `.obf` and `.obz` file handlers.
+load and caches third-party images after they are displayed. The manifest
+registers `.obf` and `.obz` file handlers.
 
 ```mermaid
 flowchart LR
@@ -186,8 +189,9 @@ rerender only subscribers to the changed slice.
 ## Invariants
 
 - **No application backend, telemetry, or tracking.** The static host receives
-  normal asset requests, and URL import contacts the URL selected by the user, but
-  the app does not send board or message content to an application service.
+  normal asset requests. URL imports and third-party media contact their source
+  hosts, and some platform speech voices may contact an external service, but the
+  app does not send board or message content to an application service.
 - **Core communication works offline once the app shell and board data have loaded
   successfully.** AI suggestions, board translation, and URL imports may be
   unavailable without preventing board reading, navigation, composition, or
@@ -262,6 +266,11 @@ rise with meaningful coverage gains and are not lowered to admit a regression.
   locales remain selectable even when the browser exposes no matching voice. The
   app does not require `SpeechSynthesisVoice.localService`, so a selected voice's
   offline and privacy behavior remains platform-dependent.
+- **Remote media is best-effort offline content.** The service worker caches
+  third-party images after their first successful display, but browser storage
+  pressure may evict them. Third-party audio remains network-dependent because
+  media playback may use range requests that opaque cross-origin responses cannot
+  reliably satisfy from this cache strategy.
 - **Deployment configuration is host-specific.** The static SPA is portable, but
   the current deployment configuration is Netlify-only (`netlify.toml`).
 

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -117,7 +117,7 @@
   "messageStop": "إيقاف",
   "onboardingSmartRewritingDescription": "وسّع النقر على الرموز إلى جمل طبيعية واضبط النبرة: مباشرة أو احترافية أو ودّية.",
   "onboardingTranslationDescription": "ترجم اللوحات محليًا للتواصل بعدة لغات.",
-  "onboardingPrivacyDescription": "يعمل بالكامل على جهازك دون أي تتبّع للبيانات أو اعتماد على السحابة.",
+  "onboardingPrivacyDescription": "لا حسابات ولا تتبّع في التطبيق. أنشئ رسائلك دون اتصال.",
   "onboardingContinue": "متابعة",
   "errorGenericTitle": "حدث خطأ ما",
   "errorPageNotFound": "الصفحة غير موجودة",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -117,7 +117,7 @@
   "messageStop": "Спиране",
   "onboardingSmartRewritingDescription": "Превърнете докосванията на плочките в естествени изречения и регулирайте тона: директен, професионален или приятелски.",
   "onboardingTranslationDescription": "Превеждайте дъските локално, за да общувате на няколко езика.",
-  "onboardingPrivacyDescription": "Работи изцяло на вашето устройство, без проследяване на данни и без зависимост от облака.",
+  "onboardingPrivacyDescription": "Без профили и проследяване в приложението. Съставяйте съобщения офлайн.",
   "onboardingContinue": "Продължаване",
   "errorGenericTitle": "Нещо се обърка",
   "errorPageNotFound": "Страницата не е намерена",

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -117,7 +117,7 @@
   "messageStop": "থামান",
   "onboardingSmartRewritingDescription": "টাইলে ট্যাপকে স্বাভাবিক বাক্যে রূপান্তর করুন এবং টোন সামঞ্জস্য করুন: সরাসরি, পেশাদার বা বন্ধুত্বপূর্ণ।",
   "onboardingTranslationDescription": "একাধিক ভাষায় যোগাযোগ করতে বোর্ড স্থানীয়ভাবে অনুবাদ করুন।",
-  "onboardingPrivacyDescription": "সম্পূর্ণরূপে আপনার ডিভাইসে চলে, কোনো ডেটা ট্র্যাকিং ছাড়াই এবং ক্লাউডের ওপর নির্ভরতা ছাড়াই।",
+  "onboardingPrivacyDescription": "কোনো অ্যাকাউন্ট বা অ্যাপ ট্র্যাকিং নেই। অফলাইনে বার্তা তৈরি করুন।",
   "onboardingContinue": "চালিয়ে যান",
   "errorGenericTitle": "কিছু একটা ভুল হয়েছে",
   "errorPageNotFound": "পৃষ্ঠাটি পাওয়া যায়নি",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -117,7 +117,7 @@
   "messageStop": "Zastavit",
   "onboardingSmartRewritingDescription": "Rozšiřte klepnutí na dlaždice do přirozených vět a upravte tón: přímý, profesionální nebo přátelský.",
   "onboardingTranslationDescription": "Překládejte tabulky lokálně, abyste komunikovali ve více jazycích.",
-  "onboardingPrivacyDescription": "Běží zcela ve vašem zařízení, bez sledování dat a bez závislosti na cloudu.",
+  "onboardingPrivacyDescription": "Bez účtů a sledování v aplikaci. Sestavujte zprávy offline.",
   "onboardingContinue": "Pokračovat",
   "errorGenericTitle": "Něco se pokazilo",
   "errorPageNotFound": "Stránka nebyla nalezena",

--- a/messages/da.json
+++ b/messages/da.json
@@ -117,7 +117,7 @@
   "messageStop": "Stop",
   "onboardingSmartRewritingDescription": "Udvid tryk på felter til naturlige sætninger, og justér tonen: direkte, professionel eller venlig.",
   "onboardingTranslationDescription": "Oversæt tavler lokalt, så du kan kommunikere på flere sprog.",
-  "onboardingPrivacyDescription": "Kører helt på din enhed, uden datasporing og uden afhængighed af skyen.",
+  "onboardingPrivacyDescription": "Ingen konti eller sporing i appen. Skriv beskeder offline.",
   "onboardingContinue": "Fortsæt",
   "errorGenericTitle": "Noget gik galt",
   "errorPageNotFound": "Siden blev ikke fundet",

--- a/messages/de.json
+++ b/messages/de.json
@@ -117,7 +117,7 @@
   "messageStop": "Stopp",
   "onboardingSmartRewritingDescription": "Erweitere Kachel-Tipps zu natürlichen Sätzen und passe den Ton an: direkt, professionell oder freundlich.",
   "onboardingTranslationDescription": "Übersetze Tafeln lokal, um in mehreren Sprachen zu kommunizieren.",
-  "onboardingPrivacyDescription": "Läuft vollständig auf deinem Gerät – ohne Datenverfolgung und ohne Cloud-Abhängigkeiten.",
+  "onboardingPrivacyDescription": "Keine Konten, kein App-Tracking. Nachrichten offline verfassen.",
   "onboardingContinue": "Weiter",
   "errorGenericTitle": "Etwas ist schiefgelaufen",
   "errorPageNotFound": "Seite nicht gefunden",

--- a/messages/el.json
+++ b/messages/el.json
@@ -117,7 +117,7 @@
   "messageStop": "Διακοπή",
   "onboardingSmartRewritingDescription": "Επεκτείνετε τα πατήματα στα πλακίδια σε φυσικές προτάσεις και προσαρμόστε τον τόνο: άμεσος, επαγγελματικός ή φιλικός.",
   "onboardingTranslationDescription": "Μεταφράστε τους πίνακες τοπικά, για να επικοινωνείτε σε πολλές γλώσσες.",
-  "onboardingPrivacyDescription": "Εκτελείται εξ ολοκλήρου στη συσκευή σας, χωρίς παρακολούθηση δεδομένων και χωρίς εξάρτηση από το cloud.",
+  "onboardingPrivacyDescription": "Χωρίς λογαριασμούς ή παρακολούθηση στην εφαρμογή. Συνθέστε μηνύματα εκτός σύνδεσης.",
   "onboardingContinue": "Συνέχεια",
   "errorGenericTitle": "Κάτι πήγε στραβά",
   "errorPageNotFound": "Η σελίδα δεν βρέθηκε",

--- a/messages/en.json
+++ b/messages/en.json
@@ -117,7 +117,7 @@
   "messageStop": "Stop message",
   "onboardingSmartRewritingDescription": "Say more with fewer taps. AI helps your messages sound clear and natural.",
   "onboardingTranslationDescription": "Communicate across languages, right from your board.",
-  "onboardingPrivacyDescription": "Your communication stays private and works offline. No subscription needed.",
+  "onboardingPrivacyDescription": "No accounts or app tracking. Build messages offline.",
   "onboardingContinue": "Continue",
   "errorGenericTitle": "Something went wrong",
   "errorPageNotFound": "Page not found",

--- a/messages/es.json
+++ b/messages/es.json
@@ -117,7 +117,7 @@
   "messageStop": "Detener",
   "onboardingSmartRewritingDescription": "Convierte los toques en las casillas en frases naturales y ajusta el tono: directo, profesional o amistoso.",
   "onboardingTranslationDescription": "Traduce los tableros localmente para comunicarte en varios idiomas.",
-  "onboardingPrivacyDescription": "Se ejecuta por completo en tu dispositivo, sin rastreo de datos ni dependencia de la nube.",
+  "onboardingPrivacyDescription": "Sin cuentas ni seguimiento en la aplicación. Crea mensajes sin conexión.",
   "onboardingContinue": "Continuar",
   "errorGenericTitle": "Algo salió mal",
   "errorPageNotFound": "Página no encontrada",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -117,7 +117,7 @@
   "messageStop": "Pysäytä",
   "onboardingSmartRewritingDescription": "Laajenna ruutujen napautukset luonnollisiksi lauseiksi ja säädä sävyä: suora, ammattimainen tai ystävällinen.",
   "onboardingTranslationDescription": "Käännä taulut paikallisesti, jotta voit viestiä useilla kielillä.",
-  "onboardingPrivacyDescription": "Toimii kokonaan laitteellasi ilman tietojen seurantaa ja ilman pilviriippuvuutta.",
+  "onboardingPrivacyDescription": "Ei tilejä eikä sovellusseurantaa. Muodosta viestejä ilman verkkoyhteyttä.",
   "onboardingContinue": "Jatka",
   "errorGenericTitle": "Jokin meni pieleen",
   "errorPageNotFound": "Sivua ei löytynyt",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -117,7 +117,7 @@
   "messageStop": "Arrêter",
   "onboardingSmartRewritingDescription": "Transformez les appuis sur les cases en phrases naturelles et ajustez le ton : direct, professionnel ou amical.",
   "onboardingTranslationDescription": "Traduisez les tableaux localement pour communiquer en plusieurs langues.",
-  "onboardingPrivacyDescription": "Fonctionne entièrement sur votre appareil, sans suivi des données ni dépendance au cloud.",
+  "onboardingPrivacyDescription": "Aucun compte ni suivi dans l’application. Composez vos messages hors ligne.",
   "onboardingContinue": "Continuer",
   "errorGenericTitle": "Une erreur s'est produite",
   "errorPageNotFound": "Page introuvable",

--- a/messages/he.json
+++ b/messages/he.json
@@ -117,7 +117,7 @@
   "messageStop": "עצירה",
   "onboardingSmartRewritingDescription": "הרחיבו הקשות על משבצות למשפטים טבעיים והתאימו את הסגנון: ישיר, מקצועי או ידידותי.",
   "onboardingTranslationDescription": "תרגמו את הלוחות באופן מקומי כדי לתקשר במספר שפות.",
-  "onboardingPrivacyDescription": "פועל לחלוטין על המכשיר שלך, ללא מעקב אחר נתונים וללא תלות בענן.",
+  "onboardingPrivacyDescription": "בלי חשבונות או מעקב באפליקציה. אפשר ליצור הודעות במצב לא מקוון.",
   "onboardingContinue": "המשך",
   "errorGenericTitle": "משהו השתבש",
   "errorPageNotFound": "הדף לא נמצא",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -117,7 +117,7 @@
   "messageStop": "रोकें",
   "onboardingSmartRewritingDescription": "टाइल टैप को स्वाभाविक वाक्यों में बदलें और टोन समायोजित करें: प्रत्यक्ष, पेशेवर या मैत्रीपूर्ण।",
   "onboardingTranslationDescription": "कई भाषाओं में संवाद करने के लिए बोर्ड का स्थानीय रूप से अनुवाद करें।",
-  "onboardingPrivacyDescription": "पूरी तरह आपके डिवाइस पर चलता है, बिना किसी डेटा ट्रैकिंग और बिना क्लाउड पर निर्भरता के।",
+  "onboardingPrivacyDescription": "न कोई खाता, न ऐप ट्रैकिंग। ऑफ़लाइन संदेश बनाएँ।",
   "onboardingContinue": "जारी रखें",
   "errorGenericTitle": "कुछ गलत हो गया",
   "errorPageNotFound": "पृष्ठ नहीं मिला",

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -117,7 +117,7 @@
   "messageStop": "Zaustavi",
   "onboardingSmartRewritingDescription": "Proširite dodire na pločicama u prirodne rečenice i prilagodite ton: izravni, profesionalni ili prijateljski.",
   "onboardingTranslationDescription": "Prevodite ploče lokalno kako biste komunicirali na više jezika.",
-  "onboardingPrivacyDescription": "Radi u potpunosti na vašem uređaju, bez praćenja podataka i bez ovisnosti o oblaku.",
+  "onboardingPrivacyDescription": "Bez računa i praćenja u aplikaciji. Sastavljajte poruke izvan mreže.",
   "onboardingContinue": "Nastavi",
   "errorGenericTitle": "Nešto je pošlo po zlu",
   "errorPageNotFound": "Stranica nije pronađena",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -117,7 +117,7 @@
   "messageStop": "Leállítás",
   "onboardingSmartRewritingDescription": "Bővítsd a csempékre koppintást természetes mondatokká, és állítsd be a hangnemet: közvetlen, professzionális vagy barátságos.",
   "onboardingTranslationDescription": "Fordítsd le a táblákat helyben, hogy több nyelven kommunikálhass.",
-  "onboardingPrivacyDescription": "Teljes egészében az eszközödön fut, adatkövetés nélkül és felhőfüggőség nélkül.",
+  "onboardingPrivacyDescription": "Nincsenek fiókok és alkalmazáson belüli követés. Írj üzeneteket offline.",
   "onboardingContinue": "Folytatás",
   "errorGenericTitle": "Hiba történt",
   "errorPageNotFound": "Az oldal nem található",

--- a/messages/id.json
+++ b/messages/id.json
@@ -117,7 +117,7 @@
   "messageStop": "Hentikan",
   "onboardingSmartRewritingDescription": "Perluas ketukan pada petak menjadi kalimat alami dan sesuaikan nada: langsung, profesional, atau ramah.",
   "onboardingTranslationDescription": "Terjemahkan papan secara lokal untuk berkomunikasi dalam berbagai bahasa.",
-  "onboardingPrivacyDescription": "Berjalan sepenuhnya di perangkat Anda, tanpa pelacakan data dan tanpa ketergantungan cloud.",
+  "onboardingPrivacyDescription": "Tanpa akun atau pelacakan aplikasi. Susun pesan secara offline.",
   "onboardingContinue": "Lanjutkan",
   "errorGenericTitle": "Terjadi kesalahan",
   "errorPageNotFound": "Halaman tidak ditemukan",

--- a/messages/it.json
+++ b/messages/it.json
@@ -117,7 +117,7 @@
   "messageStop": "Interrompi",
   "onboardingSmartRewritingDescription": "Trasforma i tocchi sulle caselle in frasi naturali e regola il tono: diretto, professionale o amichevole.",
   "onboardingTranslationDescription": "Traduci le tabelle localmente per comunicare in più lingue.",
-  "onboardingPrivacyDescription": "Funziona interamente sul tuo dispositivo, senza tracciamento dei dati né dipendenza dal cloud.",
+  "onboardingPrivacyDescription": "Nessun account o tracciamento nell’app. Componi messaggi offline.",
   "onboardingContinue": "Continua",
   "errorGenericTitle": "Qualcosa è andato storto",
   "errorPageNotFound": "Pagina non trovata",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -117,7 +117,7 @@
   "messageStop": "停止",
   "onboardingSmartRewritingDescription": "タイルのタップを自然な文章に展開し、トーンを調整できます：率直・プロフェッショナル・フレンドリー。",
   "onboardingTranslationDescription": "ボードをデバイス上で翻訳し、複数の言語でコミュニケーションできます。",
-  "onboardingPrivacyDescription": "すべてお使いのデバイス上で動作し、データの追跡やクラウドへの依存は一切ありません。",
+  "onboardingPrivacyDescription": "アカウントもアプリの追跡も不要。オフラインでメッセージを作れます。",
   "onboardingContinue": "続ける",
   "errorGenericTitle": "問題が発生しました",
   "errorPageNotFound": "ページが見つかりません",

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -117,7 +117,7 @@
   "messageStop": "ನಿಲ್ಲಿಸಿ",
   "onboardingSmartRewritingDescription": "ಟೈಲ್‌ ಟ್ಯಾಪ್‌ಗಳನ್ನು ಸಹಜ ವಾಕ್ಯಗಳಾಗಿ ವಿಸ್ತರಿಸಿ ಮತ್ತು ಧಾಟಿಯನ್ನು ಹೊಂದಿಸಿ: ನೇರ, ವೃತ್ತಿಪರ ಅಥವಾ ಸ್ನೇಹಪರ.",
   "onboardingTranslationDescription": "ಬಹು ಭಾಷೆಗಳಲ್ಲಿ ಸಂವಹನ ನಡೆಸಲು ಬೋರ್ಡ್‌ಗಳನ್ನು ಸ್ಥಳೀಯವಾಗಿ ಅನುವಾದಿಸಿ.",
-  "onboardingPrivacyDescription": "ಸಂಪೂರ್ಣವಾಗಿ ನಿಮ್ಮ ಸಾಧನದಲ್ಲಿ ಕಾರ್ಯನಿರ್ವಹಿಸುತ್ತದೆ, ಯಾವುದೇ ಡೇಟಾ ಟ್ರ್ಯಾಕಿಂಗ್ ಇಲ್ಲದೆ ಮತ್ತು ಕ್ಲೌಡ್ ಅವಲಂಬನೆ ಇಲ್ಲದೆ.",
+  "onboardingPrivacyDescription": "ಖಾತೆಗಳು ಅಥವಾ ಆ್ಯಪ್ ಟ್ರ್ಯಾಕಿಂಗ್ ಇಲ್ಲ. ಆಫ್‌ಲೈನ್‌ನಲ್ಲಿ ಸಂದೇಶಗಳನ್ನು ರಚಿಸಿ.",
   "onboardingContinue": "ಮುಂದುವರಿಸಿ",
   "errorGenericTitle": "ಏನೋ ತಪ್ಪಾಗಿದೆ",
   "errorPageNotFound": "ಪುಟ ಕಂಡುಬಂದಿಲ್ಲ",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -117,7 +117,7 @@
   "messageStop": "중지",
   "onboardingSmartRewritingDescription": "타일 탭을 자연스러운 문장으로 확장하고 어조를 조정하세요: 직설적인, 전문적인, 친근한.",
   "onboardingTranslationDescription": "보드를 기기에서 번역하여 여러 언어로 소통하세요.",
-  "onboardingPrivacyDescription": "전적으로 기기에서 실행되며, 데이터 추적이 전혀 없고 클라우드에 의존하지 않습니다.",
+  "onboardingPrivacyDescription": "계정이나 앱 추적 없이 오프라인에서 메시지를 작성하세요.",
   "onboardingContinue": "계속",
   "errorGenericTitle": "문제가 발생했습니다",
   "errorPageNotFound": "페이지를 찾을 수 없음",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -117,7 +117,7 @@
   "messageStop": "Stoppen",
   "onboardingSmartRewritingDescription": "Breid tikken op tegels uit tot natuurlijke zinnen en pas de toon aan: direct, professioneel of vriendelijk.",
   "onboardingTranslationDescription": "Vertaal borden lokaal om in meerdere talen te communiceren.",
-  "onboardingPrivacyDescription": "Draait volledig op je apparaat, zonder gegevens te volgen en zonder afhankelijkheid van de cloud.",
+  "onboardingPrivacyDescription": "Geen accounts of apptracking. Stel berichten offline samen.",
   "onboardingContinue": "Doorgaan",
   "errorGenericTitle": "Er is iets misgegaan",
   "errorPageNotFound": "Pagina niet gevonden",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -117,7 +117,7 @@
   "messageStop": "Zatrzymaj",
   "onboardingSmartRewritingDescription": "Zamień dotknięcia kafelków w naturalne zdania i dostosuj ton: bezpośredni, profesjonalny lub przyjazny.",
   "onboardingTranslationDescription": "Tłumacz tablice lokalnie, aby porozumiewać się w wielu językach.",
-  "onboardingPrivacyDescription": "Działa w całości na Twoim urządzeniu, bez śledzenia danych i bez zależności od chmury.",
+  "onboardingPrivacyDescription": "Bez kont i śledzenia w aplikacji. Twórz wiadomości offline.",
   "onboardingContinue": "Kontynuuj",
   "errorGenericTitle": "Coś poszło nie tak",
   "errorPageNotFound": "Nie znaleziono strony",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -117,7 +117,7 @@
   "messageStop": "Parar",
   "onboardingSmartRewritingDescription": "Transforme os toques nos blocos em frases naturais e ajuste o tom: direto, profissional ou amigável.",
   "onboardingTranslationDescription": "Traduza as pranchas localmente para se comunicar em vários idiomas.",
-  "onboardingPrivacyDescription": "Funciona inteiramente no seu dispositivo, sem rastreamento de dados nem dependência da nuvem.",
+  "onboardingPrivacyDescription": "Sem contas nem rastreamento no aplicativo. Crie mensagens offline.",
   "onboardingContinue": "Continuar",
   "errorGenericTitle": "Algo deu errado",
   "errorPageNotFound": "Página não encontrada",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -117,7 +117,7 @@
   "messageStop": "Oprește",
   "onboardingSmartRewritingDescription": "Transformă atingerile pe casete în propoziții naturale și ajustează tonul: direct, profesional sau prietenos.",
   "onboardingTranslationDescription": "Tradu tablele local pentru a comunica în mai multe limbi.",
-  "onboardingPrivacyDescription": "Rulează în întregime pe dispozitivul tău, fără urmărirea datelor și fără dependență de cloud.",
+  "onboardingPrivacyDescription": "Fără conturi sau urmărire în aplicație. Compune mesaje offline.",
   "onboardingContinue": "Continuă",
   "errorGenericTitle": "Ceva nu a mers bine",
   "errorPageNotFound": "Pagina nu a fost găsită",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -117,7 +117,7 @@
   "messageStop": "Остановить",
   "onboardingSmartRewritingDescription": "Превращайте нажатия на плитки в естественные предложения и настраивайте тон: прямой, профессиональный или дружелюбный.",
   "onboardingTranslationDescription": "Переводите доски локально, чтобы общаться на нескольких языках.",
-  "onboardingPrivacyDescription": "Работает полностью на вашем устройстве, без отслеживания данных и без зависимости от облака.",
+  "onboardingPrivacyDescription": "Без учетных записей и отслеживания в приложении. Составляйте сообщения офлайн.",
   "onboardingContinue": "Продолжить",
   "errorGenericTitle": "Что-то пошло не так",
   "errorPageNotFound": "Страница не найдена",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -117,7 +117,7 @@
   "messageStop": "Zastaviť",
   "onboardingSmartRewritingDescription": "Rozšírte ťuknutia na dlaždice na prirodzené vety a upravte tón: priamy, profesionálny alebo priateľský.",
   "onboardingTranslationDescription": "Prekladajte tabuľky lokálne, aby ste komunikovali vo viacerých jazykoch.",
-  "onboardingPrivacyDescription": "Beží úplne vo vašom zariadení, bez sledovania údajov a bez závislosti od cloudu.",
+  "onboardingPrivacyDescription": "Bez účtov a sledovania v aplikácii. Tvorte správy offline.",
   "onboardingContinue": "Pokračovať",
   "errorGenericTitle": "Niečo sa pokazilo",
   "errorPageNotFound": "Stránka sa nenašla",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -117,7 +117,7 @@
   "messageStop": "Ustavi",
   "onboardingSmartRewritingDescription": "Razširite dotike ploščic v naravne stavke in prilagodite ton: neposreden, profesionalen ali prijazen.",
   "onboardingTranslationDescription": "Prevajajte table lokalno za komunikacijo v več jezikih.",
-  "onboardingPrivacyDescription": "Deluje v celoti v vaši napravi, brez sledenja podatkom in brez odvisnosti od oblaka.",
+  "onboardingPrivacyDescription": "Brez računov in sledenja v aplikaciji. Sestavljajte sporočila brez povezave.",
   "onboardingContinue": "Nadaljuj",
   "errorGenericTitle": "Nekaj je šlo narobe",
   "errorPageNotFound": "Strani ni mogoče najti",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -117,7 +117,7 @@
   "messageStop": "Stoppa",
   "onboardingSmartRewritingDescription": "Utöka tryck på rutor till naturliga meningar och justera tonen: direkt, professionell eller vänlig.",
   "onboardingTranslationDescription": "Översätt tavlor lokalt för att kommunicera på flera språk.",
-  "onboardingPrivacyDescription": "Körs helt på din enhet, utan dataspårning och utan molnberoende.",
+  "onboardingPrivacyDescription": "Inga konton eller spårning i appen. Skriv meddelanden offline.",
   "onboardingContinue": "Fortsätt",
   "errorGenericTitle": "Något gick fel",
   "errorPageNotFound": "Sidan hittades inte",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -117,7 +117,7 @@
   "messageStop": "நிறுத்து",
   "onboardingSmartRewritingDescription": "டைல் தட்டல்களை இயல்பான வாக்கியங்களாக விரிவாக்கி, தொனியை சரிசெய்யுங்கள்: நேரடி, தொழில்முறை அல்லது நட்பான.",
   "onboardingTranslationDescription": "பல மொழிகளில் தொடர்புகொள்ள பலகைகளை சாதனத்திலேயே மொழிபெயர்க்கவும்.",
-  "onboardingPrivacyDescription": "முழுவதுமாக உங்கள் சாதனத்தில் இயங்குகிறது, எந்த தரவுக் கண்காணிப்பும் இல்லாமல், கிளவுட் சார்பும் இல்லாமல்.",
+  "onboardingPrivacyDescription": "கணக்குகளோ செயலிக் கண்காணிப்போ இல்லை. இணையமின்றி செய்திகளை உருவாக்குங்கள்.",
   "onboardingContinue": "தொடரவும்",
   "errorGenericTitle": "ஏதோ தவறு நடந்தது",
   "errorPageNotFound": "பக்கம் கிடைக்கவில்லை",

--- a/messages/te.json
+++ b/messages/te.json
@@ -117,7 +117,7 @@
   "messageStop": "ఆపు",
   "onboardingSmartRewritingDescription": "టైల్ ట్యాప్‌లను సహజమైన వాక్యాలుగా విస్తరించి, టోన్‌ను సర్దుబాటు చేయండి: నేరుగా, వృత్తిపరమైన లేదా స్నేహపూర్వక.",
   "onboardingTranslationDescription": "అనేక భాషల్లో సంభాషించేందుకు బోర్డులను స్థానికంగా అనువదించండి.",
-  "onboardingPrivacyDescription": "పూర్తిగా మీ పరికరంలోనే పనిచేస్తుంది, ఎలాంటి డేటా ట్రాకింగ్ లేకుండా, క్లౌడ్ ఆధారపడటం లేకుండా.",
+  "onboardingPrivacyDescription": "ఖాతాలు లేదా యాప్ ట్రాకింగ్ ఉండదు. ఆఫ్‌లైన్‌లో సందేశాలను రూపొందించండి.",
   "onboardingContinue": "కొనసాగించు",
   "errorGenericTitle": "ఏదో తప్పు జరిగింది",
   "errorPageNotFound": "పేజీ కనుగొనబడలేదు",

--- a/messages/th.json
+++ b/messages/th.json
@@ -117,7 +117,7 @@
   "messageStop": "หยุด",
   "onboardingSmartRewritingDescription": "ขยายการแตะไทล์ให้เป็นประโยคที่เป็นธรรมชาติ และปรับโทน: ตรงไปตรงมา เป็นทางการ หรือเป็นมิตร",
   "onboardingTranslationDescription": "แปลบอร์ดในเครื่อง เพื่อสื่อสารได้หลายภาษา",
-  "onboardingPrivacyDescription": "ทำงานบนอุปกรณ์ของคุณทั้งหมด ไม่มีการติดตามข้อมูลและไม่ต้องพึ่งพาคลาวด์",
+  "onboardingPrivacyDescription": "ไม่มีบัญชีหรือการติดตามในแอป สร้างข้อความแบบออฟไลน์",
   "onboardingContinue": "ดำเนินการต่อ",
   "errorGenericTitle": "เกิดข้อผิดพลาดบางอย่าง",
   "errorPageNotFound": "ไม่พบหน้านี้",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -117,7 +117,7 @@
   "messageStop": "Durdur",
   "onboardingSmartRewritingDescription": "Karelere dokunuşları doğal cümlelere dönüştürün ve tonu ayarlayın: doğrudan, profesyonel veya samimi.",
   "onboardingTranslationDescription": "Birden fazla dilde iletişim kurmak için panoları yerel olarak çevirin.",
-  "onboardingPrivacyDescription": "Tamamen cihazınızda çalışır; veri takibi olmadan ve buluta bağımlılık olmadan.",
+  "onboardingPrivacyDescription": "Hesap veya uygulama takibi yok. Mesajları çevrimdışı oluşturun.",
   "onboardingContinue": "Devam et",
   "errorGenericTitle": "Bir şeyler ters gitti",
   "errorPageNotFound": "Sayfa bulunamadı",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -117,7 +117,7 @@
   "messageStop": "Зупинити",
   "onboardingSmartRewritingDescription": "Перетворюйте натискання на плитки на природні речення та налаштовуйте тон: прямий, професійний або дружній.",
   "onboardingTranslationDescription": "Перекладайте дошки локально, щоб спілкуватися кількома мовами.",
-  "onboardingPrivacyDescription": "Працює повністю на вашому пристрої, без відстеження даних і без залежності від хмари.",
+  "onboardingPrivacyDescription": "Без облікових записів і відстеження в застосунку. Складайте повідомлення офлайн.",
   "onboardingContinue": "Продовжити",
   "errorGenericTitle": "Щось пішло не так",
   "errorPageNotFound": "Сторінку не знайдено",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -117,7 +117,7 @@
   "messageStop": "Dừng",
   "onboardingSmartRewritingDescription": "Mở rộng các lần chạm ô thành câu tự nhiên và điều chỉnh giọng điệu: trực tiếp, chuyên nghiệp hoặc thân thiện.",
   "onboardingTranslationDescription": "Dịch bảng ngay trên thiết bị để giao tiếp bằng nhiều ngôn ngữ.",
-  "onboardingPrivacyDescription": "Chạy hoàn toàn trên thiết bị của bạn, không theo dõi dữ liệu và không phụ thuộc vào đám mây.",
+  "onboardingPrivacyDescription": "Không tài khoản, không theo dõi trong ứng dụng. Soạn tin nhắn khi ngoại tuyến.",
   "onboardingContinue": "Tiếp tục",
   "errorGenericTitle": "Đã xảy ra lỗi",
   "errorPageNotFound": "Không tìm thấy trang",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -117,7 +117,7 @@
   "messageStop": "停止",
   "onboardingSmartRewritingDescription": "将点按图块扩展为自然的句子，并调整语气：直接、专业或友好。",
   "onboardingTranslationDescription": "在本地翻译沟通板，以使用多种语言交流。",
-  "onboardingPrivacyDescription": "完全在你的设备上运行，零数据追踪，也不依赖云端。",
+  "onboardingPrivacyDescription": "无需账户，也无应用追踪。可离线编写消息。",
   "onboardingContinue": "继续",
   "errorGenericTitle": "出了点问题",
   "errorPageNotFound": "页面未找到",

--- a/src/app/onboarding/onboarding-dialog.test.tsx
+++ b/src/app/onboarding/onboarding-dialog.test.tsx
@@ -30,7 +30,7 @@ describe("OnboardingDialog", () => {
     for (const benefit of [
       "Say more with fewer taps. AI helps your messages sound clear and natural.",
       "Communicate across languages, right from your board.",
-      "Your communication stays private and works offline. No subscription needed.",
+      "No accounts or app tracking. Build messages offline.",
     ]) {
       await expect.element(screen.getByText(benefit)).toBeVisible();
     }


### PR DESCRIPTION
## Summary

- replace the onboarding privacy line with concise, accurate copy across all 35 locales
- clarify which core board behaviors work offline
- document third-party media requests, image-cache eviction, remote-audio limits, and platform-dependent speech voices
- update the onboarding browser test for the revised English copy

## Why

The previous copy implied that all communication and loaded-board behavior was private and offline. Third-party media URLs still contact their source hosts, remote audio remains network-dependent, and some platform voices may use external services. The new wording preserves the short onboarding presentation while keeping those caveats in the detailed documentation.

## User impact

Users get a clearer privacy and offline promise without turning the onboarding benefit row into a technical disclaimer.

## Validation

- `npm run lint`
- `npm test` (72 files, 525 tests)
- `npm run build`
- `git diff --check`
