### PR TITLE
Improve function flow grouping

### DIFF
--- a/src/app/routing/loaders/board-loader.ts
+++ b/src/app/routing/loaders/board-loader.ts
@@ -25,6 +25,7 @@ export async function boardLoader({
   try {
     const hydrated = await hydrateBoard(setId, boardId, request.signal);
     media = hydrated.media;
+
     const language = getStoredLanguage();
     const board = await resolveTranslatedBoard(
       setId,

--- a/src/app/settings/speech-settings.tsx
+++ b/src/app/settings/speech-settings.tsx
@@ -36,7 +36,6 @@ export function SpeechSettings() {
   const voicesByLanguage = useVoicesByLanguage();
   const { voiceURI, rate, pitch, volume } = useSpeechConfig();
   const { highlightActivePart } = useHighlightConfig();
-
   const { language } = useLanguage();
 
   const voices = voicesByLanguage[language] ?? [];
@@ -49,7 +48,6 @@ export function SpeechSettings() {
   );
 
   const hasMultipleLocales = locales.length > 1;
-
   const languageNames = new Intl.DisplayNames([language], {
     type: "language",
   });

--- a/src/features/board/activation/button-activation.ts
+++ b/src/features/board/activation/button-activation.ts
@@ -91,6 +91,7 @@ export function createButtonActivation({
       if (partsToSpeak !== message.parts) {
         message.setParts(partsToSpeak);
       }
+
       // Post-speak mutations (":speak" then ":clear") commit after the
       // utterance, so the spoken message stays visible while it plays.
       const partsAfterSpeak = parts;

--- a/src/features/board/grid/grid.tsx
+++ b/src/features/board/grid/grid.tsx
@@ -73,6 +73,7 @@ export function Grid<TItem extends { id: string }>({
               </Stack>
             );
           });
+
           return (
             <Stack
               key={rowIndex}

--- a/src/features/board/keyboard/use-board-keyboard.ts
+++ b/src/features/board/keyboard/use-board-keyboard.ts
@@ -35,6 +35,7 @@ export function useBoardKeyboard({
       }
 
       event.preventDefault();
+
       switch (action.kind) {
         case "backspace":
           message.backspace();

--- a/src/features/board/storage/board-hydration.ts
+++ b/src/features/board/storage/board-hydration.ts
@@ -70,6 +70,7 @@ function createBoardMediaResource(
       if (state === "disposed") {
         throw new Error("Cannot commit disposed board media");
       }
+
       if (state === "committed") {
         return;
       }

--- a/src/features/board/storage/boards-db.ts
+++ b/src/features/board/storage/boards-db.ts
@@ -131,6 +131,7 @@ export function getBoardsDB(): Promise<BoardsDB> {
 export async function closeBoardsDB(): Promise<void> {
   const pending = connection;
   connection = null;
+
   try {
     (await pending)?.close();
   } catch {
@@ -268,6 +269,7 @@ export async function createBoardSet(
         }),
       );
     }
+
     for (const asset of assets) {
       requests.push(
         assetStore.put({
@@ -277,6 +279,7 @@ export async function createBoardSet(
         }),
       );
     }
+
     requests.push(boardSetStore.add(record));
 
     await Promise.all(requests);
@@ -286,6 +289,7 @@ export async function createBoardSet(
     } catch {
       // Already finished — the transaction aborted itself.
     }
+
     await Promise.allSettled(requests);
     throw error;
   }

--- a/src/features/board/suggestions/to-phrases.ts
+++ b/src/features/board/suggestions/to-phrases.ts
@@ -10,11 +10,14 @@ export function toPhrases(
     if (!candidate || !isClean(candidate)) {
       return false;
     }
+
     const key = normalize(candidate);
     if (seen.has(key)) {
       return false;
     }
+
     seen.add(key);
+
     return true;
   });
 }

--- a/src/shared/hooks/use-latest-async.ts
+++ b/src/shared/hooks/use-latest-async.ts
@@ -49,6 +49,7 @@ export function useLatestAsync<T>({
         if (signal.aborted) {
           return;
         }
+
         setRound({
           signature,
           status: "rejected",

--- a/src/shared/playback/transports/speak.ts
+++ b/src/shared/playback/transports/speak.ts
@@ -49,6 +49,7 @@ export function speak(
     utterance.onerror = null;
     utterance.onboundary = null;
     signal?.removeEventListener("abort", onAbort);
+
     resolve();
   }
 

--- a/src/shared/snackbar/snackbar-provider.tsx
+++ b/src/shared/snackbar/snackbar-provider.tsx
@@ -51,6 +51,7 @@ export function SnackbarProvider({ children }: SnackbarProviderProps) {
       ...snackbarOptions,
       key: nextKeyRef.current++,
     };
+
     dispatch({ type: "show", snackbar });
   };
 
@@ -72,6 +73,7 @@ export function SnackbarProvider({ children }: SnackbarProviderProps) {
   const contextValue: SnackbarContextValue = {
     showSnackbar,
   };
+
   const message =
     typeof state.current?.message === "function"
       ? state.current.message(t)

--- a/src/shared/theme/theme-provider.tsx
+++ b/src/shared/theme/theme-provider.tsx
@@ -138,6 +138,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   const { direction } = useLanguage();
   const isRtl = direction === "rtl";
   const reducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
+
   const theme = createTheme({
     ...getThemeOptions(reducedMotion),
     direction: isRtl ? "rtl" : "ltr",

--- a/src/shared/utils/locale.ts
+++ b/src/shared/utils/locale.ts
@@ -60,6 +60,7 @@ export function getTextDirection(locale: string): "ltr" | "rtl" {
  */
 export function getNativeLanguageName(locale: string): string {
   const language = getLanguageCode(locale);
+
   try {
     return (
       new Intl.DisplayNames([language], { type: "language" }).of(language) ??


### PR DESCRIPTION
## Summary

- review non-test functions across the board, shared, and app source folders
- add paragraph boundaries between distinct setup, guard, dispatch, cleanup, and persistence phases
- remove unnecessary boundaries that split closely related hook and locale setup

## Impact

This is a whitespace-only readability cleanup. It does not change runtime behavior.

## Validation

- `npm run lint`
- `npm test` — 72 files and 525 tests passed
- `npm run build`
- `git diff --check`
