### PR TITLE
Silence router fixture warnings

### DIFF
--- a/src/app/routing/route-error-boundary.test.tsx
+++ b/src/app/routing/route-error-boundary.test.tsx
@@ -7,12 +7,22 @@ import { render } from "vitest-browser-react";
 import { RouteErrorBoundary } from "./route-error-boundary";
 import { createLocalizedRouteError, routeErrorCodes } from "./route-error";
 
+function TestRoute() {
+  return null;
+}
+
+function TestHydrateFallback() {
+  return null;
+}
+
 function renderWithLoader(loader: () => unknown) {
   const router = createMemoryRouter(
     [
       {
         path: "/",
         loader,
+        Component: TestRoute,
+        HydrateFallback: TestHydrateFallback,
         ErrorBoundary: RouteErrorBoundary,
       },
     ],

--- a/src/app/routing/use-revalidate-on-language-change.test.tsx
+++ b/src/app/routing/use-revalidate-on-language-change.test.tsx
@@ -11,12 +11,21 @@ function Probe() {
   return <p>probe ready</p>;
 }
 
+function TestHydrateFallback() {
+  return null;
+}
+
 describe("useRevalidateOnLanguageChange", () => {
   test("re-runs route loaders only when the language actually changes", async () => {
     setStoredLanguage("en");
     const loader = vi.fn(() => null);
     const router = createMemoryRouter([
-      { path: "/", element: <Probe />, loader },
+      {
+        path: "/",
+        element: <Probe />,
+        loader,
+        HydrateFallback: TestHydrateFallback,
+      },
     ]);
 
     const screen = await render(


### PR DESCRIPTION
## What changed

- add an explicit empty route component and hydration fallback to the route error-boundary test fixture
- add a hydration fallback to the language revalidation test fixture

## Why

React Router warned because the synthetic test routes did not fully declare their normal render and initial hydration states. The loaders still behaved correctly and the tests passed, but the incomplete fixture definitions produced noisy warnings.

This is test-only and does not change application behavior.

## Validation

- targeted router tests pass without warnings
- `npm run lint`
- `npm test` — 537 tests pass
- `npm run build`
