### PR TITLE
chore: bump version to 1.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aac-board-ai",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aac-board-ai",
-      "version": "1.16.1",
+      "version": "1.17.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "aac-board-ai",
   "private": true,
-  "version": "1.16.1",
+  "version": "1.17.0",
   "license": "MIT",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary

- bump the application version from 1.16.1 to 1.17.0
- update the lockfile root package version

## Validation

- `npm install`
- `npm run lint`
- `npm test` — 537 tests passed
- `npm run build`