### PR TITLE
Fix GitHub Mermaid rendering

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -129,7 +129,7 @@ sequenceDiagram
 
     User->>Router: Navigate to a board
     Router->>Storage: hydrateBoard(setId, boardId)
-    Storage->>Storage: Read OBF and assets; create URLs; map to Board
+    Storage->>Storage: Read OBF and assets, create URLs, and map to Board
     Storage-->>Router: Board + provisional media
     Router->>Translation: Resolve communication language
 
@@ -139,14 +139,14 @@ sequenceDiagram
         Translation->>AI: Translate board phrases
         AI-->>Translation: Translations
         Translation->>Storage: Start best-effort cache write
-        Note right of Storage: updateBoardStrings is not awaited;<br/>failure only costs re-translation
+        Note right of Storage: updateBoardStrings is not awaited<br/>failure only costs re-translation
         Translation-->>Router: Translated Board
     else Translator unavailable or fails
         Translation-->>Router: Untranslated Board
     end
 
     Router-->>Route: Render ready Board + provisional media
-    Route->>Route: Commit new media; dispose previous media
+    Route->>Route: Commit new media and dispose previous media
 
     Note over Router,Route: Loader failure or navigation abort disposes provisional media
 ```


### PR DESCRIPTION
## What changed

- Reworded three sequence-diagram messages to avoid semicolons in Mermaid text.

## Why

GitHub's Mermaid parser treats semicolons as statement separators. The first affected message caused `create URLs` to be parsed as a dynamic participant command, so GitHub displayed a parse error instead of the diagram.

## Impact

The **Open a board** sequence diagram in `docs/architecture.md` now renders correctly on GitHub. There is no application runtime change.

## Validation

- `npm run lint`
- `npm test` — 75 files, 537 tests passed
- `npm run build`
- `git diff --check`
