### PR TITLE
fix: restrict feature testing imports to tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -72,6 +72,17 @@ export default defineConfig([
   },
   {
     files: ["src/app/**/*.{ts,tsx}", "src/pages/**/*.{ts,tsx}"],
+    ignores: ["src/app/**/*.test.{ts,tsx}", "src/pages/**/*.test.{ts,tsx}"],
+    rules: {
+      "no-restricted-imports": restrictImports({
+        regex: "^@features/[^/]+/.+",
+        message:
+          "A feature's internals and testing API are private — use its barrel, e.g. @features/board.",
+      }),
+    },
+  },
+  {
+    files: ["src/app/**/*.test.{ts,tsx}", "src/pages/**/*.test.{ts,tsx}"],
     rules: {
       "no-restricted-imports": restrictImports({
         regex: "^@features/[^/]+/(?!testing$).+",


### PR DESCRIPTION
## Summary

- reject `@features/*/testing` imports from production app and page modules
- preserve the sanctioned testing entry for `*.test.ts(x)` files
- continue rejecting deeper feature internals and MUI package-root imports in tests

## Why

The feature-boundary rule exempted the `/testing` entry for every app and page module. That allowed production code to import test-only helpers such as `resetBoardsDB`, which can clear persisted board data.

The configuration now separates production and test scopes: production modules may consume only a feature barrel, while test modules may additionally consume the exact `/testing` entry.

## Impact

This is a lint-only guardrail with no runtime behavior change. It prevents test-support APIs from leaking into production code while preserving all existing test imports.

## Validation

- `npm run lint`
- `npm test` — 75 files and 537 tests passed
- `npm run build`
- targeted ESLint probes for production barrels, production testing entries, test barrels, test testing entries, feature internals, and MUI barrel imports
- Prettier and `git diff --check`
