### PR TITLE
Enable type-checked React linting

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,7 +27,7 @@ export default defineConfig([
       js.configs.recommended,
       tseslint.configs.recommendedTypeChecked,
       tseslint.configs.stylisticTypeChecked,
-      eslintReact.configs["recommended-typescript"],
+      eslintReact.configs["recommended-type-checked"],
       eslintReact.configs["disable-rsc"],
       reactHooks.configs.flat.recommended,
       reactRefresh.configs.vite(),

--- a/src/shared/ui/status-layout.tsx
+++ b/src/shared/ui/status-layout.tsx
@@ -31,7 +31,7 @@ export function StatusLayout({
         textAlign: "center",
       }}
     >
-      {icon && (
+      {Boolean(icon) && (
         <Box
           sx={{
             width: 64,
@@ -60,7 +60,7 @@ export function StatusLayout({
         )}
       </Box>
 
-      {action && <Box>{action}</Box>}
+      {Boolean(action) && <Box>{action}</Box>}
     </Stack>
   );
 }


### PR DESCRIPTION
## What changed

- Replaced the ESLint React `recommended-typescript` preset with `recommended-type-checked`.
- Made the optional `StatusLayout` icon and action render guards explicitly boolean.

## Why

The project already enables TypeScript project services, but the React preset was not enabling rules that use type information. Enabling the type-checked preset surfaced two conditional-rendering hazards where non-boolean `ReactNode` values could leak into the rendered output.

## Impact

React linting now uses the available TypeScript type information. `StatusLayout` continues to render optional icons and actions while safely excluding falsey non-elements.

## Validation

- `npm run lint`
- `npm test` — 537 tests passed across 75 files
- `npm run build`
- `git diff --check`
