### PR TITLE
refactor: tighten comments and MUI type imports

### DIFF
--- a/src/features/board/import/board-import.ts
+++ b/src/features/board/import/board-import.ts
@@ -25,12 +25,12 @@ export interface ImportResult {
 }
 
 /**
- * Decompression limits enforced against an OBZ archive's declared uncompressed
- * sizes before any entry is inflated — zip-bomb defense for every import path
- * (picker, drag-drop, file-handler, URL). The caps are deliberately generous
- * versus real boards (observed up to ~70MB) but bounded, so a maliciously
- * crafted archive is rejected before it can exhaust memory. Exceeding a cap
- * makes `loadBoard` throw an `OBFError` with code `"archive-too-large"`.
+ * Decompression caps used by every OBZ import path. Limits are checked against
+ * each entry's declared metadata before that entry is inflated; entries
+ * accepted earlier may already be allocated. The values are generous relative
+ * to observed boards (~70 MB) while bounding decompression allocation.
+ * Exceeding a cap makes `loadBoard` throw an `OBFError` with code
+ * `"archive-too-large"`.
  */
 export const BOARD_IMPORT_LIMITS: UnzipLimits = {
   maxTotalOriginalSize: 500 * 1024 * 1024,

--- a/src/features/board/keyboard/board-key-resolver.ts
+++ b/src/features/board/keyboard/board-key-resolver.ts
@@ -11,9 +11,9 @@ export interface KeyEventLike {
 }
 
 /**
- * Resolves a keystroke to a board action, or `null` when the board doesn't
- * claim the key — so the caller leaves it be: Enter and Space keep activating
- * the focused control, and ⌘/Ctrl combos reach the browser.
+ * Resolves board-owned keyboard shortcuts to actions. Returns `null` for
+ * unclaimed keys so native control activation and browser shortcuts can
+ * continue.
  */
 export function resolveBoardKey(
   event: KeyEventLike,

--- a/src/features/board/obf/css-color.ts
+++ b/src/features/board/obf/css-color.ts
@@ -1,8 +1,7 @@
 /**
- * Returns the color only if the browser parses it as a valid CSS <color>,
- * otherwise undefined. Guards against untrusted values that get interpolated
- * into CSS declarations: validating with the browser's own parser rejects
- * breakout payloads like "x); } a { background-image: url(...) }".
+ * Returns `color` only when the browser accepts it for the CSS `color`
+ * property. This rejects declaration-breakout strings before untrusted board
+ * colors are embedded in derived CSS.
  */
 export function sanitizeColor(color: string | undefined): string | undefined {
   if (color === undefined) {

--- a/src/features/board/testing/fixtures.ts
+++ b/src/features/board/testing/fixtures.ts
@@ -1,7 +1,4 @@
-/**
- * Minimal valid 1x1 transparent PNG as data URI.
- * Use this in tests that need an image src to avoid network requests.
- */
+/** Inline 1×1 PNG for tests that need an image source without a network request. */
 export const TEST_IMAGE_SRC =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
 

--- a/src/shared/theme/merge-sx.ts
+++ b/src/shared/theme/merge-sx.ts
@@ -1,10 +1,6 @@
 import type { SxProps, Theme } from "@mui/material/styles";
-import type { SystemStyleObject } from "@mui/system/styleFunctionSx";
 
-type SxItem =
-  | boolean
-  | SystemStyleObject<Theme>
-  | ((theme: Theme) => SystemStyleObject<Theme>);
+type SxItem = Extract<SxProps<Theme>, readonly unknown[]>[number];
 
 export function mergeSx(
   base: SxItem,

--- a/src/shared/theme/rtl.ts
+++ b/src/shared/theme/rtl.ts
@@ -1,12 +1,12 @@
 import type { Theme } from "@mui/material/styles";
 
-/** Mirrors on the X axis in RTL — for directional icons (arrows, backspace, play). */
+/** Mirrors directional icons such as Back and Backspace on the X axis in RTL. */
 export const flipForRtl = (theme: Theme) =>
   theme.direction === "rtl" ? { transform: "scaleX(-1)" } : {};
 
 /**
- * Mirrors on the X axis in LTR — for asymmetric icons that already read
- * correctly in RTL (e.g. a sidebar icon depicting a left-hand rail).
+ * Mirrors on the X axis in LTR when the source artwork already has its RTL
+ * orientation, such as `ViewSidebarOutlined` and its right-hand rail.
  */
 export const flipForLtr = (theme: Theme) =>
   theme.direction === "ltr" ? { transform: "scaleX(-1)" } : {};

--- a/src/shared/theme/safe-area.ts
+++ b/src/shared/theme/safe-area.ts
@@ -1,20 +1,16 @@
 type SafeAreaSide = "top" | "right" | "bottom" | "left";
 
 /**
- * The raw device safe-area inset for one edge — `0` when there is nothing to
- * clear (no notch, rounded corner, or home indicator). Use for full-bleed
- * content that has no gutter of its own, or when the base gutter is supplied by
- * an ancestor.
+ * Returns the CSS safe-area inset for one edge. Use for full-bleed content or
+ * when base spacing is supplied elsewhere.
  */
 export function safeAreaInset(side: SafeAreaSide): string {
   return `env(safe-area-inset-${side})`;
 }
 
 /**
- * A gutter that keeps its base length and grows to also clear the device
- * safe-area inset. Additive on purpose: bare `env()` drops the gutter when
- * there is no inset (portrait), and `max()` drops it right beside a notch —
- * this keeps the gutter AND clears the inset in every orientation.
+ * Adds the safe-area inset to a base gutter. Addition is intentional: `env()`
+ * alone omits the base gutter, while `max()` preserves only the larger term.
  */
 export function safeAreaGutter(
   base: string | number,

--- a/src/shared/utils/locale.ts
+++ b/src/shared/utils/locale.ts
@@ -3,8 +3,8 @@ function parseLocale(locale: string): Intl.Locale {
 }
 
 /**
- * Normalizes a BCP-47 locale code to canonical casing
- * (lowercase language subtag, uppercase region subtag, hyphen separator).
+ * Returns the canonical BCP 47 base name, accepting `_` separators and
+ * stripping extensions. Returns the input unchanged when parsing fails.
  */
 export function normalizeLocale(locale: string): string {
   try {
@@ -19,8 +19,8 @@ export function getLanguageCode(locale: string): string {
 }
 
 /**
- * Returns the uppercase region subtag of a locale code, or undefined when
- * none is present (e.g. "fr-CA" → "CA", "fr" → undefined).
+ * Returns the explicit region subtag in canonical form, or `undefined` when
+ * none is present (`fr-CA` → `CA`; `fr` → `undefined`).
  */
 export function getRegionCode(locale: string): string | undefined {
   try {
@@ -31,8 +31,8 @@ export function getRegionCode(locale: string): string | undefined {
 }
 
 /**
- * Returns the region most associated with a language via CLDR likely-subtags
- * (e.g. "fr" → "FR", "en" → "US"). Undefined for unrecognized input.
+ * Returns the region inferred by `Intl.Locale.maximize()` (`fr` → `FR`;
+ * `en` → `US`), or `undefined` when no region can be inferred.
  */
 export function getLikelyRegion(language: string): string | undefined {
   try {
@@ -43,8 +43,8 @@ export function getLikelyRegion(language: string): string | undefined {
 }
 
 /**
- * Falls back to "ltr" for structurally invalid input; unknown
- * but well-formed codes default to "ltr" via Intl.
+ * Returns the locale's text direction. Falls back to `ltr` when Intl rejects
+ * the tag or cannot determine a direction.
  */
 export function getTextDirection(locale: string): "ltr" | "rtl" {
   try {
@@ -54,10 +54,7 @@ export function getTextDirection(locale: string): "ltr" | "rtl" {
   }
 }
 
-/**
- * Returns the language name in its own language (endonym),
- * e.g. "es" → "español", "fr" → "français".
- */
+/** Returns the primary language's endonym (`es` → `español`; `fr` → `français`). */
 export function getNativeLanguageName(locale: string): string {
   const language = getLanguageCode(locale);
 


### PR DESCRIPTION
## Summary

- tighten JSDoc wording around archive limits, keyboard shortcuts, CSS colors, test imagery, RTL helpers, safe areas, and locale handling
- remove misleading guarantees and examples while preserving non-obvious rationale
- derive the `mergeSx` item type from Material UI's public `SxProps` type instead of importing `SystemStyleObject` from `@mui/system`

## Why

Several comments overstated guarantees or described behavior less precisely than the implementation. The `mergeSx` helper also reached into a lower-level MUI package for a type already represented by the public Material API.

## Impact

Documentation and type-only changes; runtime behavior is unchanged.

## Validation

- `npm run lint`
- `npm test` — 537 tests passed
- `npm run build`
