### PR TITLE
Add Vitest ESLint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,6 @@
 import eslintReact from "@eslint-react/eslint-plugin";
 import js from "@eslint/js";
+import vitest from "@vitest/eslint-plugin";
 import eslintConfigPrettier from "eslint-config-prettier/flat";
 import reactHooks from "eslint-plugin-react-hooks";
 import { reactRefresh } from "eslint-plugin-react-refresh";
@@ -45,6 +46,18 @@ export default defineConfig([
       "@eslint-react/no-array-index-key": "off",
       "no-restricted-imports": restrictImports(),
       curly: "error",
+    },
+  },
+  {
+    files: ["src/**/*.test.{ts,tsx}"],
+    extends: [vitest.configs.recommended],
+    rules: {
+      "vitest/expect-expect": [
+        "error",
+        {
+          assertFunctionNames: ["expect", "assert", "expectNoA11yViolations"],
+        },
+      ],
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@vitejs/plugin-react": "^6.0.5",
         "@vitest/browser-playwright": "^4.1.10",
         "@vitest/coverage-v8": "^4.1.10",
+        "@vitest/eslint-plugin": "^1.6.27",
         "axe-core": "^4.13.0",
         "babel-plugin-react-compiler": "^1.0.0",
         "eslint": "^10.8.1",
@@ -4436,6 +4437,37 @@
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/eslint-plugin": {
+      "version": "1.6.27",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.27.tgz",
+      "integrity": "sha512-X1RCAfwbatG4GFbJ/1PIHP9MSZMt0JJThqbYID+vS4L783k6QGlLPe421wQE8dHXuGCcenVLsydiM4qzsYWxhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "^8.58.0",
+        "@typescript-eslint/utils": "^8.58.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "*",
+        "eslint": ">=8.57.0",
+        "typescript": ">=5.0.0",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "vitest": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@vitejs/plugin-react": "^6.0.5",
     "@vitest/browser-playwright": "^4.1.10",
     "@vitest/coverage-v8": "^4.1.10",
+    "@vitest/eslint-plugin": "^1.6.27",
     "axe-core": "^4.13.0",
     "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "^10.8.1",

--- a/src/features/board/playback/plan-playback.test.ts
+++ b/src/features/board/playback/plan-playback.test.ts
@@ -16,11 +16,14 @@ describe("planPlayback", () => {
     const steps = planPlayback(parts);
 
     expect(steps).toHaveLength(1);
-    expect(steps[0]).toMatchObject({ kind: "speech" });
-    if (steps[0].kind === "speech") {
-      expect(steps[0].text).toBe("i want");
-      expect(steps[0].trackingKeyAt?.(2)).toBe("2");
+    const step = steps[0];
+
+    if (step.kind !== "speech") {
+      throw new Error("Expected a speech step");
     }
+
+    expect(step.text).toBe("i want");
+    expect(step.trackingKeyAt?.(2)).toBe("2");
   });
 
   test("emits a sound part as its own step carrying its part id", () => {


### PR DESCRIPTION
## Summary

- add `@vitest/eslint-plugin` as a development dependency
- apply the recommended Vitest rules to colocated test files through scoped ESLint `extends`
- recognize the shared accessibility assertion helper in `vitest/expect-expect`
- rewrite one conditional assertion so it complies with the recommended rules

## Why

Vitest-specific linting was not enabled, so invalid or ineffective test patterns could pass the general ESLint configuration unnoticed.

## Impact

Test files now receive Vitest's recommended static checks. Runtime application behavior is unchanged.

## Validation

- `npm run lint`
- `npm test` (75 files, 537 tests)
- `npm run build`
- `git diff --cached --check`
