### PR TITLE
Refactor component APIs and simplify value plumbing

### DIFF
--- a/src/app/shell/app-header.tsx
+++ b/src/app/shell/app-header.tsx
@@ -13,14 +13,14 @@ import { safeAreaGutter } from "@shared/theme/safe-area";
 
 interface AppHeaderProps {
   libraryButtonHidden?: boolean;
-  onLibraryClick: () => void;
-  onSettingsClick: () => void;
+  onOpenLibrary: () => void;
+  onOpenSettings: () => void;
 }
 
 export function AppHeader({
   libraryButtonHidden = false,
-  onLibraryClick,
-  onSettingsClick,
+  onOpenLibrary,
+  onOpenSettings,
 }: AppHeaderProps) {
   const t = useTranslate();
 
@@ -55,7 +55,7 @@ export function AppHeader({
                 size="large"
                 edge="start"
                 color="inherit"
-                onClick={onLibraryClick}
+                onClick={onOpenLibrary}
               >
                 <ViewSidebarOutlinedIcon sx={flipForLtr} />
               </IconButton>
@@ -74,7 +74,7 @@ export function AppHeader({
               size="large"
               edge="end"
               color="inherit"
-              onClick={onSettingsClick}
+              onClick={onOpenSettings}
             >
               <SettingsOutlinedIcon />
             </IconButton>

--- a/src/app/shell/app-shell.tsx
+++ b/src/app/shell/app-shell.tsx
@@ -42,8 +42,8 @@ export function AppShell() {
       <ContentColumn shifted={isLibraryPushingContent}>
         <AppHeader
           libraryButtonHidden={isLibraryPushingContent}
-          onLibraryClick={() => setIsLibraryOpen(true)}
-          onSettingsClick={() => setIsSettingsOpen(true)}
+          onOpenLibrary={() => setIsLibraryOpen(true)}
+          onOpenSettings={() => setIsSettingsOpen(true)}
         />
 
         <Box component="main" sx={{ flexGrow: 1, overflow: "auto" }}>

--- a/src/features/board/activation/button-activation.test.ts
+++ b/src/features/board/activation/button-activation.test.ts
@@ -2,9 +2,9 @@ import type { PlaybackOutcome } from "@shared/playback/playback-context";
 import { describe, expect, test, vi } from "vitest";
 import type { MessagePart } from "../message/message-types";
 import type { BoardButton } from "../types";
-import { createButtonActivation } from "./button-activation";
+import { createButtonActivator } from "./button-activation";
 
-type ActivationOptions = Parameters<typeof createButtonActivation>[0];
+type ActivationOptions = Parameters<typeof createButtonActivator>[0];
 
 function createMessageStub(
   parts: MessagePart[] = [],
@@ -40,14 +40,18 @@ function setup(opts: SetupOptions = {}) {
   const playback = opts.playback ?? createPlaybackStub();
   const navigation = opts.navigation ?? createNavigationStub();
 
-  const activation = createButtonActivation({ message, playback, navigation });
+  const activateButton = createButtonActivator({
+    message,
+    playback,
+    navigation,
+  });
 
-  return { activation, message, playback, navigation };
+  return { activateButton, message, playback, navigation };
 }
 
-describe("createButtonActivation", () => {
+describe("createButtonActivator", () => {
   test("navigates to the linked board and skips message and audio when loadBoard.id is set", () => {
-    const { activation, message, playback, navigation } = setup();
+    const { activateButton, message, playback, navigation } = setup();
 
     const button: BoardButton = {
       id: "btn",
@@ -55,7 +59,7 @@ describe("createButtonActivation", () => {
       loadBoard: { id: "child-board" },
     };
 
-    activation.activateButton(button);
+    activateButton(button);
 
     expect(navigation.goToBoard).toHaveBeenCalledWith("child-board");
     expect(message.setParts).not.toHaveBeenCalled();
@@ -64,18 +68,18 @@ describe("createButtonActivation", () => {
   });
 
   test("maps home to navigation.goHome", () => {
-    const { activation, navigation } = setup();
+    const { activateButton, navigation } = setup();
 
-    activation.activateButton({ id: "btn", actions: [{ kind: "home" }] });
+    activateButton({ id: "btn", actions: [{ kind: "home" }] });
 
     expect(navigation.goHome).toHaveBeenCalledTimes(1);
   });
 
   test("spell appends the text via setParts", () => {
     const message = createMessageStub([]);
-    const { activation } = setup({ message });
+    const { activateButton } = setup({ message });
 
-    activation.activateButton({
+    activateButton({
       id: "btn",
       actions: [{ kind: "spell", text: "t" }],
     });
@@ -89,9 +93,9 @@ describe("createButtonActivation", () => {
 
   test("space appends an empty-label part via setParts", () => {
     const message = createMessageStub([]);
-    const { activation } = setup({ message });
+    const { activateButton } = setup({ message });
 
-    activation.activateButton({ id: "btn", actions: [{ kind: "space" }] });
+    activateButton({ id: "btn", actions: [{ kind: "space" }] });
 
     expect(message.setParts).toHaveBeenCalledTimes(1);
     const [committed] = vi.mocked(message.setParts).mock.calls[0];
@@ -105,9 +109,9 @@ describe("createButtonActivation", () => {
       { id: "1", label: "hello" },
       { id: "2", label: "world" },
     ]);
-    const { activation } = setup({ message });
+    const { activateButton } = setup({ message });
 
-    activation.activateButton({ id: "btn", actions: [{ kind: "backspace" }] });
+    activateButton({ id: "btn", actions: [{ kind: "backspace" }] });
 
     expect(message.setParts).toHaveBeenCalledWith([
       { id: "1", label: "hello" },
@@ -117,9 +121,9 @@ describe("createButtonActivation", () => {
 
   test("clear empties the message via setParts", () => {
     const message = createMessageStub([{ id: "1", label: "hello" }]);
-    const { activation } = setup({ message });
+    const { activateButton } = setup({ message });
 
-    activation.activateButton({ id: "btn", actions: [{ kind: "clear" }] });
+    activateButton({ id: "btn", actions: [{ kind: "clear" }] });
 
     expect(message.setParts).toHaveBeenCalledWith([]);
   });
@@ -127,9 +131,9 @@ describe("createButtonActivation", () => {
   test("spelling then speaking speaks a message that includes the spelled letter", () => {
     const message = createMessageStub([]);
     const playback = createPlaybackStub();
-    const { activation } = setup({ message, playback });
+    const { activateButton } = setup({ message, playback });
 
-    activation.activateButton({
+    activateButton({
       id: "btn",
       actions: [{ kind: "spell", text: "s" }, { kind: "speak" }],
     });
@@ -153,9 +157,9 @@ describe("createButtonActivation", () => {
           resolvePlay = () => resolve("completed");
         }),
     );
-    const { activation } = setup({ message, playback });
+    const { activateButton } = setup({ message, playback });
 
-    activation.activateButton({
+    activateButton({
       id: "btn",
       actions: [{ kind: "speak" }, { kind: "clear" }],
     });
@@ -176,9 +180,9 @@ describe("createButtonActivation", () => {
     playback.playMessage = vi.fn((): Promise<PlaybackOutcome> =>
       Promise.resolve("interrupted"),
     );
-    const { activation } = setup({ message, playback });
+    const { activateButton } = setup({ message, playback });
 
-    activation.activateButton({
+    activateButton({
       id: "btn",
       actions: [{ kind: "speak" }, { kind: "clear" }],
     });
@@ -190,9 +194,9 @@ describe("createButtonActivation", () => {
   test("a mutation-only sequence folds every mutation into one commit and never plays", () => {
     const message = createMessageStub([]);
     const playback = createPlaybackStub();
-    const { activation } = setup({ message, playback });
+    const { activateButton } = setup({ message, playback });
 
-    activation.activateButton({
+    activateButton({
       id: "btn",
       actions: [
         { kind: "spell", text: "h" },
@@ -211,9 +215,9 @@ describe("createButtonActivation", () => {
     const initialParts: MessagePart[] = [{ id: "1", label: "hi" }];
     const message = createMessageStub(initialParts);
     const playback = createPlaybackStub();
-    const { activation } = setup({ message, playback });
+    const { activateButton } = setup({ message, playback });
 
-    activation.activateButton({ id: "btn", actions: [{ kind: "speak" }] });
+    activateButton({ id: "btn", actions: [{ kind: "speak" }] });
 
     expect(playback.playMessage).toHaveBeenCalledWith(initialParts);
 
@@ -223,9 +227,9 @@ describe("createButtonActivation", () => {
   });
 
   test("treats an empty actions array as no actions and speaks instead", () => {
-    const { activation, message } = setup();
+    const { activateButton, message } = setup();
 
-    activation.activateButton({
+    activateButton({
       id: "btn",
       label: "hi",
       actions: [],
@@ -236,9 +240,9 @@ describe("createButtonActivation", () => {
 
   test("adds the button as a message part when there are no actions and no loadBoard", () => {
     const message = createMessageStub([]);
-    const { activation } = setup({ message });
+    const { activateButton } = setup({ message });
 
-    activation.activateButton({
+    activateButton({
       id: "btn",
       label: "hi",
       vocalization: "hello",
@@ -257,9 +261,9 @@ describe("createButtonActivation", () => {
   });
 
   test("passes the composed sound part to playback", () => {
-    const { activation, playback } = setup();
+    const { activateButton, playback } = setup();
 
-    activation.activateButton({
+    activateButton({
       id: "btn",
       label: "bell",
       soundSrc: "bell.mp3",
@@ -272,9 +276,9 @@ describe("createButtonActivation", () => {
   });
 
   test("passes vocalization to playback without handling speech mechanics", () => {
-    const { activation, playback } = setup();
+    const { activateButton, playback } = setup();
 
-    activation.activateButton({
+    activateButton({
       id: "btn",
       label: "I",
       vocalization: "Hello",
@@ -286,9 +290,9 @@ describe("createButtonActivation", () => {
   });
 
   test("passes label-only content to playback", () => {
-    const { activation, playback } = setup();
+    const { activateButton, playback } = setup();
 
-    activation.activateButton({ id: "btn", label: "Goodbye" });
+    activateButton({ id: "btn", label: "Goodbye" });
 
     expect(playback.playPart).toHaveBeenCalledWith(
       expect.objectContaining({ label: "Goodbye" }),
@@ -296,9 +300,9 @@ describe("createButtonActivation", () => {
   });
 
   test("delegates inaudible content so playback policy stays centralized", () => {
-    const { activation, message, playback } = setup();
+    const { activateButton, message, playback } = setup();
 
-    activation.activateButton({ id: "btn" });
+    activateButton({ id: "btn" });
 
     expect(message.setParts).toHaveBeenCalledTimes(1);
     expect(playback.playPart).toHaveBeenCalledTimes(1);

--- a/src/features/board/activation/button-activation.ts
+++ b/src/features/board/activation/button-activation.ts
@@ -25,21 +25,19 @@ interface ActivationNavigation {
   goHome: () => void;
 }
 
-interface ButtonActivationOptions {
+interface ButtonActivatorOptions {
   message: ActivationMessage;
   playback: ActivationPlayback;
   navigation: ActivationNavigation;
 }
 
-interface ButtonActivation {
-  activateButton: (button: BoardButton) => void;
-}
+type ButtonActivator = (button: BoardButton) => void;
 
-export function createButtonActivation({
+export function createButtonActivator({
   message,
   playback,
   navigation,
-}: ButtonActivationOptions): ButtonActivation {
+}: ButtonActivatorOptions): ButtonActivator {
   function activateButton(button: BoardButton) {
     const intents = resolveButtonIntents(button);
 
@@ -109,5 +107,5 @@ export function createButtonActivation({
     }
   }
 
-  return { activateButton };
+  return activateButton;
 }

--- a/src/features/board/board-sets/board-set-delete-dialog.test.tsx
+++ b/src/features/board/board-sets/board-set-delete-dialog.test.tsx
@@ -15,7 +15,7 @@ describe("BoardSetDeleteDialog", () => {
     const screen = await renderWithProviders(
       <BoardSetDeleteDialog
         boardSet={makeBoardSet({ name: "Core Words" })}
-        onConfirm={vi.fn()}
+        onDelete={vi.fn()}
         onClose={vi.fn()}
       />,
     );
@@ -28,7 +28,7 @@ describe("BoardSetDeleteDialog", () => {
     const screen = await renderWithProviders(
       <BoardSetDeleteDialog
         boardSet={makeBoardSet({ name: "Core Words", boardCount: 1 })}
-        onConfirm={vi.fn()}
+        onDelete={vi.fn()}
         onClose={vi.fn()}
       />,
     );
@@ -49,7 +49,7 @@ describe("BoardSetDeleteDialog", () => {
     const screen = await renderWithProviders(
       <BoardSetDeleteDialog
         boardSet={makeBoardSet({ boardCount: 5 })}
-        onConfirm={vi.fn()}
+        onDelete={vi.fn()}
         onClose={vi.fn()}
       />,
     );
@@ -67,7 +67,7 @@ describe("BoardSetDeleteDialog", () => {
     const screen = await renderWithProviders(
       <BoardSetDeleteDialog
         boardSet={null}
-        onConfirm={vi.fn()}
+        onDelete={vi.fn()}
         onClose={vi.fn()}
       />,
     );
@@ -81,30 +81,30 @@ describe("BoardSetDeleteDialog", () => {
       .not.toBeInTheDocument();
   });
 
-  test("calls onConfirm when Delete is clicked", async () => {
-    const onConfirm = vi.fn();
+  test("calls onDelete when Delete is clicked", async () => {
+    const onDelete = vi.fn();
     const onClose = vi.fn();
     const screen = await renderWithProviders(
       <BoardSetDeleteDialog
         boardSet={makeBoardSet()}
-        onConfirm={onConfirm}
+        onDelete={onDelete}
         onClose={onClose}
       />,
     );
 
     await screen.getByRole("button", { name: "Delete" }).click();
 
-    expect(onConfirm).toHaveBeenCalledOnce();
+    expect(onDelete).toHaveBeenCalledOnce();
     expect(onClose).not.toHaveBeenCalled();
   });
 
   test("calls onClose when Cancel is clicked", async () => {
-    const onConfirm = vi.fn();
+    const onDelete = vi.fn();
     const onClose = vi.fn();
     const screen = await renderWithProviders(
       <BoardSetDeleteDialog
         boardSet={makeBoardSet()}
-        onConfirm={onConfirm}
+        onDelete={onDelete}
         onClose={onClose}
       />,
     );
@@ -112,6 +112,6 @@ describe("BoardSetDeleteDialog", () => {
     await screen.getByRole("button", { name: "Cancel" }).click();
 
     expect(onClose).toHaveBeenCalledOnce();
-    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onDelete).not.toHaveBeenCalled();
   });
 });

--- a/src/features/board/board-sets/board-set-delete-dialog.tsx
+++ b/src/features/board/board-sets/board-set-delete-dialog.tsx
@@ -10,13 +10,13 @@ import type { BoardSetRecord } from "../storage/board-set-storage";
 
 interface BoardSetDeleteDialogProps {
   boardSet: BoardSetRecord | null;
-  onConfirm: () => void;
+  onDelete: () => void;
   onClose: () => void;
 }
 
 export function BoardSetDeleteDialog({
   boardSet,
-  onConfirm,
+  onDelete,
   onClose,
 }: BoardSetDeleteDialogProps) {
   const t = useTranslate();
@@ -44,7 +44,7 @@ export function BoardSetDeleteDialog({
 
       <DialogActions>
         <Button onClick={onClose}>{t(m.libraryCancel)}</Button>
-        <Button onClick={onConfirm} color="error">
+        <Button onClick={onDelete} color="error">
           {t(m.libraryDelete)}
         </Button>
       </DialogActions>

--- a/src/features/board/board-sets/board-set-library.tsx
+++ b/src/features/board/board-sets/board-set-library.tsx
@@ -117,7 +117,7 @@ export function BoardSetLibrary({
 
       <BoardSetDeleteDialog
         boardSet={deleteTarget}
-        onConfirm={() => void handleDelete()}
+        onDelete={() => void handleDelete()}
         onClose={() => setDeleteTarget(null)}
       />
     </>

--- a/src/features/board/communication-board.tsx
+++ b/src/features/board/communication-board.tsx
@@ -113,7 +113,7 @@ export function CommunicationBoard({ board }: CommunicationBoardProps) {
               status={suggestions.status}
               phrases={suggestions.phrases}
               onEnable={suggestions.enable}
-              onPhraseClick={message.setFromText}
+              onPhraseSelect={message.setFromText}
             />
           )}
         </Stack>

--- a/src/features/board/communication-board.tsx
+++ b/src/features/board/communication-board.tsx
@@ -82,7 +82,7 @@ export function CommunicationBoard({ board }: CommunicationBoardProps) {
       labelPlacement={tileLabelPlacement}
       variant={button.loadBoard?.id ? "folder" : undefined}
       borderHidden={!areTileBordersVisible}
-      onClick={() => activateButton(button)}
+      onActivate={() => activateButton(button)}
       {...props}
     />
   );
@@ -104,7 +104,7 @@ export function CommunicationBoard({ board }: CommunicationBoardProps) {
         <Stack direction="row" spacing={2} sx={{ flex: 1, minWidth: 0 }}>
           {!isSmallScreen && (
             <NavButtons
-              onHomeClick={navigation.isHome ? scrollGridToOrigin : undefined}
+              onHome={navigation.isHome ? scrollGridToOrigin : undefined}
             />
           )}
 
@@ -151,7 +151,7 @@ export function CommunicationBoard({ board }: CommunicationBoardProps) {
           }}
         >
           <NavButtons
-            onHomeClick={navigation.isHome ? scrollGridToOrigin : undefined}
+            onHome={navigation.isHome ? scrollGridToOrigin : undefined}
           />
 
           <BackspaceButton

--- a/src/features/board/communication-board.tsx
+++ b/src/features/board/communication-board.tsx
@@ -8,7 +8,7 @@ import { useLanguage } from "@shared/language/use-language";
 import { useTranslate } from "@shared/language/use-translate";
 import { safeAreaInset } from "@shared/theme/safe-area";
 import { useRef, type CSSProperties } from "react";
-import { createButtonActivation } from "./activation/button-activation";
+import { createButtonActivator } from "./activation/button-activation";
 import { useBoardAppearanceConfig } from "./appearance/appearance-store";
 import { Grid, type GridItemProps } from "./grid/grid";
 import { useBoardKeyboard } from "./keyboard/use-board-keyboard";
@@ -60,7 +60,7 @@ export function CommunicationBoard({ board }: CommunicationBoardProps) {
     gridRef.current?.scrollTo({ left: 0, top: 0 });
   }
 
-  const { activateButton } = createButtonActivation({
+  const activateButton = createButtonActivator({
     message,
     playback,
     navigation,

--- a/src/features/board/communication-board.tsx
+++ b/src/features/board/communication-board.tsx
@@ -7,7 +7,7 @@ import { m } from "@paraglide/messages.js";
 import { useLanguage } from "@shared/language/use-language";
 import { useTranslate } from "@shared/language/use-translate";
 import { safeAreaInset } from "@shared/theme/safe-area";
-import { useRef } from "react";
+import { useRef, type CSSProperties } from "react";
 import { createButtonActivation } from "./activation/button-activation";
 import { useBoardAppearanceConfig } from "./appearance/appearance-store";
 import { Grid, type GridItemProps } from "./grid/grid";
@@ -26,6 +26,10 @@ import type { Board, BoardButton } from "./types";
 interface CommunicationBoardProps {
   board: Board;
 }
+
+type BoardRootStyle = CSSProperties & {
+  "--tile-saturation": string;
+};
 
 const boardRootSx = (theme: Theme) => ({
   height: "100%",
@@ -64,6 +68,9 @@ export function CommunicationBoard({ board }: CommunicationBoardProps) {
 
   const keyboard = useBoardKeyboard({ message, playback });
   const hasMessage = message.parts.length > 0;
+  const boardRootStyle: BoardRootStyle = {
+    "--tile-saturation": String(tileSaturation),
+  };
 
   const renderTile = (button: BoardButton, props: GridItemProps) => (
     <Tile
@@ -84,7 +91,8 @@ export function CommunicationBoard({ board }: CommunicationBoardProps) {
     <Stack
       {...keyboard.rootProps}
       direction="column"
-      sx={[boardRootSx, { "--tile-saturation": String(tileSaturation) }]}
+      sx={boardRootSx}
+      style={boardRootStyle}
     >
       <BoardPlaybackMessageBar parts={message.parts} />
 

--- a/src/features/board/grid/grid-dom.ts
+++ b/src/features/board/grid/grid-dom.ts
@@ -1,7 +1,7 @@
 import type { GridPosition } from "./grid-model";
 
 const GRID_CELL_SELECTOR = "[role='gridcell']";
-const FOCUSABLE_SELECTOR = "[tabindex]";
+const GRID_FOCUS_TARGET_SELECTOR = "[tabindex]";
 
 export interface GridFocusTarget {
   element: HTMLElement;
@@ -17,13 +17,13 @@ export function findFocusableInGridPosition(
   position: GridPosition,
 ): HTMLElement | null {
   return root.querySelector<HTMLElement>(
-    `${GRID_CELL_SELECTOR}[aria-rowindex='${position.row + 1}'][aria-colindex='${position.col + 1}'] ${FOCUSABLE_SELECTOR}`,
+    `${GRID_CELL_SELECTOR}[aria-rowindex='${position.row + 1}'][aria-colindex='${position.col + 1}'] ${GRID_FOCUS_TARGET_SELECTOR}`,
   );
 }
 
 export function findFirstGridFocusable(root: HTMLElement): HTMLElement | null {
   return root.querySelector<HTMLElement>(
-    `${GRID_CELL_SELECTOR} ${FOCUSABLE_SELECTOR}`,
+    `${GRID_CELL_SELECTOR} ${GRID_FOCUS_TARGET_SELECTOR}`,
   );
 }
 
@@ -40,7 +40,7 @@ export function listGridFocusTargets(
     }
 
     for (const element of cell.querySelectorAll<HTMLElement>(
-      FOCUSABLE_SELECTOR,
+      GRID_FOCUS_TARGET_SELECTOR,
     )) {
       targets.push({ element, position });
     }

--- a/src/features/board/message/message-bar.test.tsx
+++ b/src/features/board/message/message-bar.test.tsx
@@ -24,8 +24,8 @@ function createProps(
     parts: [],
     activePartId: null,
     isPlaying: false,
-    onPlayClick: vi.fn(),
-    onStopClick: vi.fn(),
+    onPlay: vi.fn(),
+    onStop: vi.fn(),
     ...overrides,
   };
 }
@@ -169,34 +169,34 @@ describe("MessageBar", () => {
   });
 
   describe("controls", () => {
-    test("delegates play to onPlayClick while idle", async () => {
-      const onPlayClick = vi.fn();
+    test("delegates play to onPlay while idle", async () => {
+      const onPlay = vi.fn();
 
       const screen = await renderWithProviders(
         <MessageBar
           {...createProps({
             parts: [{ id: "a", label: "Hello" }],
             isPlaying: false,
-            onPlayClick,
+            onPlay,
           })}
         />,
       );
 
       await screen.getByRole("button", { name: "Play message" }).click();
 
-      expect(onPlayClick).toHaveBeenCalledTimes(1);
+      expect(onPlay).toHaveBeenCalledTimes(1);
     });
 
-    test("delegates stop to onStopClick while playing", async () => {
-      const onStopClick = vi.fn();
+    test("delegates stop to onStop while playing", async () => {
+      const onStop = vi.fn();
 
       const screen = await renderWithProviders(
-        <MessageBar {...createProps({ isPlaying: true, onStopClick })} />,
+        <MessageBar {...createProps({ isPlaying: true, onStop })} />,
       );
 
       await screen.getByRole("button", { name: "Stop message" }).click();
 
-      expect(onStopClick).toHaveBeenCalledTimes(1);
+      expect(onStop).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/features/board/message/message-bar.tsx
+++ b/src/features/board/message/message-bar.tsx
@@ -8,16 +8,16 @@ export interface MessageBarProps {
   parts: MessagePart[];
   activePartId: string | null;
   isPlaying: boolean;
-  onPlayClick: () => void;
-  onStopClick: () => void;
+  onPlay: () => void;
+  onStop: () => void;
 }
 
 export function MessageBar({
   parts,
   activePartId,
   isPlaying,
-  onPlayClick,
-  onStopClick,
+  onPlay,
+  onStop,
 }: MessageBarProps) {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
@@ -95,8 +95,8 @@ export function MessageBar({
         <PlayButton
           disabled={!isPlaying && parts.length === 0}
           isPlaying={isPlaying}
-          onPlayClick={onPlayClick}
-          onStopClick={onStopClick}
+          onPlay={onPlay}
+          onStop={onStop}
         />
       </Stack>
     </Stack>

--- a/src/features/board/message/play-button.tsx
+++ b/src/features/board/message/play-button.tsx
@@ -9,15 +9,15 @@ const iconSx = { fontSize: 32 };
 interface PlayButtonProps {
   disabled?: boolean;
   isPlaying: boolean;
-  onPlayClick: () => void;
-  onStopClick: () => void;
+  onPlay: () => void;
+  onStop: () => void;
 }
 
 export function PlayButton({
   disabled,
   isPlaying,
-  onPlayClick,
-  onStopClick,
+  onPlay,
+  onStop,
 }: PlayButtonProps) {
   const t = useTranslate();
   const label = isPlaying ? t(m.messageStop) : t(m.messagePlay);
@@ -27,7 +27,7 @@ export function PlayButton({
       color={isPlaying ? "default" : "primary"}
       disabled={disabled}
       aria-label={label}
-      onClick={isPlaying ? onStopClick : onPlayClick}
+      onClick={isPlaying ? onStop : onPlay}
       sx={{
         width: 72,
         height: 72,

--- a/src/features/board/navigation/board-selector.tsx
+++ b/src/features/board/navigation/board-selector.tsx
@@ -9,7 +9,7 @@ import { useBoardsInSet } from "./use-boards-in-set";
 export function BoardSelector() {
   const t = useTranslate();
   const { setId, boardId, goToBoard } = useBoardNavigation();
-  const { boards } = useBoardsInSet({ setId });
+  const { boards } = useBoardsInSet(setId);
   const [inputValue, setInputValue] = useState("");
 
   const selectedBoard = boards.find((board) => board.boardId === boardId);

--- a/src/features/board/navigation/board-selector.tsx
+++ b/src/features/board/navigation/board-selector.tsx
@@ -45,7 +45,7 @@ export function BoardSelector() {
             ...params.slotProps,
             input: {
               ...params.slotProps?.input,
-              sx: { height: 48, borderRadius: 8 },
+              sx: { borderRadius: 8 },
             },
             htmlInput: {
               ...params.slotProps?.htmlInput,

--- a/src/features/board/navigation/board-selector.tsx
+++ b/src/features/board/navigation/board-selector.tsx
@@ -2,7 +2,6 @@ import Autocomplete from "@mui/material/Autocomplete";
 import TextField from "@mui/material/TextField";
 import { m } from "@paraglide/messages.js";
 import { useTranslate } from "@shared/language/use-translate";
-import { useState } from "react";
 import { useBoardNavigation } from "./use-board-navigation";
 import { useBoardsInSet } from "./use-boards-in-set";
 
@@ -10,7 +9,6 @@ export function BoardSelector() {
   const t = useTranslate();
   const { setId, boardId, goToBoard } = useBoardNavigation();
   const { boards } = useBoardsInSet(setId);
-  const [inputValue, setInputValue] = useState("");
 
   const selectedBoard = boards.find((board) => board.boardId === boardId);
 
@@ -25,8 +23,6 @@ export function BoardSelector() {
       size="small"
       options={boards}
       value={selectedBoard}
-      inputValue={inputValue}
-      onInputChange={(_event, value) => setInputValue(value)}
       onChange={(_event, board) => goToBoard(board.boardId)}
       getOptionLabel={(board) => board.name}
       getOptionKey={(board) => board.boardId}
@@ -40,7 +36,6 @@ export function BoardSelector() {
       renderInput={(params) => (
         <TextField
           {...params}
-          placeholder={selectedBoard.name}
           slotProps={{
             ...params.slotProps,
             input: {

--- a/src/features/board/navigation/nav-buttons.test.tsx
+++ b/src/features/board/navigation/nav-buttons.test.tsx
@@ -16,8 +16,8 @@ async function renderAt(
   options: {
     initialIndex?: number;
     direction?: "ltr" | "rtl";
-    onBackClick?: () => void;
-    onHomeClick?: () => void;
+    onBack?: () => void;
+    onHome?: () => void;
   } = {},
 ) {
   const theme = createTheme({ direction: options.direction ?? "ltr" });
@@ -26,12 +26,7 @@ async function renderAt(
     [
       {
         path: "/sets/:setId/boards/:boardId",
-        element: (
-          <NavButtons
-            onBackClick={options.onBackClick}
-            onHomeClick={options.onHomeClick}
-          />
-        ),
+        element: <NavButtons onBack={options.onBack} onHome={options.onHome} />,
       },
     ],
     { initialEntries, initialIndex: options.initialIndex },
@@ -54,7 +49,7 @@ describe("NavButtons", () => {
   });
 
   test("navigates back to the previous board when the back button is clicked", async () => {
-    const onBackClick = vi.fn();
+    const onBack = vi.fn();
     const { router, screen } = await renderAt(
       [
         "/sets/set-1/boards/root-1",
@@ -63,27 +58,27 @@ describe("NavButtons", () => {
           state: { backStack: ["root-1"] },
         },
       ],
-      { initialIndex: 1, onBackClick },
+      { initialIndex: 1, onBack },
     );
 
     await screen.getByRole("button", { name: "Back" }).click();
 
-    expect(onBackClick).toHaveBeenCalledOnce();
+    expect(onBack).toHaveBeenCalledOnce();
     await expect
       .poll(() => router.state.location.pathname)
       .toBe("/sets/set-1/boards/root-1");
   });
 
   test("runs the Home callback and navigates home", async () => {
-    const onHomeClick = vi.fn();
+    const onHome = vi.fn();
     const { router, screen } = await renderAt(
       [{ pathname: "/sets/set-1/boards/board-2", state: { backStack: [] } }],
-      { onHomeClick },
+      { onHome },
     );
 
     await screen.getByRole("button", { name: "Home" }).click();
 
-    expect(onHomeClick).toHaveBeenCalledOnce();
+    expect(onHome).toHaveBeenCalledOnce();
     await expect
       .poll(() => router.state.location.pathname)
       .toBe("/sets/set-1/boards/root-1");

--- a/src/features/board/navigation/nav-buttons.tsx
+++ b/src/features/board/navigation/nav-buttons.tsx
@@ -8,11 +8,11 @@ import { flipForRtl } from "@shared/theme/rtl";
 import { useBoardNavigation } from "./use-board-navigation";
 
 interface NavButtonsProps {
-  onBackClick?: () => void;
-  onHomeClick?: () => void;
+  onBack?: () => void;
+  onHome?: () => void;
 }
 
-export function NavButtons({ onBackClick, onHomeClick }: NavButtonsProps = {}) {
+export function NavButtons({ onBack, onHome }: NavButtonsProps = {}) {
   const t = useTranslate();
   const { setId, canGoBack, canGoHome, isHome, goBack, goHome } =
     useBoardNavigation();
@@ -22,12 +22,12 @@ export function NavButtons({ onBackClick, onHomeClick }: NavButtonsProps = {}) {
   }
 
   function handleBackClick() {
-    onBackClick?.();
+    onBack?.();
     goBack();
   }
 
   function handleHomeClick() {
-    onHomeClick?.();
+    onHome?.();
     goHome();
   }
 
@@ -49,7 +49,7 @@ export function NavButtons({ onBackClick, onHomeClick }: NavButtonsProps = {}) {
         aria-label={t(m.navHome)}
         size="large"
         color="inherit"
-        disabled={!canGoHome || (isHome && !onHomeClick)}
+        disabled={!canGoHome || (isHome && !onHome)}
         variant="contained"
         sx={{ width: 72 }}
         onClick={handleHomeClick}

--- a/src/features/board/navigation/use-boards-in-set.ts
+++ b/src/features/board/navigation/use-boards-in-set.ts
@@ -3,10 +3,6 @@ import { useLanguage } from "@shared/language/use-language";
 import { listBoards } from "../storage/board-content-storage";
 import { findTranslations } from "../translation/board-strings";
 
-interface UseBoardsInSetOptions {
-  setId: string | undefined;
-}
-
 interface BoardSummary {
   boardId: string;
   name: string;
@@ -18,9 +14,9 @@ interface UseBoardsInSetReturn {
   error: Error | undefined;
 }
 
-export function useBoardsInSet({
-  setId,
-}: UseBoardsInSetOptions): UseBoardsInSetReturn {
+export function useBoardsInSet(
+  setId: string | undefined,
+): UseBoardsInSetReturn {
   const { language } = useLanguage();
   const { value, error, isPending } = useLatestAsync({
     enabled: setId !== undefined,

--- a/src/features/board/playback/board-playback-message-bar.tsx
+++ b/src/features/board/playback/board-playback-message-bar.tsx
@@ -19,8 +19,8 @@ export function BoardPlaybackMessageBar({
       parts={parts}
       activePartId={isMessagePartHighlightingEnabled ? activePartId : null}
       isPlaying={playback.isMessagePlaying}
-      onPlayClick={() => void playback.playMessage(parts)}
-      onStopClick={playback.stop}
+      onPlay={() => void playback.playMessage(parts)}
+      onStop={playback.stop}
     />
   );
 }

--- a/src/features/board/suggestions/suggestion-bar.test.tsx
+++ b/src/features/board/suggestions/suggestion-bar.test.tsx
@@ -16,7 +16,7 @@ function makeProps(
     status: null,
     phrases: [],
     onEnable: vi.fn(),
-    onPhraseClick: vi.fn(),
+    onPhraseSelect: vi.fn(),
     ...overrides,
   };
 }
@@ -36,19 +36,19 @@ describe("SuggestionBar", () => {
     }
   });
 
-  test("calls onPhraseClick with the correct value when a phrase chip is clicked", async () => {
+  test("calls onPhraseSelect with the correct value when a phrase chip is clicked", async () => {
     const props = makeProps({ phrases: ["Hello", "Goodbye"] });
     const screen = await renderWithProviders(<SuggestionBar {...props} />);
 
     await screen.getByRole("button", { name: "Hello" }).click();
 
-    expect(props.onPhraseClick).toHaveBeenCalledWith("Hello");
-    expect(props.onPhraseClick).toHaveBeenCalledTimes(1);
+    expect(props.onPhraseSelect).toHaveBeenCalledWith("Hello");
+    expect(props.onPhraseSelect).toHaveBeenCalledTimes(1);
 
     await screen.getByRole("button", { name: "Goodbye" }).click();
 
-    expect(props.onPhraseClick).toHaveBeenCalledWith("Goodbye");
-    expect(props.onPhraseClick).toHaveBeenCalledTimes(2);
+    expect(props.onPhraseSelect).toHaveBeenCalledWith("Goodbye");
+    expect(props.onPhraseSelect).toHaveBeenCalledTimes(2);
   });
 
   test("offers an enable chip when activation is needed", async () => {

--- a/src/features/board/suggestions/suggestion-bar.tsx
+++ b/src/features/board/suggestions/suggestion-bar.tsx
@@ -9,14 +9,14 @@ export interface SuggestionBarProps {
   status: SuggestionStatusView;
   phrases: string[];
   onEnable: () => void;
-  onPhraseClick: (phrase: string) => void;
+  onPhraseSelect: (phrase: string) => void;
 }
 
 export function SuggestionBar({
   status,
   phrases,
   onEnable,
-  onPhraseClick,
+  onPhraseSelect,
 }: SuggestionBarProps) {
   const isPending = status?.kind === "pending";
 
@@ -49,7 +49,7 @@ export function SuggestionBar({
           <Chip
             key={phrase}
             label={phrase}
-            onClick={() => onPhraseClick(phrase)}
+            onClick={() => onPhraseSelect(phrase)}
           />
         ))}
       </Box>

--- a/src/features/board/tile/tile.test.tsx
+++ b/src/features/board/tile/tile.test.tsx
@@ -35,7 +35,7 @@ function resolveColorInSrgb(cssColor: string): string {
 
 describe("Tile", () => {
   test("renders label without image when imageSrc is not provided", async () => {
-    const screen = await render(<Tile label="Hello" onClick={vi.fn()} />);
+    const screen = await render(<Tile label="Hello" onActivate={vi.fn()} />);
 
     await expect
       .element(screen.getByRole("button", { name: "Hello" }))
@@ -44,7 +44,7 @@ describe("Tile", () => {
 
   test("renders with image when imageSrc is provided", async () => {
     const screen = await render(
-      <Tile label="Cat" imageSrc={TEST_IMAGE_SRC} onClick={vi.fn()} />,
+      <Tile label="Cat" imageSrc={TEST_IMAGE_SRC} onActivate={vi.fn()} />,
     );
 
     await expect
@@ -64,7 +64,7 @@ describe("Tile", () => {
         variant="folder"
         backgroundColor="#000000"
         borderColor="#000000"
-        onClick={vi.fn()}
+        onActivate={vi.fn()}
       />,
     );
 
@@ -81,7 +81,7 @@ describe("Tile", () => {
 
   test("applies backgroundColor and a readable text color", async () => {
     const screen = await render(
-      <Tile label="Colored" backgroundColor="#000000" onClick={vi.fn()} />,
+      <Tile label="Colored" backgroundColor="#000000" onActivate={vi.fn()} />,
     );
 
     const button = screen.getByRole("button", { name: "Colored" });
@@ -97,7 +97,7 @@ describe("Tile", () => {
     const theme = createTheme({ transitions: { duration: { short: 0 } } });
     const screen = await render(
       <MUIThemeProvider theme={theme}>
-        <Tile label="Colored" backgroundColor="#ff0000" onClick={vi.fn()} />
+        <Tile label="Colored" backgroundColor="#ff0000" onActivate={vi.fn()} />
       </MUIThemeProvider>,
     );
 
@@ -117,7 +117,7 @@ describe("Tile", () => {
 
   test("applies borderColor when provided", async () => {
     const screen = await render(
-      <Tile label="Bordered" borderColor="#00ff00" onClick={vi.fn()} />,
+      <Tile label="Bordered" borderColor="#00ff00" onActivate={vi.fn()} />,
     );
 
     const button = screen.getByRole("button", { name: "Bordered" });
@@ -128,7 +128,7 @@ describe("Tile", () => {
 
   test("defaults borderColor to backgroundColor when borderColor is omitted", async () => {
     const screen = await render(
-      <Tile label="Match" backgroundColor="#ff0000" onClick={vi.fn()} />,
+      <Tile label="Match" backgroundColor="#ff0000" onActivate={vi.fn()} />,
     );
 
     const button = screen.getByRole("button", { name: "Match" });
@@ -140,7 +140,7 @@ describe("Tile", () => {
   test("desaturates the background when --tile-saturation is set", async () => {
     const screen = await render(
       <div style={{ "--tile-saturation": 0 } as CSSProperties}>
-        <Tile label="Muted" backgroundColor="#ff0000" onClick={vi.fn()} />
+        <Tile label="Muted" backgroundColor="#ff0000" onActivate={vi.fn()} />
       </div>,
     );
 
@@ -160,7 +160,7 @@ describe("Tile", () => {
         backgroundColor="#ff0000"
         borderColor="#00ff00"
         borderHidden
-        onClick={vi.fn()}
+        onActivate={vi.fn()}
       />,
     );
 
@@ -182,7 +182,7 @@ describe("Tile", () => {
         backgroundColor="#000000"
         borderColor="#000000"
         borderHidden
-        onClick={vi.fn()}
+        onActivate={vi.fn()}
       />,
     );
 
@@ -196,22 +196,24 @@ describe("Tile", () => {
     );
   });
 
-  test("calls onClick when clicked", async () => {
-    const onClick = vi.fn();
+  test("calls onActivate when clicked", async () => {
+    const onActivate = vi.fn();
 
-    const screen = await render(<Tile label="Click me" onClick={onClick} />);
+    const screen = await render(
+      <Tile label="Click me" onActivate={onActivate} />,
+    );
 
     const button = screen.getByRole("button", { name: "Click me" });
     await button.click();
 
-    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onActivate).toHaveBeenCalledTimes(1);
   });
 
-  test("does not call onClick when disabled", async () => {
-    const onClick = vi.fn();
+  test("does not call onActivate when disabled", async () => {
+    const onActivate = vi.fn();
 
     const screen = await render(
-      <Tile label="Disabled tile" onClick={onClick} disabled />,
+      <Tile label="Disabled tile" onActivate={onActivate} disabled />,
     );
 
     const button = screen.getByRole("button", { name: "Disabled tile" });
@@ -219,6 +221,6 @@ describe("Tile", () => {
     expect(getComputedStyle(button.element()).boxShadow).toBe("none");
     await button.click({ force: true });
 
-    expect(onClick).not.toHaveBeenCalled();
+    expect(onActivate).not.toHaveBeenCalled();
   });
 });

--- a/src/features/board/tile/tile.tsx
+++ b/src/features/board/tile/tile.tsx
@@ -13,7 +13,7 @@ interface TileProps {
   borderHidden?: boolean;
   labelPlacement?: TileLabelPlacement;
   tabIndex?: number;
-  onClick: () => void;
+  onActivate: () => void;
 }
 
 // Scale an author-supplied color's OKLCH chroma by the board's saturation
@@ -37,7 +37,7 @@ export function Tile({
   borderHidden,
   labelPlacement,
   tabIndex,
-  onClick,
+  onActivate,
 }: TileProps) {
   const resolvedBorderColor = borderColor ?? backgroundColor;
   const resolvedBackgroundColor = backgroundColor
@@ -49,7 +49,7 @@ export function Tile({
       disableRipple
       disabled={disabled}
       tabIndex={tabIndex}
-      onClick={onClick}
+      onClick={onActivate}
       sx={(theme) => ({
         boxShadow: (theme.vars ?? theme).shadows[2],
         width: "100%",

--- a/src/shared/language/language-provider.tsx
+++ b/src/shared/language/language-provider.tsx
@@ -17,7 +17,7 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
     document.documentElement.lang = language;
   }, [direction, language]);
 
-  useVoiceLanguageSync({ language });
+  useVoiceLanguageSync(language);
 
   const contextValue = {
     language,

--- a/src/shared/speech/use-voice-language-sync.test.ts
+++ b/src/shared/speech/use-voice-language-sync.test.ts
@@ -42,7 +42,7 @@ describe("useVoiceLanguageSync", () => {
   test("selects a voice in the new language when language changes", async () => {
     const { rerender } = await renderHook(
       ({ language }: { language: string } = { language: "en" }) =>
-        useVoiceLanguageSync({ language }),
+        useVoiceLanguageSync(language),
       { initialProps: { language: "en" } },
     );
 
@@ -60,7 +60,7 @@ describe("useVoiceLanguageSync", () => {
   test("keeps the current voice when it already matches the language", async () => {
     setVoiceURI("en-voice");
 
-    await renderHook(() => useVoiceLanguageSync({ language: "en" }));
+    await renderHook(() => useVoiceLanguageSync("en"));
 
     expect(getSpeechConfig().voiceURI).toBe("en-voice");
   });
@@ -72,7 +72,7 @@ describe("useVoiceLanguageSync", () => {
     ]);
     speechSynthesis.dispatchEvent(new Event("voiceschanged"));
 
-    await renderHook(() => useVoiceLanguageSync({ language: "en" }));
+    await renderHook(() => useVoiceLanguageSync("en"));
 
     await vi.waitFor(() => {
       expect(getSpeechConfig().voiceURI).toBe("en-default");
@@ -87,7 +87,7 @@ describe("useVoiceLanguageSync", () => {
     ]);
     speechSynthesis.dispatchEvent(new Event("voiceschanged"));
 
-    await renderHook(() => useVoiceLanguageSync({ language: "fr" }));
+    await renderHook(() => useVoiceLanguageSync("fr"));
 
     await vi.waitFor(() => {
       expect(getSpeechConfig().voiceURI).toBe("fr-fr-voice");
@@ -102,7 +102,7 @@ describe("useVoiceLanguageSync", () => {
     ]);
     speechSynthesis.dispatchEvent(new Event("voiceschanged"));
 
-    await renderHook(() => useVoiceLanguageSync({ language: "fr" }));
+    await renderHook(() => useVoiceLanguageSync("fr"));
 
     await vi.waitFor(() => {
       expect(getSpeechConfig().voiceURI).toBe("fr-ca-voice");
@@ -117,7 +117,7 @@ describe("useVoiceLanguageSync", () => {
     ]);
     speechSynthesis.dispatchEvent(new Event("voiceschanged"));
 
-    await renderHook(() => useVoiceLanguageSync({ language: "fr" }));
+    await renderHook(() => useVoiceLanguageSync("fr"));
 
     await vi.waitFor(() => {
       expect(getSpeechConfig().voiceURI).toBe("fr-ca-voice");
@@ -132,7 +132,7 @@ describe("useVoiceLanguageSync", () => {
     ]);
     speechSynthesis.dispatchEvent(new Event("voiceschanged"));
 
-    await renderHook(() => useVoiceLanguageSync({ language: "fr" }));
+    await renderHook(() => useVoiceLanguageSync("fr"));
 
     await vi.waitFor(() => {
       expect(getSpeechConfig().voiceURI).toBe("fr-be-default");

--- a/src/shared/speech/use-voice-language-sync.ts
+++ b/src/shared/speech/use-voice-language-sync.ts
@@ -10,10 +10,6 @@ import {
   useVoicesByLanguage,
 } from "./speech-store";
 
-interface UseVoiceLanguageSyncOptions {
-  language: string;
-}
-
 /**
  * The user's own region for a language, drawn from OS/browser preferences
  * (e.g. a Canadian's "fr-CA" → "CA").
@@ -31,9 +27,7 @@ function getUserRegionForLanguage(language: string): string | undefined {
   return undefined;
 }
 
-export function useVoiceLanguageSync({
-  language,
-}: UseVoiceLanguageSyncOptions): void {
+export function useVoiceLanguageSync(language: string): void {
   const voicesByLanguage = useVoicesByLanguage();
 
   useEffect(() => {


### PR DESCRIPTION
## What changed

- Rename application component callbacks around semantic actions, including tile activation, phrase selection, navigation, playback, shell controls, and board-set deletion, while keeping DOM event names at the MUI boundary.
- Preserve `BackspaceButton`'s intentional `onPress` and `onLongPress` interaction semantics.
- Simplify single-value hooks by passing the board-set ID or language directly.
- Return the button activator function directly and clarify related activation and grid naming.
- Let MUI manage board-selector input state and remove redundant sizing and placeholder overrides.
- Move the tile-saturation CSS custom property to a typed native `style` value.

## Why

These changes make application component trees describe user intent instead of DOM mechanics, while removing unnecessary wrapper objects and local state. The resulting APIs are smaller, more direct, and easier to read at their call sites.

## Impact

This is an internal refactor with no intended user-facing behavior change. Native and MUI primitives retain their platform event APIs, accessibility behavior remains intact, and the existing interaction coverage has been updated for the renamed contracts.

## Validation

- `npm run lint`
- `npm test` — 75 files, 537 tests passed
- `npm run build`
