### PR TITLE
Improve coverage, app lifecycle, and board file handling

### DIFF
--- a/src/app/routing/app-routes.tsx
+++ b/src/app/routing/app-routes.tsx
@@ -1,10 +1,10 @@
-import { AppShell } from "@app/shell/app-shell";
 import { boardLoader } from "@app/routing/loaders/board-loader";
 import { boardSetIndexLoader } from "@app/routing/loaders/board-set-index-loader";
 import { rootIndexLoader } from "@app/routing/loaders/root-index-loader";
 import { NotFound } from "@app/routing/not-found";
 import { RouteErrorBoundary } from "@app/routing/route-error-boundary";
-import { BOARD_ROUTE_ID } from "@app/routing/use-board-media-lifetime";
+import { BOARD_ROUTE_ID } from "@app/routing/use-sync-board-media-with-active-route";
+import { AppShell } from "@app/shell/app-shell";
 import { BOARD_SEGMENT, BOARD_SET_SEGMENT } from "@features/board";
 import { BoardPage } from "@pages/board-page";
 import { LoadingState } from "@shared/ui/loading-state";

--- a/src/app/routing/use-revalidate-board-on-language-change.test.tsx
+++ b/src/app/routing/use-revalidate-board-on-language-change.test.tsx
@@ -1,12 +1,12 @@
-import { describe, expect, test, vi } from "vitest";
-import { createMemoryRouter, RouterProvider } from "react-router";
-import { render } from "vitest-browser-react";
 import { LanguageProvider } from "@shared/language/language-provider";
 import { setStoredLanguage } from "@shared/language/language-store";
-import { useRevalidateOnLanguageChange } from "./use-revalidate-on-language-change";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { describe, expect, test, vi } from "vitest";
+import { render } from "vitest-browser-react";
+import { useRevalidateBoardOnLanguageChange } from "./use-revalidate-board-on-language-change";
 
 function Probe() {
-  useRevalidateOnLanguageChange();
+  useRevalidateBoardOnLanguageChange();
 
   return <p>probe ready</p>;
 }
@@ -15,7 +15,7 @@ function TestHydrateFallback() {
   return null;
 }
 
-describe("useRevalidateOnLanguageChange", () => {
+describe("useRevalidateBoardOnLanguageChange", () => {
   test("re-runs route loaders only when the language actually changes", async () => {
     setStoredLanguage("en");
     const loader = vi.fn(() => null);

--- a/src/app/routing/use-revalidate-board-on-language-change.ts
+++ b/src/app/routing/use-revalidate-board-on-language-change.ts
@@ -4,7 +4,7 @@ import { useRevalidator } from "react-router";
 
 // Board translations are resolved in the route loader, so a language change must
 // re-run the loaders to re-translate the board currently on screen.
-export function useRevalidateOnLanguageChange(): void {
+export function useRevalidateBoardOnLanguageChange(): void {
   const { language } = useLanguage();
   const { revalidate } = useRevalidator();
   const previousLanguageRef = useRef(language);

--- a/src/app/routing/use-sync-board-media-with-active-route.test.tsx
+++ b/src/app/routing/use-sync-board-media-with-active-route.test.tsx
@@ -1,20 +1,20 @@
 import { hydrateBoard, type HydratedBoard } from "@features/board";
 import { makeOBFBoard, seedBoardSets } from "@features/board/testing";
+import { assertDefined } from "@shared/testing/assert-defined";
 import { StrictMode } from "react";
 import {
   createMemoryRouter,
   Outlet,
-  type LoaderFunctionArgs,
   useLoaderData,
+  type LoaderFunctionArgs,
 } from "react-router";
 import { RouterProvider } from "react-router/dom";
 import { expect, test, vi } from "vitest";
 import { render } from "vitest-browser-react";
-import { assertDefined } from "@shared/testing/assert-defined";
 import {
   BOARD_ROUTE_ID,
-  useBoardMediaLifetime,
-} from "./use-board-media-lifetime";
+  useSyncBoardMediaWithActiveRoute,
+} from "./use-sync-board-media-with-active-route";
 
 const SET_ID = "media-lifetime-set";
 const IMAGE_PATH = "images/test.png";
@@ -61,7 +61,7 @@ async function waitForGate(gate: Gate, signal: AbortSignal): Promise<void> {
 }
 
 function TestShell() {
-  useBoardMediaLifetime();
+  useSyncBoardMediaWithActiveRoute();
 
   return <Outlet />;
 }

--- a/src/app/routing/use-sync-board-media-with-active-route.ts
+++ b/src/app/routing/use-sync-board-media-with-active-route.ts
@@ -6,12 +6,12 @@ export const BOARD_ROUTE_ID = "board";
 
 let committedMedia: BoardMediaResource | undefined;
 
-export function useBoardMediaLifetime(): void {
+export function useSyncBoardMediaWithActiveRoute(): void {
   const loadedBoard = useRouteLoaderData<HydratedBoard>(BOARD_ROUTE_ID);
   const media = loadedBoard?.media;
 
-  // Route data becoming undefined is the unmount signal. Effect cleanup would
-  // revoke live media during Strict Mode's development replay.
+  // The persistent app shell observes the board route becoming unmatched.
+  // Effect cleanup would revoke live media during Strict Mode's replay.
   useEffect(() => replaceCommittedMedia(media), [media]);
 }
 

--- a/src/app/shell/app-shell.tsx
+++ b/src/app/shell/app-shell.tsx
@@ -1,15 +1,15 @@
-import { AppHeader } from "@app/shell/app-header";
-import { ContentColumn } from "@app/shell/content-column";
 import { LibraryDrawer } from "@app/library/library-drawer";
 import { OnboardingDialog } from "@app/onboarding/onboarding-dialog";
 import { useOnboarding } from "@app/onboarding/use-onboarding";
-import { useBoardMediaLifetime } from "@app/routing/use-board-media-lifetime";
-import { useRevalidateOnLanguageChange } from "@app/routing/use-revalidate-on-language-change";
+import { useRevalidateBoardOnLanguageChange } from "@app/routing/use-revalidate-board-on-language-change";
+import { useSyncBoardMediaWithActiveRoute } from "@app/routing/use-sync-board-media-with-active-route";
 import { SettingsDrawer } from "@app/settings/settings-drawer";
+import { AppHeader } from "@app/shell/app-header";
+import { ContentColumn } from "@app/shell/content-column";
 import {
   BoardFileDropOverlay,
   useBoardFileDrop,
-  useFileHandlerLaunch,
+  useImportLaunchedBoardFiles,
 } from "@features/board";
 import Box from "@mui/material/Box";
 import useMediaQuery from "@mui/material/useMediaQuery";
@@ -27,9 +27,9 @@ export function AppShell() {
   );
   const isLibraryPushingContent = isPersistentLibrary && isLibraryOpen;
 
-  useFileHandlerLaunch();
-  useBoardMediaLifetime();
-  useRevalidateOnLanguageChange();
+  useImportLaunchedBoardFiles();
+  useSyncBoardMediaWithActiveRoute();
+  useRevalidateBoardOnLanguageChange();
 
   return (
     <Box sx={{ height: "100svh", display: "flex" }} {...fileDrop.dropHandlers}>

--- a/src/features/board/grid/grid-layout.ts
+++ b/src/features/board/grid/grid-layout.ts
@@ -3,7 +3,7 @@ import type { Theme } from "@mui/material/styles";
 const MUI_SPACING_UNIT_PX = 8;
 const MIN_CELL_SIZE_PX = 96;
 const PAD = "var(--pad)";
-const PAD_TOTAL = `calc(2 * ${PAD})`;
+const TOTAL_PADDING = `calc(2 * ${PAD})`;
 const SMALL_SCREEN_PADDING = 2;
 const DEFAULT_PADDING = 3;
 
@@ -81,17 +81,17 @@ function trackAxisQueries(
   gap: number,
   padding: number,
 ): Record<string, Record<string, number>> {
-  const steps: [string, Record<string, number>][] = Array.from(
-    { length: Math.max(0, count - 1) },
-    (_, index) => {
-      const visible = index + 2;
-      const threshold = trackFitThreshold(visible, gap, padding);
+  const queries: Record<string, Record<string, number>> = {};
 
-      return [`@container (${feature}: ${threshold})`, { [property]: visible }];
-    },
-  );
+  for (let visible = 2; visible <= count; visible++) {
+    const threshold = trackFitThreshold(visible, gap, padding);
 
-  return Object.fromEntries(steps);
+    queries[`@container (${feature}: ${threshold})`] = {
+      [property]: visible,
+    };
+  }
+
+  return queries;
 }
 
 function trackFitThreshold(
@@ -113,7 +113,7 @@ function trackSize(
   gap: number,
   visible: string,
 ): string {
-  return `calc((${extent} - ${PAD_TOTAL} - (${visible} - 1) * ${theme.spacing(gap)}) / ${visible})`;
+  return `calc((${extent} - ${TOTAL_PADDING} - (${visible} - 1) * ${theme.spacing(gap)}) / ${visible})`;
 }
 
 function gridExtent(
@@ -122,5 +122,5 @@ function gridExtent(
   gap: number,
   count: number,
 ): string {
-  return `calc(${count} * ${cellSize} + ${count - 1} * ${theme.spacing(gap)} + ${PAD_TOTAL})`;
+  return `calc(${count} * ${cellSize} + ${count - 1} * ${theme.spacing(gap)} + ${TOTAL_PADDING})`;
 }

--- a/src/features/board/import/file-picker.ts
+++ b/src/features/board/import/file-picker.ts
@@ -19,7 +19,7 @@ export function openFiles({
     input.addEventListener(
       "change",
       () => {
-        resolve(input.files ? Array.from(input.files) : []);
+        resolve(Array.from(input.files ?? []));
       },
       { once: true },
     );
@@ -32,6 +32,6 @@ export function openFiles({
       { once: true },
     );
 
-    input.click();
+    input.showPicker();
   });
 }

--- a/src/features/board/import/use-import-launched-board-files.test.tsx
+++ b/src/features/board/import/use-import-launched-board-files.test.tsx
@@ -4,27 +4,32 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { render } from "vitest-browser-react";
 import { listBoardSets } from "../storage/board-set-storage";
 import { loadFixtureFile, resetBoardsDB } from "../testing";
-import { useFileHandlerLaunch } from "./use-file-handler-launch";
+import { useImportLaunchedBoardFiles } from "./use-import-launched-board-files";
 
 const OBF_FIXTURE = "lots-of-stuff.obf";
 const IMPORTED_SET_ID = "lots-of-stuff";
 
 function LaunchHarness() {
-  useFileHandlerLaunch();
+  useImportLaunchedBoardFiles();
 
   return <div data-testid="path">{useLocation().pathname}</div>;
 }
 
 function stubLaunchQueue() {
   let consumer: ((params: LaunchParams) => void) | undefined;
+  let consumerInstallCount = 0;
 
   vi.stubGlobal("launchQueue", {
     setConsumer: (next: (params: LaunchParams) => void) => {
       consumer = next;
+      consumerInstallCount += 1;
     },
   });
 
-  return (...files: FileSystemFileHandle[]) => consumer?.({ files });
+  return {
+    getConsumerInstallCount: () => consumerInstallCount,
+    launch: (...files: FileSystemFileHandle[]) => consumer?.({ files }),
+  };
 }
 
 function fileHandle(file: File): FileSystemFileHandle {
@@ -47,7 +52,7 @@ function renderLaunchHandler() {
   );
 }
 
-describe("useFileHandlerLaunch", () => {
+describe("useImportLaunchedBoardFiles", () => {
   beforeEach(async () => {
     await resetBoardsDB();
   });
@@ -62,10 +67,13 @@ describe("useFileHandlerLaunch", () => {
   });
 
   test("imports only the board files and opens the result", async () => {
-    const launch = stubLaunchQueue();
+    const launchQueue = stubLaunchQueue();
     const screen = await renderLaunchHandler();
+    const initialConsumerInstallCount = launchQueue.getConsumerInstallCount();
 
-    launch(
+    expect(initialConsumerInstallCount).toBeGreaterThan(0);
+
+    launchQueue.launch(
       fileHandle(new File([""], "notes.txt")),
       fileHandle(await loadFixtureFile(OBF_FIXTURE)),
     );
@@ -79,13 +87,16 @@ describe("useFileHandlerLaunch", () => {
     await expect
       .element(screen.getByTestId("path"))
       .toHaveTextContent(`/sets/${IMPORTED_SET_ID}/boards/`);
+    expect(launchQueue.getConsumerInstallCount()).toBe(
+      initialConsumerInstallCount,
+    );
   });
 
   test("reports a file that can no longer be opened", async () => {
-    const launch = stubLaunchQueue();
+    const launchQueue = stubLaunchQueue();
     const screen = await renderLaunchHandler();
 
-    launch(inaccessibleFileHandle());
+    launchQueue.launch(inaccessibleFileHandle());
 
     await expect
       .element(screen.getByRole("alert"))

--- a/src/features/board/import/use-import-launched-board-files.ts
+++ b/src/features/board/import/use-import-launched-board-files.ts
@@ -1,20 +1,15 @@
 import { m } from "@paraglide/messages.js";
 import { useSnackbar } from "@shared/snackbar/use-snackbar";
-import { useEffect } from "react";
+import { useEffect, useEffectEvent } from "react";
 import { isBoardFile } from "./board-file-formats";
 import { useImportBoardFiles } from "./use-import-board-files";
 
-export function useFileHandlerLaunch(): void {
+export function useImportLaunchedBoardFiles(): void {
   const { importAndOpenBoardFiles } = useImportBoardFiles();
   const { showSnackbar } = useSnackbar();
 
-  useEffect(() => {
-    const queue = window.launchQueue;
-    if (!queue) {
-      return;
-    }
-
-    async function importFileHandles(handles: readonly FileSystemFileHandle[]) {
+  const importLaunchedFiles = useEffectEvent(
+    async (handles: readonly FileSystemFileHandle[]) => {
       try {
         const opened = await Promise.all(
           handles.map((handle) => handle.getFile()),
@@ -27,10 +22,17 @@ export function useFileHandlerLaunch(): void {
           severity: "error",
         });
       }
+    },
+  );
+
+  useEffect(() => {
+    const queue = window.launchQueue;
+    if (!queue) {
+      return;
     }
 
     queue.setConsumer(({ files }) => {
-      void importFileHandles(files);
+      void importLaunchedFiles(files);
     });
-  }, [importAndOpenBoardFiles, showSnackbar]);
+  }, []);
 }

--- a/src/features/board/index.ts
+++ b/src/features/board/index.ts
@@ -15,7 +15,7 @@ export { CommunicationBoard } from "./communication-board";
 export { BoardFileDropOverlay } from "./import/board-file-drop-overlay";
 export { importBoardFromUrl } from "./import/import-from-url";
 export { useBoardFileDrop } from "./import/use-board-file-drop";
-export { useFileHandlerLaunch } from "./import/use-file-handler-launch";
+export { useImportLaunchedBoardFiles } from "./import/use-import-launched-board-files";
 export {
   BOARD_SEGMENT,
   BOARD_SET_SEGMENT,

--- a/src/features/board/storage/board-set-storage.ts
+++ b/src/features/board/storage/board-set-storage.ts
@@ -17,32 +17,32 @@ export class BoardSetAlreadyExistsError extends Error {
 }
 
 export interface BoardSetInput {
-  setId: string;
-  name: string;
-  rootBoardId: string;
-  author?: string;
-  description?: string;
-  license?: string;
-  locale?: string;
-  gridRows?: number;
-  gridColumns?: number;
+  readonly setId: string;
+  readonly name: string;
+  readonly rootBoardId: string;
+  readonly author?: string;
+  readonly description?: string;
+  readonly license?: string;
+  readonly locale?: string;
+  readonly gridRows?: number;
+  readonly gridColumns?: number;
 }
 
 export interface BoardInput {
-  boardId: string;
-  name: string;
-  obf: OBFBoard;
+  readonly boardId: string;
+  readonly name: string;
+  readonly obf: OBFBoard;
 }
 
 export interface AssetInput {
-  path: string;
-  blob: Blob;
+  readonly path: string;
+  readonly blob: Blob;
 }
 
 export interface BoardSetCreateInput {
-  boardSet: BoardSetInput;
-  boards: BoardInput[];
-  assets: AssetInput[];
+  readonly boardSet: BoardSetInput;
+  readonly boards: readonly BoardInput[];
+  readonly assets: readonly AssetInput[];
 }
 
 export async function getBoardSet(

--- a/src/features/board/storage/boards-db.test.ts
+++ b/src/features/board/storage/boards-db.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { resetBoardsDB } from "../testing";
-import { closeBoardsDB, getBoardsDB } from "./boards-db";
+import { closeBoardsDB, getBoardsDB, normalizeAssetPath } from "./boards-db";
 
 beforeEach(async () => {
   await resetBoardsDB();
@@ -31,4 +31,13 @@ describe("getBoardsDB", () => {
     });
     expect((await second.get("boardSets", "set-1"))?.name).toBe("Persisted");
   });
+});
+
+describe("normalizeAssetPath", () => {
+  test.each(["", "/", "////", "\\"])(
+    "rejects a path that normalizes to empty: %j",
+    (rawPath) => {
+      expect(() => normalizeAssetPath(rawPath)).toThrow("Path cannot be empty");
+    },
+  );
 });

--- a/src/features/board/storage/boards-db.ts
+++ b/src/features/board/storage/boards-db.ts
@@ -3,30 +3,30 @@ import type { DBSchema, IDBPDatabase } from "idb";
 import { openDB } from "idb";
 
 export interface BoardSetRecord {
-  setId: string;
-  name: string;
-  rootBoardId: string;
-  updatedAt: number;
-  boardCount: number;
-  author?: string;
-  description?: string;
-  license?: string;
-  locale?: string;
-  gridRows?: number;
-  gridColumns?: number;
+  readonly setId: string;
+  readonly name: string;
+  readonly rootBoardId: string;
+  readonly updatedAt: number;
+  readonly boardCount: number;
+  readonly author?: string;
+  readonly description?: string;
+  readonly license?: string;
+  readonly locale?: string;
+  readonly gridRows?: number;
+  readonly gridColumns?: number;
 }
 
 export interface BoardRecord {
-  setId: string;
-  boardId: string;
-  name: string;
-  obf: OBFBoard;
+  readonly setId: string;
+  readonly boardId: string;
+  readonly name: string;
+  readonly obf: OBFBoard;
 }
 
 interface AssetRecord {
-  setId: string;
-  path: string;
-  blob: Blob;
+  readonly setId: string;
+  readonly path: string;
+  readonly blob: Blob;
 }
 
 const MAX_ID_LENGTH = 255;

--- a/src/features/board/storage/boards-db.ts
+++ b/src/features/board/storage/boards-db.ts
@@ -62,14 +62,16 @@ const DB_NAME = "aac-boards-db";
 const DB_VERSION = 1;
 
 export function normalizeAssetPath(rawPath: string): string {
-  if (!rawPath) {
-    throw new Error("Path cannot be empty");
-  }
-
-  return rawPath
+  const path = rawPath
     .replace(/\\/g, "/")
     .replace(/^\/+/, "")
     .replace(/\/{2,}/g, "/");
+
+  if (!path) {
+    throw new Error("Path cannot be empty");
+  }
+
+  return path;
 }
 
 export function validateId(id: string, fieldName: string): void {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -146,6 +146,7 @@ export default defineConfig({
       instances: [{ browser: "chromium" }],
     },
     coverage: {
+      include: ["src/**/*.{ts,tsx}"],
       exclude: [
         ...coverageConfigDefaults.exclude,
         "src/paraglide/**",


### PR DESCRIPTION
## Summary

- include every TypeScript source file in coverage collection
- rename app-shell hooks around their observable responsibilities and use `useEffectEvent` to keep the file-launch consumer stable across rerenders
- clarify active-board media synchronization and board language revalidation naming
- reject empty normalized asset paths and make board storage inputs and records readonly
- clarify grid padding naming
- open file inputs with `showPicker()` while preserving explicit change and cancel handling

## Why

Vitest's default coverage collection omitted source files that were never loaded by the test suite, which could hide untested code. App-shell hook names described mechanisms more than responsibilities, and the launch-queue Effect depended on callbacks recreated during rendering, causing unnecessary consumer replacement.

The additional board utility fixes strengthen asset-path validation and type contracts, clarify grid calculations, and use the platform's explicit picker API for file imports.

## Impact

Coverage reports now account for all source TypeScript files. The launch consumer has a clearer application-lifetime registration model, board lifecycle responsibilities are easier to understand, and file imports use `HTMLInputElement.showPicker()` while still resolving an empty selection on cancellation.

## Validation

- `npm run lint`
- `npm test` — 75 files, 541 tests
- `npm run build`
