### PR TITLE
docs: link repository guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ npm run build                       # Type-check and build for production
 
 ## Architecture
 
-AAC Board AI is built with React 19, the React Compiler, TypeScript, Material UI, React Router, IndexedDB, Vite, Vitest, and Playwright. See [docs/architecture.md](docs/architecture.md) for the design, module boundaries, storage model, and accessibility invariants.
+AAC Board AI is built with React 19, the React Compiler, TypeScript, Material UI, React Router, IndexedDB, Vite, Vitest, and Playwright. See [docs/architecture.md](docs/architecture.md) for the design, module boundaries, storage model, and accessibility invariants. Coding-agent commands, standards, and change boundaries live in [AGENTS.md](AGENTS.md).
 
 ## Contributing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,8 +10,9 @@
 > `communication-board.tsx`.
 
 This document describes the app's modules, ownership boundaries, invariants, and
-load-bearing decisions. Setup and basic commands live in `README.md`; contributor
-conventions live in `AGENTS.md`; symbol-level behavior lives beside the code. The
+load-bearing decisions. Setup and basic commands live in
+[README.md](../README.md); coding-agent instructions live in
+[AGENTS.md](../AGENTS.md); symbol-level behavior lives beside the code. The
 intended audience is contributors familiar with React, TypeScript, and the Web
 Platform. AAC terms are defined in the [glossary](#glossary).
 


### PR DESCRIPTION
## Summary

- link the contributor instructions from the README architecture section
- convert repository-guide references in the architecture document into navigable links

## Why

Make the project’s contributor and architecture guidance easier to discover and navigate.

## Impact

Documentation-only; no runtime behavior changes.

## Validation

- `npx prettier --check README.md docs/architecture.md`