### PR TITLE
Fix test image fixture ownership

### DIFF
--- a/src/app/routing/use-sync-board-media-with-active-route.test.tsx
+++ b/src/app/routing/use-sync-board-media-with-active-route.test.tsx
@@ -1,5 +1,9 @@
 import { hydrateBoard, type HydratedBoard } from "@features/board";
-import { makeOBFBoard, seedBoardSets } from "@features/board/testing";
+import {
+  loadTestImageBlob,
+  makeOBFBoard,
+  seedBoardSets,
+} from "@features/board/testing";
 import { assertDefined } from "@shared/testing/assert-defined";
 import { StrictMode } from "react";
 import {
@@ -18,7 +22,6 @@ import {
 
 const SET_ID = "media-lifetime-set";
 const IMAGE_PATH = "images/test.png";
-const REAL_PNG_URL = "/pwa-192x192.png";
 
 interface Gate {
   promise: Promise<void>;
@@ -113,10 +116,7 @@ function makeBoard(boardId: string, name: string) {
 }
 
 async function seedBoards(): Promise<void> {
-  const pngResponse = await fetch(REAL_PNG_URL);
-  if (!pngResponse.ok) {
-    throw new Error(`Could not fetch ${REAL_PNG_URL} for fixture image`);
-  }
+  const pngBlob = await loadTestImageBlob();
 
   await seedBoardSets([
     {
@@ -128,7 +128,7 @@ async function seedBoards(): Promise<void> {
         makeBoard("second", "Second Board"),
         makeBoard("third", "Third Board"),
       ],
-      assets: [{ path: IMAGE_PATH, blob: await pngResponse.blob() }],
+      assets: [{ path: IMAGE_PATH, blob: pngBlob }],
     },
   ]);
 }

--- a/src/features/board/storage/board-hydration.test.ts
+++ b/src/features/board/storage/board-hydration.test.ts
@@ -2,7 +2,7 @@ import { assertDefined } from "@shared/testing/assert-defined";
 import type { OBFBoard } from "@shayc/open-board-format";
 import { beforeEach, describe, expect, test } from "vitest";
 import { refreshBoardSets } from "../board-sets/board-sets-store";
-import { resetBoardsDB } from "../testing";
+import { loadTestImageBlob, resetBoardsDB } from "../testing";
 import { BoardNotFoundError } from "./board-content-storage";
 import { hydrateBoard, type HydratedBoard } from "./board-hydration";
 import { createBoardSet } from "./board-set-storage";
@@ -10,15 +10,9 @@ import { createBoardSet } from "./board-set-storage";
 const SET_ID = "loader-test-set";
 const BOARD_ID = "loader-test-board";
 const IMAGE_PATH = "images/test.png";
-const REAL_PNG_URL = "/pwa-192x192.png";
 
 async function seedTestBoard(): Promise<void> {
-  const pngResponse = await fetch(REAL_PNG_URL);
-  if (!pngResponse.ok) {
-    throw new Error(`Could not fetch ${REAL_PNG_URL} for fixture image`);
-  }
-
-  const pngBlob = await pngResponse.blob();
+  const pngBlob = await loadTestImageBlob();
 
   const obfBoard: OBFBoard = {
     format: "open-board-0.1",

--- a/src/features/board/testing/fixtures.ts
+++ b/src/features/board/testing/fixtures.ts
@@ -4,6 +4,12 @@ export const TEST_IMAGE_SRC =
 
 const SAMPLE_BOARDS_DIR = "/src/features/board/testing/sample-boards";
 
+export async function loadTestImageBlob(): Promise<Blob> {
+  const response = await fetch(TEST_IMAGE_SRC);
+
+  return response.blob();
+}
+
 export async function loadFixtureFile(name: string): Promise<File> {
   const response = await fetch(`${SAMPLE_BOARDS_DIR}/${name}`);
 

--- a/src/features/board/testing/index.ts
+++ b/src/features/board/testing/index.ts
@@ -4,4 +4,4 @@ export {
   resetBoardsDB,
   seedBoardSets,
 } from "./db";
-export { loadFixtureFile, TEST_IMAGE_SRC } from "./fixtures";
+export { loadFixtureFile, loadTestImageBlob, TEST_IMAGE_SRC } from "./fixtures";


### PR DESCRIPTION
## Summary

- add a feature-owned helper that converts the existing inline test PNG into a blob
- expose the helper through `@features/board/testing`
- update board hydration and route media-lifecycle tests to stop fetching the production PWA icon

## Why

The media tests used `public/pwa-192x192.png` as generic fixture bytes, coupling test behavior to branding and deployment assets. Test data should be owned by the board testing seam.

## Impact

Production behavior is unchanged. The PWA icon is now branding-only, while media tests depend solely on test-owned fixture data.

## Verification

- `npm run lint`
- `npm test` — 75 files, 541 tests passed
- `npm run build`
- `git diff --check`
