### PR TITLE
Fix Paraglide compilation order

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,14 @@
   "scripts": {
     "dev": "vite",
     "dev:host": "vite --host",
-    "build": "tsc -b && vite build",
+    "build": "npm run paraglide:compile && tsc -b && vite build",
     "lint": "eslint",
     "format": "prettier --write .",
+    "paraglide:compile": "paraglide-js compile --project ./project.inlang --outdir ./src/paraglide --strategy globalVariable baseLocale",
     "preview": "vite preview",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "prepare": "husky && paraglide-js compile --project ./project.inlang --outdir ./src/paraglide --strategy globalVariable baseLocale"
+    "prepare": "husky && npm run paraglide:compile"
   },
   "lint-staged": {
     "*.{ts,tsx}": [


### PR DESCRIPTION
## Summary

- compile Paraglide messages before the TypeScript build
- reuse the dedicated compilation script during `prepare`

## Why

`tsc -b` previously ran before Vite's Paraglide plugin regenerated messages. After a message change, TypeScript could therefore read stale generated output and make local build correctness depend on command history.

## Impact

`npm run build` now type-checks the current message definitions while preserving the existing locale strategy and Paraglide output behavior.

## Validation

- `npm run lint`
- `npm test` (541 tests)
- `npm run build`
