### PR TITLE
Use Paraglide text direction helper

### DIFF
--- a/src/shared/language/language-provider.tsx
+++ b/src/shared/language/language-provider.tsx
@@ -1,5 +1,5 @@
+import { getTextDirection } from "@paraglide/runtime";
 import { useVoiceLanguageSync } from "@shared/speech/use-voice-language-sync";
-import { getTextDirection } from "@shared/utils/locale";
 import { useLayoutEffect, type ReactNode } from "react";
 import { LanguageContext } from "./language-context";
 import { setStoredLanguage, useStoredLanguage } from "./language-store";

--- a/src/shared/utils/locale.test.ts
+++ b/src/shared/utils/locale.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "vitest";
 import {
   getLanguageCode,
   getNativeLanguageName,
-  getTextDirection,
   normalizeLocale,
 } from "./locale";
 
@@ -34,27 +33,6 @@ describe("getLanguageCode", () => {
     ["zh-Hant-CN", "zh"],
   ])("extracts primary language from %s → %s", (input, expected) => {
     expect(getLanguageCode(input)).toBe(expected);
-  });
-});
-
-describe("getTextDirection", () => {
-  test.each(["en", "zh-TW"])("returns ltr for %s", (input) => {
-    expect(getTextDirection(input)).toBe("ltr");
-  });
-
-  test.each(["ar", "he", "fa", "ur", "ckb", "sd", "he-IL"])(
-    "returns rtl for %s",
-    (input) => {
-      expect(getTextDirection(input)).toBe("rtl");
-    },
-  );
-
-  test("returns ltr for well-formed but unknown codes (maximize finds no script)", () => {
-    expect(getTextDirection("xx")).toBe("ltr");
-  });
-
-  test("returns ltr when Intl.Locale rejects structurally invalid input", () => {
-    expect(getTextDirection("!!!")).toBe("ltr");
   });
 });
 

--- a/src/shared/utils/locale.ts
+++ b/src/shared/utils/locale.ts
@@ -42,18 +42,6 @@ export function getLikelyRegion(language: string): string | undefined {
   }
 }
 
-/**
- * Returns the locale's text direction. Falls back to `ltr` when Intl rejects
- * the tag or cannot determine a direction.
- */
-export function getTextDirection(locale: string): "ltr" | "rtl" {
-  try {
-    return parseLocale(locale).getTextInfo().direction ?? "ltr";
-  } catch {
-    return "ltr";
-  }
-}
-
 /** Returns the primary language's endonym (`es` → `español`; `fr` → `français`). */
 export function getNativeLanguageName(locale: string): string {
   const language = getLanguageCode(locale);


### PR DESCRIPTION
## Summary

- use Paraglide's generated `getTextDirection` runtime helper in the language provider
- remove the duplicate local implementation and its implementation-level tests
- retain app-shell coverage for observable LTR and RTL document behavior

## Why

Paraglide 2.13 and later officially provide this helper, including a language-based RTL fallback when `Intl.Locale` text-direction APIs are unavailable. Using the generated runtime API avoids maintaining a less robust duplicate.

## Impact

Direction handling remains unchanged in supported browsers and becomes more resilient in runtimes without `Intl.Locale#getTextInfo`.

## Validation

- `npm run lint`
- `npm test` (530 passed)
- `npm run build`
