### PR TITLE
Update Paraglide to 2.24.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@babel/core": "^7.29.7",
         "@eslint-react/eslint-plugin": "^5.18.6",
         "@eslint/js": "^10.0.1",
-        "@inlang/paraglide-js": "^2.24.0",
+        "@inlang/paraglide-js": "^2.24.1",
         "@rolldown/plugin-babel": "^0.2.3",
         "@types/babel__core": "^7.20.5",
         "@types/dom-chromium-ai": "^0.0.17",
@@ -2128,14 +2128,14 @@
       }
     },
     "node_modules/@inlang/paraglide-js": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/@inlang/paraglide-js/-/paraglide-js-2.24.0.tgz",
-      "integrity": "sha512-xI5nFnqcapa2CrSY0Z0VotC1Dt6+vBZEcb8zqR7mX6C+NP5CfztxxTccjBwdVmPZqm7OzmEY9auhRA7W54jibg==",
+      "version": "2.24.1",
+      "resolved": "https://registry.npmjs.org/@inlang/paraglide-js/-/paraglide-js-2.24.1.tgz",
+      "integrity": "sha512-r/gak0kY2yuqgz0RFxccb7A89fgcLpiqoEbYfv3nxlqyhdW2v8NajE1A2xiXrv/iAo7WCX4zk8EJAhL69rcp0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inlang/recommend-sherlock": "^0.2.1",
-        "@inlang/sdk": "^3.0.0",
+        "@inlang/sdk": "^3.0.1",
         "commander": "11.1.0",
         "consola": "3.4.0",
         "json5": "2.2.3",
@@ -2169,13 +2169,13 @@
       }
     },
     "node_modules/@inlang/sdk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@inlang/sdk/-/sdk-3.0.0.tgz",
-      "integrity": "sha512-jUo4NkxlreP22ZppCXygMp2gdgqkIcc0rt+dEruC9ylmESqRyWEF6muzIMsyU1CMKIhR6dxOtGG2v+H+MNu43w==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@inlang/sdk/-/sdk-3.0.1.tgz",
+      "integrity": "sha512-QvyMYjCqF7CnrTp8ZaPiuwpmxsoQPIDgfqGeWfqi4FDxBREye4QdyaZS4DGwIlCZXybF/YMj0TtL2uBfbmajug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lix-js/sdk": "0.12.0",
+        "@lix-js/sdk": "0.12.2",
         "@sinclair/typebox": "^0.31.17",
         "kysely": "^0.28.12",
         "sqlite-wasm-kysely": "0.3.0",
@@ -2280,25 +2280,25 @@
       }
     },
     "node_modules/@lix-js/sdk": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@lix-js/sdk/-/sdk-0.12.0.tgz",
-      "integrity": "sha512-Vn4IYLmQyvqrVM+wcpzK6yDAZoK2Q4Hi9wRSsslfr1CcLQanRV1Tfheb5Kh2xy5NBLLbzFmFLsl7ElIKo8wVuA==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@lix-js/sdk/-/sdk-0.12.2.tgz",
+      "integrity": "sha512-sKGOPdVKdChS5q60F4VQE4ZTcf0B7ZJM3KGCVQFN2suVNKhHcllbsCiwRYuM5WL7Yu1ql7YexltJ2FCsDqKePg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.3"
       },
       "optionalDependencies": {
-        "@lix-js/sdk-darwin-arm64": "0.12.0",
-        "@lix-js/sdk-linux-arm64": "0.12.0",
-        "@lix-js/sdk-linux-x64": "0.12.0",
-        "@lix-js/sdk-win32-x64": "0.12.0"
+        "@lix-js/sdk-darwin-arm64": "0.12.2",
+        "@lix-js/sdk-linux-arm64": "0.12.2",
+        "@lix-js/sdk-linux-x64": "0.12.2",
+        "@lix-js/sdk-win32-x64": "0.12.2"
       }
     },
     "node_modules/@lix-js/sdk-darwin-arm64": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@lix-js/sdk-darwin-arm64/-/sdk-darwin-arm64-0.12.0.tgz",
-      "integrity": "sha512-Pt6Q17kpvoTJCBaUdo5SfXuDFf1Fx2vODvnWlFILBmwV7xzUh9g2ALRF8nZr2jDWSeAi6g8PnjXDvryp2ug81g==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@lix-js/sdk-darwin-arm64/-/sdk-darwin-arm64-0.12.2.tgz",
+      "integrity": "sha512-0mBRIfgZfaey1/d0mijv7fBIGPeaTIMCDOPr3s4RUlHy/j+llNmAyDS2iNlalFh9nQGys7JNzo2Hv3FQbdKmug==",
       "cpu": [
         "arm64"
       ],
@@ -2309,9 +2309,9 @@
       ]
     },
     "node_modules/@lix-js/sdk-linux-arm64": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@lix-js/sdk-linux-arm64/-/sdk-linux-arm64-0.12.0.tgz",
-      "integrity": "sha512-tI+yZ6DOHIZhsblXMdMhFlq1k5m0Jc+/MF7im5MWzHk7KtYzdInW40uzg5NdjXkqlkFPsnugiNJzuCHCaW2XBg==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@lix-js/sdk-linux-arm64/-/sdk-linux-arm64-0.12.2.tgz",
+      "integrity": "sha512-817uJlC2KTIKDaqQvALTu03hEJpNxEA+9d33FNs8sOm9pAguOWiAK1zGA2SD0IgS9Q8NqQeABLb84OesW5/NCA==",
       "cpu": [
         "arm64"
       ],
@@ -2322,9 +2322,9 @@
       ]
     },
     "node_modules/@lix-js/sdk-linux-x64": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@lix-js/sdk-linux-x64/-/sdk-linux-x64-0.12.0.tgz",
-      "integrity": "sha512-OTvkeZ3LNp3b1uHWBHGYPpeSQAv7NLj/kXbaUY1CMCyvZCFoWRvvz9Fmojv0mdWJV0j5qenJZF42XCiXVtcbrQ==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@lix-js/sdk-linux-x64/-/sdk-linux-x64-0.12.2.tgz",
+      "integrity": "sha512-rA7lw1jBr6azBHR5Sh/RzOKSAlRcmVea7VeI4VQqpy0PZs+5tWoK9iVC41V4oCIKssRv2wrkbvyP3CqInhoknQ==",
       "cpu": [
         "x64"
       ],
@@ -2335,9 +2335,9 @@
       ]
     },
     "node_modules/@lix-js/sdk-win32-x64": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@lix-js/sdk-win32-x64/-/sdk-win32-x64-0.12.0.tgz",
-      "integrity": "sha512-5THoK6ZEvYveHPmD23hEdxhElZw1OxunWof/ZCR6OlX2scfvCadEQ/snDAg1vXeelAh3VrZTh3fzPCO8rF/Rew==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@lix-js/sdk-win32-x64/-/sdk-win32-x64-0.12.2.tgz",
+      "integrity": "sha512-y9IikCdrYx6cFnfqeUvYKPw6KBY016U2F2wYDILYZDZndccK2xw7lJChX163w9PewMwY3GsC/UqRBi5yqFAJ2w==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/core": "^7.29.7",
     "@eslint-react/eslint-plugin": "^5.18.6",
     "@eslint/js": "^10.0.1",
-    "@inlang/paraglide-js": "^2.24.0",
+    "@inlang/paraglide-js": "^2.24.1",
     "@rolldown/plugin-babel": "^0.2.3",
     "@types/babel__core": "^7.20.5",
     "@types/dom-chromium-ai": "^0.0.17",


### PR DESCRIPTION
## What changed

- Updated `@inlang/paraglide-js` from 2.24.0 to 2.24.1.
- Refreshed the lockfile, including the matching `@inlang/sdk` and `@lix-js/sdk` transitive updates.

## Why

Keeps the localization build tooling on the latest patch release and records the resolved transitive dependency versions.

## Impact

No application behavior or import/export formats change. This is a development dependency update.

## Validation

- `npm run lint`
- `npm test` (75 files, 530 tests)
- `npm run build`