### PR TITLE
Pin inlang message format plugin to 4.4.3

### DIFF
--- a/project.inlang/settings.json
+++ b/project.inlang/settings.json
@@ -39,7 +39,7 @@
     "zh"
   ],
   "modules": [
-    "https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@latest/dist/index.js"
+    "https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.4.3/dist/index.js"
   ],
   "plugin.inlang.messageFormat": {
     "pathPattern": "./messages/{locale}.json"


### PR DESCRIPTION
## What changed

Pinned the inlang message-format plugin URL in `project.inlang/settings.json` from the mutable `@latest` tag to version `4.4.3`.

## Why

The mutable CDN tag allowed a future plugin release to change localization compilation without a repository change. Pinning the current official release makes installs and builds reproducible while preserving today's behavior.

## Impact

No runtime behavior or translation content changes. Paraglide continues using the same plugin version that `@latest` currently resolves to.

## Validation

- `npm run lint`
- `npm test` — 75 files, 530 tests passed
- `npm run build`
