### PR TITLE
Show library load failure state

### DIFF
--- a/messages/ar.json
+++ b/messages/ar.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "لوحة تواصل",
   "board": "لوحة",
   "libraryLoading": "جارٍ تحميل مجموعات اللوحات...",
+  "libraryLoadFailed": "تعذر تحميل المكتبة",
   "libraryEmptyTitle": "المكتبة فارغة",
   "libraryEmptyDescription": "استورد ملفات اللوحات للبدء.",
   "libraryImportBoards": "استيراد ملفات اللوحات",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "Комуникационна дъска",
   "board": "Дъска",
   "libraryLoading": "Зареждане на наборите от дъски...",
+  "libraryLoadFailed": "Библиотеката не можа да се зареди",
   "libraryEmptyTitle": "Библиотеката е празна",
   "libraryEmptyDescription": "Импортирайте файлове с дъски, за да започнете.",
   "libraryImportBoards": "Импортиране на файлове с дъски",

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "যোগাযোগ বোর্ড",
   "board": "বোর্ড",
   "libraryLoading": "বোর্ড সেট লোড হচ্ছে…",
+  "libraryLoadFailed": "লাইব্রেরি লোড করা যায়নি",
   "libraryEmptyTitle": "লাইব্রেরি খালি",
   "libraryEmptyDescription": "শুরু করতে বোর্ড ফাইল আমদানি করুন।",
   "libraryImportBoards": "বোর্ড ফাইল আমদানি করুন",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "Komunikační tabulka",
   "board": "Tabulka",
   "libraryLoading": "Načítání sad tabulek...",
+  "libraryLoadFailed": "Knihovnu se nepodařilo načíst",
   "libraryEmptyTitle": "Knihovna je prázdná",
   "libraryEmptyDescription": "Začněte importem souborů tabulek.",
   "libraryImportBoards": "Importovat soubory tabulek",

--- a/messages/da.json
+++ b/messages/da.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "Kommunikationstavle",
   "board": "Tavle",
   "libraryLoading": "Indlæser tavlesæt...",
+  "libraryLoadFailed": "Biblioteket kunne ikke indlæses",
   "libraryEmptyTitle": "Biblioteket er tomt",
   "libraryEmptyDescription": "Importér tavlefiler for at komme i gang.",
   "libraryImportBoards": "Importér tavlefiler",

--- a/messages/de.json
+++ b/messages/de.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "Kommunikationstafel",
   "board": "Tafel",
   "libraryLoading": "Tafelsätze werden geladen...",
+  "libraryLoadFailed": "Bibliothek konnte nicht geladen werden",
   "libraryEmptyTitle": "Die Bibliothek ist leer",
   "libraryEmptyDescription": "Importiere Tafeldateien, um loszulegen.",
   "libraryImportBoards": "Tafeldateien importieren",

--- a/messages/el.json
+++ b/messages/el.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "Πίνακας επικοινωνίας",
   "board": "Πίνακας",
   "libraryLoading": "Φόρτωση συνόλων πινάκων...",
+  "libraryLoadFailed": "Δεν ήταν δυνατή η φόρτωση της βιβλιοθήκης",
   "libraryEmptyTitle": "Η βιβλιοθήκη είναι κενή",
   "libraryEmptyDescription": "Εισαγάγετε αρχεία πινάκων για να ξεκινήσετε.",
   "libraryImportBoards": "Εισαγωγή αρχείων πινάκων",

--- a/messages/en.json
+++ b/messages/en.json
@@ -7,6 +7,7 @@
   "boardGridLabel": "Communication board",
   "board": "Board",
   "libraryLoading": "Loading board sets...",
+  "libraryLoadFailed": "Couldn't load library",
   "libraryEmptyTitle": "Library is empty",
   "libraryEmptyDescription": "Import board files to get started.",
   "libraryImportBoards": "Import board files",

--- a/messages/es.json
+++ b/messages/es.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "Tablero de comunicación",
   "board": "Tablero",
   "libraryLoading": "Cargando conjuntos de tableros...",
+  "libraryLoadFailed": "No se pudo cargar la biblioteca",
   "libraryEmptyTitle": "La biblioteca está vacía",
   "libraryEmptyDescription": "Importa archivos de tableros para empezar.",
   "libraryImportBoards": "Importar archivos de tableros",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "Kommunikointitaulu",
   "board": "Taulu",
   "libraryLoading": "Ladataan taulusarjoja...",
+  "libraryLoadFailed": "Kirjastoa ei voitu ladata",
   "libraryEmptyTitle": "Kirjasto on tyhjä",
   "libraryEmptyDescription": "Tuo taulutiedostoja päästäksesi alkuun.",
   "libraryImportBoards": "Tuo taulutiedostoja",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "Tableau de communication",
   "board": "Tableau",
   "libraryLoading": "Chargement des ensembles de tableaux...",
+  "libraryLoadFailed": "Impossible de charger la bibliothèque",
   "libraryEmptyTitle": "La bibliothèque est vide",
   "libraryEmptyDescription": "Importez des fichiers de tableaux pour commencer.",
   "libraryImportBoards": "Importer des fichiers de tableaux",

--- a/messages/he.json
+++ b/messages/he.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "לוח תקשורת",
   "board": "לוח",
   "libraryLoading": "טעינת ערכות לוחות...",
+  "libraryLoadFailed": "לא ניתן לטעון את הספרייה",
   "libraryEmptyTitle": "הספרייה ריקה",
   "libraryEmptyDescription": "כדי להתחיל, יש לייבא קובצי לוחות.",
   "libraryImportBoards": "ייבוא קובצי לוחות",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "संचार बोर्ड",
   "board": "बोर्ड",
   "libraryLoading": "बोर्ड सेट लोड हो रहे हैं…",
+  "libraryLoadFailed": "लाइब्रेरी लोड नहीं हो सकी",
   "libraryEmptyTitle": "लाइब्रेरी खाली है",
   "libraryEmptyDescription": "शुरू करने के लिए बोर्ड फ़ाइलें आयात करें।",
   "libraryImportBoards": "बोर्ड फ़ाइलें आयात करें",

--- a/messages/hr.json
+++ b/messages/hr.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "Komunikacijska ploča",
   "board": "Ploča",
   "libraryLoading": "Učitavanje skupova ploča...",
+  "libraryLoadFailed": "Nije moguće učitati knjižnicu",
   "libraryEmptyTitle": "Knjižnica je prazna",
   "libraryEmptyDescription": "Za početak uvezite datoteke ploča.",
   "libraryImportBoards": "Uvezi datoteke ploča",

--- a/messages/hu.json
+++ b/messages/hu.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "Kommunikációs tábla",
   "board": "Tábla",
   "libraryLoading": "Táblakészletek betöltése...",
+  "libraryLoadFailed": "Nem sikerült betölteni a könyvtárat",
   "libraryEmptyTitle": "A könyvtár üres",
   "libraryEmptyDescription": "Az induláshoz importálj táblafájlokat.",
   "libraryImportBoards": "Táblafájlok importálása",

--- a/messages/id.json
+++ b/messages/id.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "Papan komunikasi",
   "board": "Papan",
   "libraryLoading": "Memuat set papan...",
+  "libraryLoadFailed": "Tidak dapat memuat pustaka",
   "libraryEmptyTitle": "Pustaka kosong",
   "libraryEmptyDescription": "Impor berkas papan untuk memulai.",
   "libraryImportBoards": "Impor berkas papan",

--- a/messages/it.json
+++ b/messages/it.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "Tabella di comunicazione",
   "board": "Tabella",
   "libraryLoading": "Caricamento set di tabelle...",
+  "libraryLoadFailed": "Impossibile caricare la libreria",
   "libraryEmptyTitle": "La libreria è vuota",
   "libraryEmptyDescription": "Importa file di tabelle per iniziare.",
   "libraryImportBoards": "Importa file di tabelle",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "コミュニケーションボード",
   "board": "ボード",
   "libraryLoading": "ボードセットを読み込んでいます…",
+  "libraryLoadFailed": "ライブラリを読み込めませんでした",
   "libraryEmptyTitle": "ライブラリは空です",
   "libraryEmptyDescription": "ボードファイルをインポートして始めましょう。",
   "libraryImportBoards": "ボードファイルをインポート",

--- a/messages/kn.json
+++ b/messages/kn.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "ಸಂವಹನ ಬೋರ್ಡ್",
   "board": "ಬೋರ್ಡ್",
   "libraryLoading": "ಬೋರ್ಡ್ ಸೆಟ್‌ಗಳು ಲೋಡ್ ಆಗುತ್ತಿವೆ…",
+  "libraryLoadFailed": "ಲೈಬ್ರರಿಯನ್ನು ಲೋಡ್ ಮಾಡಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ",
   "libraryEmptyTitle": "ಗ್ರಂಥಾಲಯ ಖಾಲಿಯಾಗಿದೆ",
   "libraryEmptyDescription": "ಪ್ರಾರಂಭಿಸಲು ಬೋರ್ಡ್ ಫೈಲ್‌ಗಳನ್ನು ಆಮದು ಮಾಡಿ.",
   "libraryImportBoards": "ಬೋರ್ಡ್ ಫೈಲ್‌ಗಳನ್ನು ಆಮದು ಮಾಡಿ",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "의사소통 보드",
   "board": "보드",
   "libraryLoading": "보드 세트를 불러오는 중…",
+  "libraryLoadFailed": "라이브러리를 불러올 수 없습니다",
   "libraryEmptyTitle": "라이브러리가 비어 있습니다",
   "libraryEmptyDescription": "보드 파일을 가져와 시작하세요.",
   "libraryImportBoards": "보드 파일 가져오기",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "Communicatiebord",
   "board": "Bord",
   "libraryLoading": "Bordsets laden...",
+  "libraryLoadFailed": "Bibliotheek kan niet worden geladen",
   "libraryEmptyTitle": "De bibliotheek is leeg",
   "libraryEmptyDescription": "Importeer bordbestanden om te beginnen.",
   "libraryImportBoards": "Bordbestanden importeren",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "Tablica komunikacyjna",
   "board": "Tablica",
   "libraryLoading": "Ładowanie zestawów tablic...",
+  "libraryLoadFailed": "Nie udało się wczytać biblioteki",
   "libraryEmptyTitle": "Biblioteka jest pusta",
   "libraryEmptyDescription": "Zaimportuj pliki tablic, aby rozpocząć.",
   "libraryImportBoards": "Importuj pliki tablic",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "Prancha de comunicação",
   "board": "Prancha",
   "libraryLoading": "Carregando conjuntos de pranchas...",
+  "libraryLoadFailed": "Não foi possível carregar a biblioteca",
   "libraryEmptyTitle": "A biblioteca está vazia",
   "libraryEmptyDescription": "Importe arquivos de pranchas para começar.",
   "libraryImportBoards": "Importar arquivos de pranchas",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "Tablă de comunicare",
   "board": "Tablă",
   "libraryLoading": "Se încarcă seturile de table...",
+  "libraryLoadFailed": "Biblioteca nu a putut fi încărcată",
   "libraryEmptyTitle": "Biblioteca este goală",
   "libraryEmptyDescription": "Importă fișiere de table pentru a începe.",
   "libraryImportBoards": "Importă fișiere de table",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "Коммуникационная доска",
   "board": "Доска",
   "libraryLoading": "Загрузка наборов досок...",
+  "libraryLoadFailed": "Не удалось загрузить библиотеку",
   "libraryEmptyTitle": "Библиотека пуста",
   "libraryEmptyDescription": "Импортируйте файлы досок, чтобы начать.",
   "libraryImportBoards": "Импортировать файлы досок",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "Komunikačná tabuľka",
   "board": "Tabuľka",
   "libraryLoading": "Načítavajú sa súpravy tabuliek...",
+  "libraryLoadFailed": "Knižnicu sa nepodarilo načítať",
   "libraryEmptyTitle": "Knižnica je prázdna",
   "libraryEmptyDescription": "Začnite importovaním súborov tabuliek.",
   "libraryImportBoards": "Importovať súbory tabuliek",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "Komunikacijska tabla",
   "board": "Tabla",
   "libraryLoading": "Nalaganje kompletov tabel...",
+  "libraryLoadFailed": "Knjižnice ni bilo mogoče naložiti",
   "libraryEmptyTitle": "Knjižnica je prazna",
   "libraryEmptyDescription": "Za začetek uvozite datoteke tabel.",
   "libraryImportBoards": "Uvozi datoteke tabel",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "Kommunikationstavla",
   "board": "Tavla",
   "libraryLoading": "Laddar taveluppsättningar...",
+  "libraryLoadFailed": "Det gick inte att läsa in biblioteket",
   "libraryEmptyTitle": "Biblioteket är tomt",
   "libraryEmptyDescription": "Importera tavelfiler för att komma igång.",
   "libraryImportBoards": "Importera tavelfiler",

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "தொடர்பு பலகை",
   "board": "பலகை",
   "libraryLoading": "பலகைத் தொகுப்புகள் ஏற்றப்படுகின்றன…",
+  "libraryLoadFailed": "நூலகத்தை ஏற்ற முடியவில்லை",
   "libraryEmptyTitle": "நூலகம் காலியாக உள்ளது",
   "libraryEmptyDescription": "தொடங்க பலகைக் கோப்புகளை இறக்குமதி செய்யுங்கள்.",
   "libraryImportBoards": "பலகைக் கோப்புகளை இறக்குமதி செய்",

--- a/messages/te.json
+++ b/messages/te.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "సంభాషణ బోర్డు",
   "board": "బోర్డు",
   "libraryLoading": "బోర్డు సెట్లు లోడ్ అవుతున్నాయి…",
+  "libraryLoadFailed": "లైబ్రరీని లోడ్ చేయడం సాధ్యపడలేదు",
   "libraryEmptyTitle": "లైబ్రరీ ఖాళీగా ఉంది",
   "libraryEmptyDescription": "ప్రారంభించడానికి బోర్డు ఫైళ్లను దిగుమతి చేయండి.",
   "libraryImportBoards": "బోర్డు ఫైళ్లను దిగుమతి చేయి",

--- a/messages/th.json
+++ b/messages/th.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "บอร์ดสื่อสาร",
   "board": "บอร์ด",
   "libraryLoading": "กำลังโหลดชุดบอร์ด...",
+  "libraryLoadFailed": "ไม่สามารถโหลดคลังได้",
   "libraryEmptyTitle": "คลังว่างเปล่า",
   "libraryEmptyDescription": "นำเข้าไฟล์บอร์ดเพื่อเริ่มต้น",
   "libraryImportBoards": "นำเข้าไฟล์บอร์ด",

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "İletişim panosu",
   "board": "Pano",
   "libraryLoading": "Pano setleri yükleniyor...",
+  "libraryLoadFailed": "Kitaplık yüklenemedi",
   "libraryEmptyTitle": "Kitaplık boş",
   "libraryEmptyDescription": "Başlamak için pano dosyalarını içe aktarın.",
   "libraryImportBoards": "Pano dosyalarını içe aktar",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "Комунікаційна дошка",
   "board": "Дошка",
   "libraryLoading": "Завантаження наборів дошок...",
+  "libraryLoadFailed": "Не вдалося завантажити бібліотеку",
   "libraryEmptyTitle": "Бібліотека порожня",
   "libraryEmptyDescription": "Імпортуйте файли дошок, щоб почати.",
   "libraryImportBoards": "Імпортувати файли дошок",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "Bảng giao tiếp",
   "board": "Bảng",
   "libraryLoading": "Đang tải các bộ bảng...",
+  "libraryLoadFailed": "Không thể tải thư viện",
   "libraryEmptyTitle": "Thư viện trống",
   "libraryEmptyDescription": "Nhập tệp bảng để bắt đầu.",
   "libraryImportBoards": "Nhập tệp bảng",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -8,6 +8,7 @@
   "boardGridLabel": "沟通板",
   "board": "沟通板",
   "libraryLoading": "正在加载沟通板集……",
+  "libraryLoadFailed": "无法加载板库",
   "libraryEmptyTitle": "板库为空",
   "libraryEmptyDescription": "导入沟通板文件即可开始。",
   "libraryImportBoards": "导入沟通板文件",

--- a/src/features/board/board-sets/board-set-library.test.tsx
+++ b/src/features/board/board-sets/board-set-library.test.tsx
@@ -2,9 +2,11 @@ import { resetBoardsDB, seedBoardSets } from "../testing";
 import { AppProviders } from "@shared/providers/app-providers";
 import { expectNoA11yViolations } from "@shared/testing/axe";
 import { MemoryRouter } from "react-router";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { render } from "vitest-browser-react";
+import { closeBoardsDB, getBoardsDB } from "../storage/boards-db";
 import { BoardSetLibrary } from "./board-set-library";
+import { refreshBoardSets } from "./board-sets-store";
 
 function renderBoardSetLibrary(onSelect = vi.fn()) {
   return render(
@@ -21,6 +23,10 @@ describe("BoardSetLibrary", () => {
     await resetBoardsDB();
   });
 
+  afterEach(async () => {
+    await closeBoardsDB();
+  });
+
   test("shows the empty state with an import action when no sets exist", async () => {
     const screen = await renderBoardSetLibrary();
 
@@ -30,6 +36,21 @@ describe("BoardSetLibrary", () => {
     await expect
       .element(screen.getByRole("button", { name: "Import board files" }))
       .toBeInTheDocument();
+  });
+
+  test("shows an error instead of the empty state when sets cannot be retrieved", async () => {
+    const db = await getBoardsDB();
+    db.close();
+    await refreshBoardSets();
+
+    const screen = await renderBoardSetLibrary();
+
+    await expect
+      .element(screen.getByText("Couldn't load library"))
+      .toBeInTheDocument();
+    await expect
+      .element(screen.getByText("Library is empty"))
+      .not.toBeInTheDocument();
   });
 
   test("invokes onSelect when a set is chosen", async () => {

--- a/src/features/board/board-sets/board-set-library.tsx
+++ b/src/features/board/board-sets/board-set-library.tsx
@@ -10,6 +10,7 @@ import { m } from "@paraglide/messages.js";
 import { useTranslate } from "@shared/language/use-translate";
 import { useSnackbar } from "@shared/snackbar/use-snackbar";
 import { EmptyState } from "@shared/ui/empty-state";
+import { ErrorState } from "@shared/ui/error-state";
 import { LoadingState } from "@shared/ui/loading-state";
 import { useState } from "react";
 import { useImportBoardFiles } from "../import/use-import-board-files";
@@ -30,7 +31,7 @@ export function BoardSetLibrary({
   onSelect,
 }: BoardSetLibraryProps) {
   const t = useTranslate();
-  const { boardSets, isLoading } = useBoardSets();
+  const { boardSets, isLoading, error } = useBoardSets();
   const { pickAndImportBoardFiles } = useImportBoardFiles();
   const { showSnackbar } = useSnackbar();
 
@@ -65,6 +66,14 @@ export function BoardSetLibrary({
     return (
       <Box sx={{ px: 2, height: "100%" }}>
         <LoadingState message={t(m.libraryLoading)} />
+      </Box>
+    );
+  }
+
+  if (error && boardSets.length === 0) {
+    return (
+      <Box sx={{ px: 2, height: "100%" }}>
+        <ErrorState icon={null} title={t(m.libraryLoadFailed)} />
       </Box>
     );
   }


### PR DESCRIPTION
## Summary

- show a single iconless error message when board sets cannot be retrieved and no cached sets are available
- keep the existing empty-library state for successful retrievals that return no board sets
- localize the new message across all supported locales
- cover the retrieval-failure branch with a browser test using IndexedDB

## Why

The board-set hook exposed retrieval errors, but the library ignored them. An initial storage failure therefore appeared as an empty library, which could incorrectly suggest that a user's communication boards were gone.

## Impact

Users now see “Couldn't load library” for that failure condition. Previously loaded board sets remain visible on refresh failures. This intentionally adds no retry control or ARIA behavior.

## Validation

- `npm run lint`
- `npm test` — 531 tests passed
- `npm run build`
