### PR TITLE
Document experimental browser flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,26 @@ Suggestions are optional; the original message is replaced only when the user ac
 | Rewriter    | Alternative phrasing that preserves the original tone or adopts a more casual one |
 | Translator  | Translated board names, labels, and spoken phrases                                |
 
+## Enable experimental AI features
+
+Proofreading and rewriting currently require experimental browser flags. Open each address for your browser and set the flag to **Enabled**:
+
+**Google Chrome**
+
+```text
+chrome://flags/#proofreader-api
+chrome://flags/#rewriter-api
+```
+
+**Microsoft Edge Canary or Dev**
+
+```text
+edge://flags/#edge-proofreader-api
+edge://flags/#edge-llm-rewriter-api-for-phi-mini
+```
+
+Then restart your browser.
+
 ## A complete board, with or without AI
 
 - **Starter board** — Includes the Quick Core 24 board with linked vocabulary categories.


### PR DESCRIPTION
## Summary

- document the Chrome and Microsoft Edge flags required for Proofreader and Rewriter
- identify the supported Edge preview channels as Canary or Dev
- place setup instructions after the product demo and Built-in AI overview

## Why

Proofreader and Rewriter are still experimental, so users and developers need clear browser setup instructions without interrupting the README’s initial product story.

## Impact

Visitors can see what AAC Board AI does before encountering setup steps, then enable the experimental APIs in the appropriate browser channel.

## Validation

- `git diff --check`
- `npx prettier --check README.md`

Tests were not run because this is a documentation-only change.
