### PR TITLE
Avoid async dependency signature collisions

### DIFF
--- a/src/shared/hooks/use-latest-async.test.ts
+++ b/src/shared/hooks/use-latest-async.test.ts
@@ -69,6 +69,35 @@ describe("useLatestAsync", () => {
     expect(result.current.value).toBeUndefined();
   });
 
+  test("starts a new round for dependency tuples that join to the same string", async () => {
+    interface TestProps {
+      deps: readonly (string | number | boolean)[];
+      label: string;
+    }
+
+    const firstProps: TestProps = {
+      deps: ["a\0b", "c"],
+      label: "first",
+    };
+    const run = vi.fn((label: string) => Promise.resolve(label));
+    const { result, rerender } = await renderHook(
+      ({ deps, label }: TestProps = firstProps) =>
+        useLatestAsync({
+          enabled: true,
+          deps,
+          run: () => run(label),
+        }),
+      { initialProps: firstProps },
+    );
+
+    await vi.waitFor(() => expect(result.current.value).toBe("first"));
+
+    await rerender({ deps: ["a", "b\0c"], label: "second" });
+
+    await vi.waitFor(() => expect(result.current.value).toBe("second"));
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
   test("hides the previous value the instant deps change, until the next resolves", async () => {
     const pending: ((value: string) => void)[] = [];
     const { result, rerender } = await renderHook(

--- a/src/shared/hooks/use-latest-async.ts
+++ b/src/shared/hooks/use-latest-async.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useEffectEvent, useState } from "react";
 
 interface UseLatestAsyncOptions<T> {
   enabled: boolean;
@@ -21,12 +21,8 @@ export function useLatestAsync<T>({
   deps,
   run,
 }: UseLatestAsyncOptions<T>): UseLatestAsyncReturn<T> {
-  const signature = deps.join("\0");
-
-  const runRef = useRef(run);
-  useEffect(() => {
-    runRef.current = run;
-  });
+  const signature = JSON.stringify(deps);
+  const runLatest = useEffectEvent(run);
 
   const [round, setRound] = useState<SettledRound<T>>();
 
@@ -38,8 +34,7 @@ export function useLatestAsync<T>({
     const controller = new AbortController();
     const { signal } = controller;
 
-    runRef
-      .current(signal)
+    runLatest(signal)
       .then((value) => {
         if (!signal.aborted) {
           setRound({ signature, status: "resolved", value });


### PR DESCRIPTION
## Summary

- serialize async dependency tuples with JSON to preserve value boundaries
- use `useEffectEvent` to call the latest async runner without ref indirection
- add regression coverage for dependency tuples that previously shared a signature

## Why

Joining dependencies with a NUL delimiter allowed distinct tuples containing that delimiter to produce the same signature. The hook could then retain a stale result instead of starting a new async round.

## Impact

Dependency changes now reliably start a fresh request for the app's string-based call sites. The runner also uses React's supported Effect Event API.

## Validation

- `npm run lint`
- `npm test` — 75 files, 532 tests passed
- `npm run build`
