### PR TITLE
fix: set titles for route errors

### DIFF
--- a/src/app/routing/app-routes.test.tsx
+++ b/src/app/routing/app-routes.test.tsx
@@ -21,11 +21,13 @@ async function renderApp(initialEntry = "/") {
     initialEntries: [initialEntry],
   });
 
-  return render(
+  const screen = await render(
     <AppProviders>
       <RouterProvider router={router} />
     </AppProviders>,
   );
+
+  return { router, screen };
 }
 
 describe("app flow", () => {
@@ -40,7 +42,7 @@ describe("app flow", () => {
   test("first run: imported board set opens, composes across boards, and speaks", async () => {
     await importBoardFromUrl(OBZ_FIXTURE_URL);
 
-    const screen = await renderApp();
+    const { screen } = await renderApp();
 
     await screen.getByRole("button", { name: "Continue" }).click();
     await expect
@@ -67,7 +69,7 @@ describe("app flow", () => {
   });
 
   test("empty database: imports and opens the bundled starter board", async () => {
-    const screen = await renderApp();
+    const { screen } = await renderApp();
 
     await screen.getByRole("button", { name: "Continue" }).click();
     await expect
@@ -78,7 +80,7 @@ describe("app flow", () => {
   test("?board= link that collides with an existing set keeps both", async () => {
     await seedExistingLotsOfStuffSet();
 
-    const screen = await renderApp(
+    const { screen } = await renderApp(
       `/?board=${encodeURIComponent(OBZ_FIXTURE_URL)}`,
     );
 
@@ -93,13 +95,19 @@ describe("app flow", () => {
     );
   });
 
-  test("an unmatched URL renders the localized not-found page inside the shell", async () => {
-    const screen = await renderApp("/nonexistent");
+  test("client navigation from a board sets the localized not-found title", async () => {
+    const { router, screen } = await renderApp();
 
-    // The shell still mounts on a miss, so dismiss onboarding first.
     await screen.getByRole("button", { name: "Continue" }).click();
+    await expect
+      .element(screen.getByRole("grid", { name: "Quick Core 24" }))
+      .toBeVisible();
+    expect(document.title).toBe("Quick Core 24");
+
+    await router.navigate("/nonexistent");
 
     await expect.element(screen.getByText("Page not found")).toBeVisible();
+    expect(document.title).toBe("Page not found");
     await expect
       .element(screen.getByRole("link", { name: "Go home" }))
       .toHaveAttribute("href", "/");

--- a/src/app/routing/not-found.tsx
+++ b/src/app/routing/not-found.tsx
@@ -9,15 +9,19 @@ import { Link } from "react-router";
 // available, rather than falling through to react-router's unstyled default.
 export function NotFound() {
   const t = useTranslate();
+  const title = t(m.errorPageNotFound);
 
   return (
-    <ErrorState
-      title={t(m.errorPageNotFound)}
-      action={
-        <Button component={Link} to="/" variant="contained">
-          {t(m.errorGoHome)}
-        </Button>
-      }
-    />
+    <>
+      <title>{title}</title>
+      <ErrorState
+        title={title}
+        action={
+          <Button component={Link} to="/" variant="contained">
+            {t(m.errorGoHome)}
+          </Button>
+        }
+      />
+    </>
   );
 }

--- a/src/app/routing/route-error-boundary.test.tsx
+++ b/src/app/routing/route-error-boundary.test.tsx
@@ -2,7 +2,7 @@ import { AppProviders } from "@shared/providers/app-providers";
 import { setStoredLanguage } from "@shared/language/language-store";
 import { createMemoryRouter, data } from "react-router";
 import { RouterProvider } from "react-router/dom";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { render } from "vitest-browser-react";
 import { RouteErrorBoundary } from "./route-error-boundary";
 import { createLocalizedRouteError, routeErrorCodes } from "./route-error";
@@ -81,9 +81,11 @@ describe("RouteErrorBoundary", () => {
     );
 
     await expect.element(screen.getByText("Board not found")).toBeVisible();
+    expect(document.title).toBe("Board not found");
 
     await screen.getByRole("button", { name: "switch-to-hebrew" }).click();
     await expect.element(screen.getByText("הלוח לא נמצא")).toBeVisible();
+    await vi.waitFor(() => expect(document.title).toBe("הלוח לא נמצא"));
   });
 
   test("distinguishes a missing board set from a missing board", async () => {

--- a/src/app/routing/route-error-boundary.tsx
+++ b/src/app/routing/route-error-boundary.tsx
@@ -15,14 +15,17 @@ export function RouteErrorBoundary() {
   const title = getErrorTitle(error, t);
 
   return (
-    <ErrorState
-      title={title}
-      action={
-        <Button component={Link} to="/" variant="contained">
-          {t(m.errorGoHome)}
-        </Button>
-      }
-    />
+    <>
+      <title>{title}</title>
+      <ErrorState
+        title={title}
+        action={
+          <Button component={Link} to="/" variant="contained">
+            {t(m.errorGoHome)}
+          </Button>
+        }
+      />
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary

- set localized document titles on the not-found page and route error boundary
- keep the visible error heading and browser title sourced from the same translation
- cover client navigation away from a board and live language changes in browser tests

## Root cause

Board pages rendered their own `<title>`, but route errors and unmatched routes did not. After client-side navigation, the previous board name could therefore remain in the browser tab even while an error page was displayed.

## Impact

Users now see a browser title that matches the displayed error state, including after changing the app language.

## Validation

- `npm test -- src/app/routing/app-routes.test.tsx src/app/routing/route-error-boundary.test.tsx`
- `npm run lint -- src/app/routing/app-routes.test.tsx src/app/routing/not-found.tsx src/app/routing/route-error-boundary.test.tsx src/app/routing/route-error-boundary.tsx`
- `npm run build`
- pre-commit ESLint and Prettier hooks
