### PR TITLE
Use native React Compiler integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,12 +26,9 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@babel/core": "^7.29.7",
         "@eslint-react/eslint-plugin": "^5.18.6",
         "@eslint/js": "^10.0.1",
         "@inlang/paraglide-js": "^2.24.1",
-        "@rolldown/plugin-babel": "^0.2.3",
-        "@types/babel__core": "^7.20.5",
         "@types/dom-chromium-ai": "^0.0.17",
         "@types/node": "^24.13.3",
         "@types/react": "^19.2.18",
@@ -43,7 +40,6 @@
         "@vitest/coverage-v8": "^4.1.11",
         "@vitest/eslint-plugin": "^1.6.27",
         "axe-core": "^4.13.0",
-        "babel-plugin-react-compiler": "^1.0.0",
         "eslint": "^10.9.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react-hooks": "^7.1.1",
@@ -51,6 +47,7 @@
         "globals": "^17.11.0",
         "husky": "^9.1.7",
         "lint-staged": "^17.3.0",
+        "oxc-transform-react": "^0.145.0",
         "prettier": "3.9.6",
         "typescript": "npm:@typescript/typescript6@^6.0.2",
         "typescript-eslint": "^8.67.0",
@@ -2617,6 +2614,353 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@oxc-transform-react/binding-android-arm-eabi": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-android-arm-eabi/-/binding-android-arm-eabi-0.145.0.tgz",
+      "integrity": "sha512-KuK3zAp10yFyeAxIXlZn2ycsFpaKLxUmj5BVRS1io4XfwnKTozb/goZakgKD5JEiHOVOtEKt1r7pTrmW/pFxxA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform-react/binding-android-arm64": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-android-arm64/-/binding-android-arm64-0.145.0.tgz",
+      "integrity": "sha512-eDUKx6MAgRAF67JPScjLF6h8lL2qmlvFrXGSG8mYFIVJb++NMyDygiIo8TAKdWQNguoBElUZw/SK2EPRaKsryQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform-react/binding-darwin-arm64": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-darwin-arm64/-/binding-darwin-arm64-0.145.0.tgz",
+      "integrity": "sha512-msCgwbVLswJ08JaUOjfPddieVJwE4IT1Y23A1DDyKVyzZp2ormo9a4ffDEu9nmmovdEj8VqAyFgggsgzIkBVrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform-react/binding-darwin-x64": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-darwin-x64/-/binding-darwin-x64-0.145.0.tgz",
+      "integrity": "sha512-R0PtsoOCsARulmWhLG1fFInT+98TRl/H6w6ifi8XOLvpdsksD1rxsw4Ol84lHbdHCcMNjfJTckZzQIZBMiXkLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform-react/binding-freebsd-x64": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-freebsd-x64/-/binding-freebsd-x64-0.145.0.tgz",
+      "integrity": "sha512-/MJ7+IvxfutSGqn6hIXU92wGNk5FlkqbTHM+kEl7ytLLOSAyivYhF2gxdYMmXTwOG56k2XviMcE0D/TBjdyoRA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform-react/binding-linux-arm-gnueabihf": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.145.0.tgz",
+      "integrity": "sha512-ssHZ0W2wSjQwaBQdkg8u+A7dTdw2vkGSK0hRfCoDCkRkETu+19Q8Tae7NNxlYHcP1iUQYhEj8Qfgpq+S/MdrYA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform-react/binding-linux-arm-musleabihf": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.145.0.tgz",
+      "integrity": "sha512-adJy4lQVcoIW6CUzQYbDgbHZMDSLoizwCinG2Dex29jdACKwIgXQQrIAHAgfveaZleKIB/rf3usGoRcOGyfz7Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform-react/binding-linux-arm64-gnu": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.145.0.tgz",
+      "integrity": "sha512-7KRa0CC1FaSKx5sy+bDtqGvXF+RiVoMmSe8OmTKm9kRZkNVdmsmpnsQhgravehTohlWDveo5aoGMwcFtffGDmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform-react/binding-linux-arm64-musl": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.145.0.tgz",
+      "integrity": "sha512-fGhZkDnk2RoMp6THas9HFGorF0A1wwPPA/2Lu9IUO1ip5MJqS/JG7/conmiz0DBG0PWBtnKl2Y8sA/VBiD/oQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform-react/binding-linux-ppc64-gnu": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.145.0.tgz",
+      "integrity": "sha512-VBaUTjRZYRypD2tL7cmbM2Fn6fvTnacLQ1GdsU1Y6A3fkqA/z+wc5Vy1QnnuFe9sIwb9xCvSS2tJVlucR39FYw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform-react/binding-linux-riscv64-gnu": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.145.0.tgz",
+      "integrity": "sha512-s2cimMVAmWe9dtjyWdGsYtevi9C7gJoOXwrCZD0BX7hgyGmuBO3iWQjx4W48hdXlWS176NoxuFIHAN72N86upA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform-react/binding-linux-riscv64-musl": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.145.0.tgz",
+      "integrity": "sha512-hFPrsL2nKL4aa8vFmheR53PcrxQgym8bnaSD1pMX9IoyQq+/ksAuw1CDJSV9c5xhxxZdw/KTPVer7M/6OQvfoA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform-react/binding-linux-s390x-gnu": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.145.0.tgz",
+      "integrity": "sha512-YLKhySqqu0JAtT0z8GuaFF7Hht3IvQLZShTH0DxeV28NwSthva+qJ7GN09ALT1bqRVvMjNGycgPHaGSWBUIt7A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform-react/binding-linux-x64-gnu": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.145.0.tgz",
+      "integrity": "sha512-WqgJ+0M9mwQ1cRfSgk4vzYudD2imLSBhUZ2QFes06vUjigts5Dw4NajWKc2JibPHYsoiUA9Zj39zWwC5AxXEGQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform-react/binding-linux-x64-musl": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-linux-x64-musl/-/binding-linux-x64-musl-0.145.0.tgz",
+      "integrity": "sha512-eIre/TjGt07IVKoWUrUOkPxN7UKeWxbiGvCywoGLDRe1/2K50MrA2vQahZ8AlW5CLmajOr9ePKrkRzLg1fa0cQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform-react/binding-openharmony-arm64": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-openharmony-arm64/-/binding-openharmony-arm64-0.145.0.tgz",
+      "integrity": "sha512-zhWiyJ+9XD4cuhSZIT6aozuXDHcZHNdoVe88xVmx2XN00anjZ6VAGj31rhD8ndha/F8NllcQEr8Q61Dr2MHv5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform-react/binding-win32-arm64-msvc": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.145.0.tgz",
+      "integrity": "sha512-Q0oiZfrfYyhmpqH2K0dylDTooIadecGsoiQks7G0AbuszCu2I7zYyJo4ArFc3d5Hj49Jjc5dDAE5WP/Sg2p8hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform-react/binding-win32-ia32-msvc": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.145.0.tgz",
+      "integrity": "sha512-ERpriVJY5S8hXd3BJi4UtzsIVsEQnntmpqTgRqh0XCaflLRLTQnPWpkO8rgtI7xye5MRhfhA+qsxKg2olJs4qA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-transform-react/binding-win32-x64-msvc": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/@oxc-transform-react/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.145.0.tgz",
+      "integrity": "sha512-sa781BGPLDw8+7ATrgUpLr0f4t0Q14O+zk3fOuQbUpjW5jERc9a3k1xIYKX1JkTG/sszoFhi8LzyCoMC49tkWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
@@ -2914,37 +3258,6 @@
       ],
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/plugin-babel": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/plugin-babel/-/plugin-babel-0.2.3.tgz",
-      "integrity": "sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=22.12.0 || ^24.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.29.0 || ^8.0.0-rc.1",
-        "@babel/plugin-transform-runtime": "^7.29.0 || ^8.0.0-rc.1",
-        "@babel/runtime": "^7.27.0 || ^8.0.0-rc.1",
-        "rolldown": "^1.0.0-rc.5",
-        "vite": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/plugin-transform-runtime": {
-          "optional": true
-        },
-        "@babel/runtime": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3544,51 +3857,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@types/babel__core": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
-      }
-    },
-    "node_modules/@types/babel__generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.28.2"
       }
     },
     "node_modules/@types/chai": {
@@ -4841,16 +5109,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "node_modules/babel-plugin-react-compiler": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
-      "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.26.0"
       }
     },
     "node_modules/balanced-match": {
@@ -7868,6 +8126,40 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/oxc-transform-react": {
+      "version": "0.145.0",
+      "resolved": "https://registry.npmjs.org/oxc-transform-react/-/oxc-transform-react-0.145.0.tgz",
+      "integrity": "sha512-y8cfjow11WKvDekonySPVvRUvNuIvqNT0LZ0Aey6j5dsNUD6k4hy6Mae/SLmng5egmb1GdJS11GduJ+IoEAXEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-transform-react/binding-android-arm-eabi": "0.145.0",
+        "@oxc-transform-react/binding-android-arm64": "0.145.0",
+        "@oxc-transform-react/binding-darwin-arm64": "0.145.0",
+        "@oxc-transform-react/binding-darwin-x64": "0.145.0",
+        "@oxc-transform-react/binding-freebsd-x64": "0.145.0",
+        "@oxc-transform-react/binding-linux-arm-gnueabihf": "0.145.0",
+        "@oxc-transform-react/binding-linux-arm-musleabihf": "0.145.0",
+        "@oxc-transform-react/binding-linux-arm64-gnu": "0.145.0",
+        "@oxc-transform-react/binding-linux-arm64-musl": "0.145.0",
+        "@oxc-transform-react/binding-linux-ppc64-gnu": "0.145.0",
+        "@oxc-transform-react/binding-linux-riscv64-gnu": "0.145.0",
+        "@oxc-transform-react/binding-linux-riscv64-musl": "0.145.0",
+        "@oxc-transform-react/binding-linux-s390x-gnu": "0.145.0",
+        "@oxc-transform-react/binding-linux-x64-gnu": "0.145.0",
+        "@oxc-transform-react/binding-linux-x64-musl": "0.145.0",
+        "@oxc-transform-react/binding-openharmony-arm64": "0.145.0",
+        "@oxc-transform-react/binding-win32-arm64-msvc": "0.145.0",
+        "@oxc-transform-react/binding-win32-ia32-msvc": "0.145.0",
+        "@oxc-transform-react/binding-win32-x64-msvc": "0.145.0"
       }
     },
     "node_modules/p-limit": {

--- a/package.json
+++ b/package.json
@@ -46,12 +46,9 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@babel/core": "^7.29.7",
     "@eslint-react/eslint-plugin": "^5.18.6",
     "@eslint/js": "^10.0.1",
     "@inlang/paraglide-js": "^2.24.1",
-    "@rolldown/plugin-babel": "^0.2.3",
-    "@types/babel__core": "^7.20.5",
     "@types/dom-chromium-ai": "^0.0.17",
     "@types/node": "^24.13.3",
     "@types/react": "^19.2.18",
@@ -63,7 +60,6 @@
     "@vitest/coverage-v8": "^4.1.11",
     "@vitest/eslint-plugin": "^1.6.27",
     "axe-core": "^4.13.0",
-    "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "^10.9.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^7.1.1",
@@ -71,6 +67,7 @@
     "globals": "^17.11.0",
     "husky": "^9.1.7",
     "lint-staged": "^17.3.0",
+    "oxc-transform-react": "^0.145.0",
     "prettier": "3.9.6",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "typescript-eslint": "^8.67.0",

--- a/src/shared/ui/error-state.tsx
+++ b/src/shared/ui/error-state.tsx
@@ -3,9 +3,8 @@ import { StatusLayout, type StatusLayoutProps } from "./status-layout";
 
 type ErrorStateProps = Omit<StatusLayoutProps, "kind">;
 
-export function ErrorState({
-  icon = <ErrorOutlineIcon />,
-  ...props
-}: ErrorStateProps) {
+const defaultIcon = <ErrorOutlineIcon />;
+
+export function ErrorState({ icon = defaultIcon, ...props }: ErrorStateProps) {
   return <StatusLayout kind="error" icon={icon} {...props} />;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,5 @@
 import { paraglideVitePlugin } from "@inlang/paraglide-js";
-import babel from "@rolldown/plugin-babel";
-import react, { reactCompilerPreset } from "@vitejs/plugin-react";
+import react from "@vitejs/plugin-react";
 import { playwright } from "@vitest/browser-playwright";
 import path from "node:path";
 import { defineConfig, type Plugin } from "vite";
@@ -27,8 +26,7 @@ const themeColorHtmlPlugin: Plugin = {
 export default defineConfig({
   plugins: [
     themeColorHtmlPlugin,
-    react(),
-    babel({ presets: [reactCompilerPreset()] }),
+    react({ compiler: true }),
     paraglideVitePlugin({
       project: "./project.inlang",
       outdir: "./src/paraglide",


### PR DESCRIPTION
## Summary

- replace the Babel React Compiler preset with the experimental native Oxc integration in Vite
- remove the Babel compiler dependencies and add oxc-transform-react
- hoist the ErrorState default icon so the native compiler can optimize it while preserving explicit null as no icon

## Verification

- npm run lint
- npm test — 75 test files, 532 tests passed
- npm run build
- native compiler completed without diagnostics