### PR TITLE
Migrate Oxfmt configuration to TypeScript

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "./node_modules/oxfmt/configuration_schema.json",
-  "printWidth": 80
-}

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from "oxfmt";
+
+export default defineConfig({
+  printWidth: 80,
+});

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -19,5 +19,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["oxlint.config.ts", "vite.config.ts"]
+  "include": ["oxfmt.config.ts", "oxlint.config.ts", "vite.config.ts"]
 }


### PR DESCRIPTION
## Summary

- replace `.oxfmtrc.json` with typed `oxfmt.config.ts`
- preserve the existing 80-column print width
- include the formatter config in the Node TypeScript project

## Validation

- `npm run format:check`
- `npm run lint`
- `npm test` (532 tests)
- `npm run build`