### PR TITLE
Improve Sherlock and Paraglide editor integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ Oxfmt and Oxlint own formatting and mechanical rules; the guidance below covers 
 - Prefer the smallest meaningful input a component or function needs; don't pass large objects solely to access one leaf property.
 - Avoid long dot-chains (`order.customer.address.city`); derive values close to the data source.
 - Use the path aliases (`@app/*`, `@features/*`, `@shared/*`, `@pages/*`, `@paraglide/*`).
-- User-facing strings go through Paraglide: add keys to `messages/en.json` (and sibling locales); import `m` from `@paraglide/messages.js`. Never hardcode UI text.
+- User-facing strings go through Paraglide: add keys to `messages/en.json` (and sibling locales); import `m` from `@paraglide/messages.js`. Never hardcode UI text. In React, call messages through `useTranslate()` as `t(m.messageKey)` so renders subscribe to locale changes; Sherlock extraction emits `m.messageKey()` and must be adapted before committing.
 - The React Compiler is enabled: write Compiler-native code; don't add `useMemo`/`useCallback` for performance.
 
 ### Comments

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "oxlint",
     "format": "oxfmt",
     "format:check": "oxfmt --check",
-    "paraglide:compile": "paraglide-js compile --project ./project.inlang --outdir ./src/paraglide --strategy globalVariable baseLocale",
+    "paraglide:compile": "paraglide-js compile --project ./project.inlang --outdir ./src/paraglide --strategy globalVariable baseLocale --emit-ts-declarations",
     "preview": "vite preview",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/project.inlang/settings.json
+++ b/project.inlang/settings.json
@@ -39,7 +39,8 @@
     "zh"
   ],
   "modules": [
-    "https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.4.3/dist/index.js"
+    "https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.4.3/dist/index.js",
+    "https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2.2.12/dist/index.js"
   ],
   "plugin.inlang.messageFormat": {
     "pathPattern": "./messages/{locale}.json"

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -6,7 +6,6 @@
     "module": "ESNext",
     "types": ["vite/client", "dom-chromium-ai"],
     "skipLibCheck": true,
-    "allowJs": true,
     "allowArbitraryExtensions": true,
 
     "paths": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
     paraglideVitePlugin({
       project: "./project.inlang",
       outdir: "./src/paraglide",
+      emitTsDeclarations: true,
       strategy: ["globalVariable", "baseLocale"],
     }),
     VitePWA({


### PR DESCRIPTION
## Summary

- configure Sherlock to recognize Paraglide message functions
- document the required reactive React message-call pattern
- emit TypeScript declarations in CLI and Vite compilation
- replace JavaScript/JSDoc inference with generated declaration types

## Validation

- npm run format:check
- npm run lint
- npm test (75 files, 532 tests)
- npm run build
- git diff --check