### PR TITLE
Use native Vite tsconfig path resolution

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -20,6 +20,7 @@
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
+    "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,6 @@
 import { paraglideVitePlugin } from "@inlang/paraglide-js";
 import react from "@vitejs/plugin-react";
 import { playwright } from "@vitest/browser-playwright";
-import path from "node:path";
 import { defineConfig, type Plugin } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
 import { coverageConfigDefaults } from "vitest/config";
@@ -91,13 +90,7 @@ export default defineConfig({
     }),
   ],
   resolve: {
-    alias: {
-      "@app": path.resolve(import.meta.dirname, "./src/app"),
-      "@features": path.resolve(import.meta.dirname, "./src/features"),
-      "@pages": path.resolve(import.meta.dirname, "./src/pages"),
-      "@paraglide": path.resolve(import.meta.dirname, "./src/paraglide"),
-      "@shared": path.resolve(import.meta.dirname, "./src/shared"),
-    },
+    tsconfigPaths: true,
   },
   optimizeDeps: {
     include: [


### PR DESCRIPTION
## Summary

- resolve TypeScript path aliases with Vite 8 native `resolve.tsconfigPaths`
- remove the duplicated Vite alias map and unused `node:path` import
- explicitly enable `isolatedModules` for Vite/Oxc single-file transpilation

## Verification

- `npm run format:check`
- `npm run lint`
- `npm test` (532 tests)
- `npm run build`