### PR TITLE
Use MUI reduced-motion theme API

### DIFF
--- a/src/features/board/board-sets/board-set-list.tsx
+++ b/src/features/board/board-sets/board-set-list.tsx
@@ -87,6 +87,9 @@ export function BoardSetList({
                   transition: theme.transitions.create("opacity", {
                     duration: theme.transitions.duration.shortest,
                   }),
+                  "@media (prefers-reduced-motion: reduce)": {
+                    transition: "none",
+                  },
                 },
                 "& .MuiListItem-root:is(:hover, :focus-within, [data-menu-open]) .MuiListItemSecondaryAction-root":
                   { opacity: 1, pointerEvents: "auto" },

--- a/src/features/board/tile/tile.tsx
+++ b/src/features/board/tile/tile.tsx
@@ -77,6 +77,9 @@ export function Tile({
             duration: theme.transitions.duration.short,
           },
         ),
+        "@media (prefers-reduced-motion: reduce)": {
+          transition: "none",
+        },
         "&:hover": {
           boxShadow: (theme.vars ?? theme).shadows[4],
           "@media (hover: hover)": {

--- a/src/shared/theme/theme-provider.tsx
+++ b/src/shared/theme/theme-provider.tsx
@@ -6,7 +6,6 @@ import {
   ThemeProvider as MUIThemeProvider,
   type ThemeOptions,
 } from "@mui/material/styles";
-import useMediaQuery from "@mui/material/useMediaQuery";
 import rtlPlugin from "@mui/stylis-plugin-rtl";
 import { useLanguage } from "@shared/language/use-language";
 import { ThemeColorMeta } from "@shared/theme/theme-color-meta";
@@ -24,129 +23,116 @@ const rtlCache = createCache({
   stylisPlugins: [prefixer, rtlPlugin],
 });
 
-function getThemeOptions(reducedMotion: boolean) {
-  return {
-    cssVariables: {
-      colorSchemeSelector: "class",
-      // index.html owns color-scheme; MUI only emits the palette vars.
-      disableCssColorScheme: true,
+const themeOptions = {
+  cssVariables: {
+    colorSchemeSelector: "class",
+    // index.html owns color-scheme; MUI only emits the palette vars.
+    disableCssColorScheme: true,
+  },
+  colorSchemes: {
+    light: { palette: { background: { default: SHELL_LIGHT } } },
+    dark: { palette: { background: { default: SHELL_DARK } } },
+  },
+  motion: {
+    reducedMotion: "system",
+  },
+  typography: {
+    button: {
+      textTransform: "none",
     },
-    colorSchemes: {
-      light: { palette: { background: { default: SHELL_LIGHT } } },
-      dark: { palette: { background: { default: SHELL_DARK } } },
-    },
-    transitions: reducedMotion
-      ? {
-          duration: {
-            shortest: 0,
-            shorter: 0,
-            short: 0,
-            standard: 0,
-            complex: 0,
-            enteringScreen: 0,
-            leavingScreen: 0,
-          },
-        }
-      : undefined,
-    typography: {
-      button: {
-        textTransform: "none",
-      },
-    },
-    components: {
-      MuiCssBaseline: {
-        styleOverrides: {
-          html: {
-            overscrollBehaviorY: "none",
-          },
-          body: {
-            userSelect: "none",
-          },
+  },
+  components: {
+    MuiCssBaseline: {
+      styleOverrides: {
+        html: {
+          overscrollBehaviorY: "none",
+        },
+        body: {
+          userSelect: "none",
         },
       },
-      MuiAppBar: {
-        defaultProps: {
-          elevation: 0,
-        },
-        styleOverrides: {
-          root: ({ theme }) => {
-            const palette = theme.vars?.palette ?? theme.palette;
+    },
+    MuiAppBar: {
+      defaultProps: {
+        elevation: 0,
+      },
+      styleOverrides: {
+        root: ({ theme }) => {
+          const palette = (theme.vars ?? theme).palette;
 
-            return {
-              backgroundColor: SHELL_LIGHT,
-              color: palette.text.primary,
-              backgroundImage: "none",
-              ...theme.applyStyles("dark", {
-                backgroundColor: SHELL_DARK,
-              }),
-            };
-          },
-        },
-      },
-      MuiDrawer: {
-        styleOverrides: {
-          paper: ({ theme }) => ({
-            ...theme.applyStyles("dark", {
-              backgroundColor: SHELL_DARK,
-              backgroundImage: "none",
-            }),
-          }),
-        },
-      },
-      MuiDialog: {
-        styleOverrides: {
-          paper: {
-            borderRadius: 32,
-          },
-        },
-      },
-      MuiDialogActions: {
-        styleOverrides: {
-          root: {
-            padding: 16,
-          },
-        },
-      },
-      MuiButton: {
-        styleOverrides: {
-          root: {
-            borderRadius: 32,
-            paddingTop: 12,
-            paddingBottom: 12,
-          },
-        },
-      },
-      MuiOutlinedInput: {
-        styleOverrides: {
-          root: {
-            borderRadius: 32,
-          },
-        },
-      },
-      MuiListItemButton: {
-        styleOverrides: {
-          root: {
-            borderRadius: 32,
-          },
+          return {
+            backgroundColor: palette.background.default,
+            color: palette.text.primary,
+            backgroundImage: "none",
+          };
         },
       },
     },
-  } satisfies ThemeOptions;
-}
+    MuiDrawer: {
+      styleOverrides: {
+        paper: ({ theme }) => ({
+          backgroundColor: (theme.vars ?? theme).palette.background.default,
+          backgroundImage: "none",
+        }),
+      },
+    },
+    MuiDialog: {
+      styleOverrides: {
+        paper: {
+          borderRadius: 32,
+        },
+      },
+    },
+    MuiDialogActions: {
+      styleOverrides: {
+        root: {
+          padding: 16,
+        },
+      },
+    },
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 32,
+          paddingTop: 12,
+          paddingBottom: 12,
+        },
+      },
+    },
+    MuiOutlinedInput: {
+      styleOverrides: {
+        root: {
+          borderRadius: 32,
+        },
+      },
+    },
+    MuiListItemButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 32,
+        },
+      },
+    },
+  },
+} satisfies ThemeOptions;
+
+const ltrTheme = createTheme({
+  ...themeOptions,
+  direction: "ltr",
+});
+
+const rtlTheme = createTheme({
+  ...themeOptions,
+  direction: "rtl",
+});
 
 export function ThemeProvider({ children }: ThemeProviderProps) {
   const { direction } = useLanguage();
   const isRtl = direction === "rtl";
-  const reducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
-
-  const theme = createTheme({
-    ...getThemeOptions(reducedMotion),
-    direction: isRtl ? "rtl" : "ltr",
-  });
 
   return (
     <CacheProvider value={isRtl ? rtlCache : ltrCache}>
-      <MUIThemeProvider theme={theme} noSsr>
+      <MUIThemeProvider theme={isRtl ? rtlTheme : ltrTheme} noSsr>
         <CssBaseline />
         <ThemeColorMeta />
         {children}

--- a/src/shared/theme/theme-provider.tsx
+++ b/src/shared/theme/theme-provider.tsx
@@ -146,7 +146,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
 
   return (
     <CacheProvider value={isRtl ? rtlCache : ltrCache}>
-      <MUIThemeProvider theme={theme}>
+      <MUIThemeProvider theme={theme} noSsr>
         <CssBaseline />
         <ThemeColorMeta />
         {children}


### PR DESCRIPTION
## Summary

- avoid the client-only color-scheme double render with `noSsr`
- use MUI’s system reduced-motion API and static LTR/RTL themes
- resolve shell colors through palette variables and retain reduced-motion rules for app-defined transitions

## Testing

- `npm run format`
- `npm run lint`
- `npm test` (532 tests passed)
- `npm run build`